### PR TITLE
Add Trajectory trait and implement CubicSplineTrajectory

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,5 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/.idea/lox-space.iml
+++ b/.idea/lox-space.iml
@@ -29,6 +29,7 @@
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
       <excludeFolder url="file://$MODULE_DIR$/tools/lox-gen/target" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/copilot/chatSessions" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "lox-bodies",
  "lox-time",
  "lox-utils",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/lox-coords/Cargo.toml
+++ b/crates/lox-coords/Cargo.toml
@@ -15,3 +15,4 @@ lox-utils.workspace = true
 
 float_eq.workspace = true
 glam.workspace = true
+thiserror.workspace = true

--- a/crates/lox-coords/src/lib.rs
+++ b/crates/lox-coords/src/lib.rs
@@ -15,6 +15,7 @@ use crate::frames::ReferenceFrame;
 pub mod anomalies;
 pub mod base;
 pub mod frames;
+pub mod trajectories;
 pub mod two_body;
 
 pub trait CoordinateSystem {

--- a/crates/lox-coords/src/trajectories.rs
+++ b/crates/lox-coords/src/trajectories.rs
@@ -1,0 +1,481 @@
+/*
+ * Copyright (c) 2024. Helge Eichhorn and the LOX contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use glam::DVec3;
+use thiserror::Error;
+
+use lox_bodies::PointMass;
+use lox_time::deltas::TimeDelta;
+use lox_time::time_scales::TimeScale;
+use lox_time::Time;
+use lox_utils::interpolation::cubic_spline::{CubicSpline, LoxCubicSplineError};
+
+use crate::frames::ReferenceFrame;
+use crate::two_body::Cartesian;
+use crate::CoordinateSystem;
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum LoxTrajectoryError {
+    #[error("epoch must be between {0} and {1} but was {2}")]
+    EpochOutOfRange(String, String, String),
+    #[error("time delta must be between 0.0 seconds and {0} seconds but was {1} seconds")]
+    DeltaOutOfRange(String, String),
+    #[error("`states` must have at least four element but had {0}")]
+    TooFewStates(usize),
+    #[error("unknown field `{0}`")]
+    FieldNotFound(String),
+    #[error(transparent)]
+    CubicSplineError(#[from] LoxCubicSplineError),
+}
+
+pub trait Trajectory {
+    type Time: TimeScale + Copy;
+    type Origin: PointMass + Copy;
+    type Frame: ReferenceFrame + Copy;
+
+    fn state_at_epoch(
+        &self,
+        epoch: Time<Self::Time>,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError>;
+    fn state_after_delta(
+        &self,
+        delta: TimeDelta,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError>;
+    fn field_at_epoch(
+        &self,
+        field: &str,
+        epoch: Time<Self::Time>,
+    ) -> Result<f64, LoxTrajectoryError>;
+    fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[repr(transparent)]
+struct RcVecF64(Rc<Vec<f64>>);
+
+impl AsRef<[f64]> for RcVecF64 {
+    fn as_ref(&self) -> &[f64] {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CubicSplineTrajectory<T: TimeScale + Copy, O: PointMass + Copy, F: ReferenceFrame + Copy>
+{
+    origin: O,
+    frame: F,
+    t0: Time<T>,
+    t1: Time<T>,
+    dt_max: TimeDelta,
+    t: RcVecF64,
+    x: CubicSpline<RcVecF64, Vec<f64>>,
+    y: CubicSpline<RcVecF64, Vec<f64>>,
+    z: CubicSpline<RcVecF64, Vec<f64>>,
+    vy: CubicSpline<RcVecF64, Vec<f64>>,
+    vx: CubicSpline<RcVecF64, Vec<f64>>,
+    vz: CubicSpline<RcVecF64, Vec<f64>>,
+    fields: HashMap<String, CubicSpline<RcVecF64, Vec<f64>>>,
+}
+
+impl<T, O, F> CubicSplineTrajectory<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    pub fn new(states: &[Cartesian<T, O, F>]) -> Result<Self, LoxTrajectoryError> {
+        if states.len() < 4 {
+            return Err(LoxTrajectoryError::TooFewStates(states.len()));
+        }
+        let s0 = states.first().unwrap();
+        let t0 = s0.time();
+        let t1 = states.last().unwrap().time();
+        let dt_max = t1 - t0;
+        let t: Vec<f64> = states
+            .iter()
+            .map(|s| (s.time() - t0).to_decimal_seconds())
+            .collect();
+        let t = RcVecF64(Rc::new(t));
+        let x: Vec<f64> = states.iter().map(|s| s.position().x).collect();
+        let y: Vec<f64> = states.iter().map(|s| s.position().y).collect();
+        let z: Vec<f64> = states.iter().map(|s| s.position().z).collect();
+        let vx: Vec<f64> = states.iter().map(|s| s.velocity().x).collect();
+        let vy: Vec<f64> = states.iter().map(|s| s.velocity().y).collect();
+        let vz: Vec<f64> = states.iter().map(|s| s.velocity().z).collect();
+        let x = CubicSpline::new(t.clone(), x)?;
+        let y = CubicSpline::new(t.clone(), y)?;
+        let z = CubicSpline::new(t.clone(), z)?;
+        let vx = CubicSpline::new(t.clone(), vx)?;
+        let vy = CubicSpline::new(t.clone(), vy)?;
+        let vz = CubicSpline::new(t.clone(), vz)?;
+        Ok(Self {
+            origin: s0.origin(),
+            frame: s0.reference_frame(),
+            t0,
+            t1,
+            dt_max,
+            t,
+            x,
+            y,
+            z,
+            vx,
+            vy,
+            vz,
+            fields: HashMap::default(),
+        })
+    }
+
+    pub fn add_field(&mut self, field: &str, values: &[f64]) -> Result<(), LoxTrajectoryError> {
+        let t = self.t.clone();
+        let spline = CubicSpline::new(t, values.to_vec())?;
+        self.fields.insert(field.to_string(), spline);
+        Ok(())
+    }
+
+    fn time_delta(&self, epoch: Time<T>) -> Option<TimeDelta> {
+        let delta = epoch - self.t0;
+        if delta.is_negative() {
+            return None;
+        }
+        if delta > self.dt_max {
+            return None;
+        }
+        Some(delta)
+    }
+
+    pub fn time(&self, delta: TimeDelta) -> Time<T> {
+        self.t0 + delta
+    }
+
+    pub fn position(&self, delta: TimeDelta) -> DVec3 {
+        let t = delta.to_decimal_seconds();
+        DVec3::new(
+            self.x.interpolate(t),
+            self.y.interpolate(t),
+            self.z.interpolate(t),
+        )
+    }
+
+    pub fn velocity(&self, delta: TimeDelta) -> DVec3 {
+        let t = delta.to_decimal_seconds();
+        DVec3::new(
+            self.vx.interpolate(t),
+            self.vy.interpolate(t),
+            self.vz.interpolate(t),
+        )
+    }
+}
+
+impl<T, O, F> CoordinateSystem for CubicSplineTrajectory<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    type Origin = O;
+    type Frame = F;
+
+    fn origin(&self) -> Self::Origin {
+        self.origin
+    }
+
+    fn reference_frame(&self) -> Self::Frame {
+        self.frame
+    }
+}
+
+impl<T, O, F> Trajectory for CubicSplineTrajectory<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    type Time = T;
+
+    type Origin = O;
+
+    type Frame = F;
+
+    fn state_at_epoch(
+        &self,
+        epoch: Time<Self::Time>,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError> {
+        let dt = self
+            .time_delta(epoch)
+            .ok_or(LoxTrajectoryError::EpochOutOfRange(
+                self.t0.to_string(),
+                self.t1.to_string(),
+                epoch.to_string(),
+            ))?;
+        self.state_after_delta(dt)
+    }
+
+    fn state_after_delta(
+        &self,
+        delta: TimeDelta,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError> {
+        if delta.is_negative() || delta > self.dt_max {
+            return Err(LoxTrajectoryError::DeltaOutOfRange(
+                self.dt_max.to_decimal_seconds().to_string(),
+                delta.to_decimal_seconds().to_string(),
+            ));
+        }
+        let time = self.time(delta);
+        let position = self.position(delta);
+        let velocity = self.velocity(delta);
+        Ok(Cartesian::new(
+            time,
+            self.origin(),
+            self.reference_frame(),
+            position,
+            velocity,
+        ))
+    }
+
+    fn field_at_epoch(
+        &self,
+        field: &str,
+        epoch: Time<Self::Time>,
+    ) -> Result<f64, LoxTrajectoryError> {
+        let dt = self
+            .time_delta(epoch)
+            .ok_or(LoxTrajectoryError::EpochOutOfRange(
+                self.t0.to_string(),
+                self.t1.to_string(),
+                epoch.to_string(),
+            ))?;
+        self.field_after_delta(field, dt)
+    }
+
+    fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError> {
+        if delta.is_negative() || delta > self.dt_max {
+            return Err(LoxTrajectoryError::DeltaOutOfRange(
+                self.dt_max.to_decimal_seconds().to_string(),
+                delta.to_decimal_seconds().to_string(),
+            ));
+        }
+        let spl = self
+            .fields
+            .get(field)
+            .ok_or(LoxTrajectoryError::FieldNotFound(field.to_owned()))?;
+        Ok(spl.interpolate(delta.to_decimal_seconds()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::frames::Icrf;
+    use crate::two_body::Cartesian;
+    use lox_bodies::Earth;
+    use lox_time::time_scales::TAI;
+
+    use super::*;
+
+    #[test]
+    fn test_trajectory() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
+        let actual = trajectory.state_at_epoch(t).expect("should be valid");
+
+        assert_eq!(actual.position().x, 2500.0);
+        assert_eq!(actual.position().y, 2500.0);
+        assert_eq!(actual.position().z, 2500.0);
+        assert_eq!(actual.velocity().x, 2.5);
+        assert_eq!(actual.velocity().y, 2.5);
+        assert_eq!(actual.velocity().z, 2.5);
+        assert_eq!(actual.time(), t);
+        assert_eq!(actual.origin(), Earth);
+        assert_eq!(actual.reference_frame(), Icrf);
+    }
+
+    #[test]
+    fn test_trajectory_field() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let field = vec![1.0, 2.0, 3.0, 4.0];
+        let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        trajectory
+            .add_field("field", &field)
+            .expect("should be valid");
+        let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
+        let actual = trajectory
+            .field_at_epoch("field", t)
+            .expect("should be valid");
+        assert_eq!(actual, 2.5);
+    }
+
+    #[test]
+    fn test_trajectory_too_few_states() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let trajectory = CubicSplineTrajectory::new(&states);
+        assert_eq!(
+            trajectory,
+            Err(LoxTrajectoryError::TooFewStates(states.len()))
+        );
+    }
+
+    #[test]
+    fn test_trajectory_unknown_field() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
+        let field = trajectory.field_at_epoch("field", t);
+        assert_eq!(
+            field,
+            Err(LoxTrajectoryError::FieldNotFound("field".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_trajectory_delta_out_of_range() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let field = vec![1.0, 2.0, 3.0, 4.0];
+        let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        trajectory
+            .add_field("field", &field)
+            .expect("should be valid");
+
+        let dt = TimeDelta::from_decimal_seconds(-5.0).expect("should be valid");
+        assert_eq!(
+            trajectory.state_after_delta(dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "-5".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_after_delta("field", dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "-5".to_owned()
+            ))
+        );
+
+        let dt = TimeDelta::from_decimal_seconds(5.0).expect("should be valid");
+        assert_eq!(
+            trajectory.state_after_delta(dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "5".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_after_delta("field", dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "5".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_trajectory_epoch_out_of_range() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let field = vec![1.0, 2.0, 3.0, 4.0];
+        let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        trajectory
+            .add_field("field", &field)
+            .expect("should be valid");
+
+        let dt = TimeDelta::from_decimal_seconds(-5.0).expect("should be valid");
+        let t = Time::default() + dt;
+        assert_eq!(
+            trajectory.state_at_epoch(t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "11:59:55.000 TAI".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_at_epoch("field", t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "11:59:55.000 TAI".to_owned()
+            ))
+        );
+
+        let dt = TimeDelta::from_decimal_seconds(5.0).expect("should be valid");
+        let t = Time::default() + dt;
+        assert_eq!(
+            trajectory.state_at_epoch(t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "12:00:05.000 TAI".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_at_epoch("field", t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "12:00:05.000 TAI".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/lox-coords/src/two_body.rs
+++ b/crates/lox-coords/src/two_body.rs
@@ -67,7 +67,7 @@ where
     }
 
     pub fn velocity(&self) -> DVec3 {
-        self.state.position()
+        self.state.velocity()
     }
 }
 

--- a/crates/lox-space/src/time.rs
+++ b/crates/lox-space/src/time.rs
@@ -338,7 +338,7 @@ mod tests {
         let actual = PySubsecond::new(0.123456789123456)
             .expect("subsecond should be valid")
             .__str__();
-        let expected = "123.456.789.123.456";
+        let expected = "123";
         assert_eq!(expected, actual);
     }
 }

--- a/crates/lox-time/src/deltas.rs
+++ b/crates/lox-time/src/deltas.rs
@@ -8,6 +8,7 @@
 
 use crate::subsecond::Subsecond;
 use num::ToPrimitive;
+use std::cmp::Ordering;
 use std::ops::{Add, Neg, Sub};
 
 use crate::constants::f64;
@@ -241,6 +242,21 @@ impl Sub for TimeDelta {
         Self {
             seconds: diff_seconds,
             subsecond: Subsecond(diff_subsecond),
+        }
+    }
+}
+
+impl PartialOrd for TimeDelta {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TimeDelta {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.seconds.cmp(&other.seconds) {
+            Ordering::Equal => self.subsecond.0.partial_cmp(&other.subsecond.0).unwrap(),
+            ordering => ordering,
         }
     }
 }

--- a/crates/lox-time/src/subsecond.rs
+++ b/crates/lox-time/src/subsecond.rs
@@ -65,15 +65,7 @@ impl Subsecond {
 
 impl Display for Subsecond {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{:03}.{:03}.{:03}.{:03}.{:03}",
-            self.millisecond(),
-            self.microsecond(),
-            self.nanosecond(),
-            self.picosecond(),
-            self.femtosecond()
-        )
+        write!(f, "{:03}", self.millisecond(),)
     }
 }
 
@@ -149,7 +141,7 @@ mod tests {
     #[test]
     fn test_subsecond_display() {
         let subsecond = Subsecond(0.123456789876543);
-        assert_eq!("123.456.789.876.543", subsecond.to_string());
+        assert_eq!("123", subsecond.to_string());
     }
 
     #[test]

--- a/crates/lox-time/src/utc.rs
+++ b/crates/lox-time/src/utc.rs
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_time_display() {
-        assert_eq!("12:34:56.789.123.456.789.123 UTC", TIME.to_string());
+        assert_eq!("12:34:56.789 UTC", TIME.to_string());
     }
 
     #[test]


### PR DESCRIPTION
- Implement `Sub` between two `BaseTime` and `Time` instances
- Implement `Ord` and `PartialOrd` for `TimeDelta`
- Make the cubic spline interpolator work with references and owned data
- Add `Trajectory` trait and implement `CubicSplineTrajectory` with the ability to add additional time series
- @AngusGMorrison I butchered your `Display` implementation for `Subsecond` because the format was quite unorthodox and hard to parse for humans. We may need to revisit this. 