### PR TITLE
Implement Vallado propagator

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,5 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/.idea/lox-space.iml
+++ b/.idea/lox-space.iml
@@ -29,6 +29,7 @@
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
       <excludeFolder url="file://$MODULE_DIR$/tools/lox-gen/target" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/copilot/chatSessions" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/lox-space.iml
+++ b/.idea/lox-space.iml
@@ -25,6 +25,7 @@
       <sourceFolder url="file://$MODULE_DIR$/crates/lox-space/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/crates/lox-utils/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/lox-utils/src/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/lox-propagators/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tools/lox-gen/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lox-propagators"
+version = "0.1.0"
+dependencies = [
+ "float_eq",
+ "libm",
+ "lox-bodies",
+ "lox-coords",
+ "lox-time",
+ "thiserror",
+]
+
+[[package]]
 name = "lox-space"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "lox-bodies",
  "lox-time",
  "lox-utils",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lox-utils = { path = "crates/lox-utils" }
 lox-earth = { path = "crates/lox-earth" }
 lox-ephem = { path = "crates/lox-ephem" }
 lox-io = { path = "crates/lox-io" }
+lox-propagators = { path = "crates/lox-propagators" }
 lox-space = { path = "crates/lox-space" }
 lox-time = { path = "crates/lox-time" }
 
@@ -29,6 +30,7 @@ dyn-clone = "1.0.17"
 fast_polynomial = "0.1.0"
 float_eq = "1.0.1"
 glam = "0.25.0"
+libm = "0.2.1"
 mockall = "0.12.1"
 nalgebra = "0.32.4"
 nom = "7.1.3"

--- a/crates/lox-coords/Cargo.toml
+++ b/crates/lox-coords/Cargo.toml
@@ -15,3 +15,4 @@ lox-utils.workspace = true
 
 float_eq.workspace = true
 glam.workspace = true
+thiserror.workspace = true

--- a/crates/lox-coords/src/base.rs
+++ b/crates/lox-coords/src/base.rs
@@ -9,6 +9,7 @@
 use float_eq::float_eq;
 use glam::{DMat3, DVec3};
 
+use lox_time::base_time::BaseTime;
 use lox_utils::math::{mod_two_pi, normalize_two_pi};
 
 use crate::anomalies::{eccentric_to_true, hyperbolic_to_true};
@@ -17,6 +18,8 @@ pub trait BaseTwoBody {
     fn to_cartesian_state(&self, grav_param: f64) -> BaseCartesian;
     fn to_keplerian_state(&self, grav_param: f64) -> BaseKeplerian;
 }
+
+pub type BaseState = (BaseTime, BaseCartesian);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BaseCartesian {

--- a/crates/lox-coords/src/lib.rs
+++ b/crates/lox-coords/src/lib.rs
@@ -15,6 +15,7 @@ use crate::frames::ReferenceFrame;
 pub mod anomalies;
 pub mod base;
 pub mod frames;
+pub mod trajectories;
 pub mod two_body;
 
 pub trait CoordinateSystem {

--- a/crates/lox-coords/src/trajectories.rs
+++ b/crates/lox-coords/src/trajectories.rs
@@ -6,70 +6,56 @@
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
-use std::rc::Rc;
-
-use glam::DVec3;
+use lox_time::base_time::BaseTime;
 use thiserror::Error;
 
 use lox_bodies::PointMass;
 use lox_time::deltas::TimeDelta;
 use lox_time::time_scales::TimeScale;
 use lox_time::Time;
-use lox_utils::interpolation::cubic_spline::{CubicSpline, LoxCubicSplineError};
+use lox_utils::interpolation::cubic_spline::LoxCubicSplineError;
 
+use crate::base::BaseCartesian;
 use crate::frames::ReferenceFrame;
 use crate::two_body::Cartesian;
 use crate::CoordinateSystem;
 
+use self::base::{BaseCubicSplineTrajectory, BaseTrajectory};
+
+pub mod base;
+
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum LoxTrajectoryError {
-    #[error("epoch must be between {0} and {1} but was {2}")]
-    EpochOutOfRange(String, String, String),
     #[error("time delta must be between 0.0 seconds and {0} seconds but was {1} seconds")]
     DeltaOutOfRange(String, String),
-    #[error("`states` must have at least four element but had {0}")]
-    TooFewStates(usize),
+    #[error("`times` and `states` must have the same length but were {0} and {1}")]
+    DimensionMismatch(usize, usize),
+    #[error("epoch must be between {0} and {1} but was {2}")]
+    EpochOutOfRange(String, String, String),
     #[error("unknown field `{0}`")]
     FieldNotFound(String),
+    #[error("`states` must have at least four element but had {0}")]
+    TooFewStates(usize),
     #[error(transparent)]
     CubicSplineError(#[from] LoxCubicSplineError),
 }
 
 pub trait Trajectory<T: TimeScale + Copy, O: PointMass + Copy, F: ReferenceFrame + Copy> {
-    fn state_at_epoch(&self, epoch: Time<T>) -> Result<Cartesian<T, O, F>, LoxTrajectoryError>;
+    fn state_at_time(&self, time: Time<T>) -> Result<Cartesian<T, O, F>, LoxTrajectoryError>;
     fn state_after_delta(&self, delta: TimeDelta)
         -> Result<Cartesian<T, O, F>, LoxTrajectoryError>;
-    fn field_at_epoch(&self, field: &str, epoch: Time<T>) -> Result<f64, LoxTrajectoryError>;
+    fn set_field(&mut self, field: &str, data: &[f64]) -> Result<(), LoxTrajectoryError>;
+    fn field_at_time(&self, field: &str, time: Time<T>) -> Result<f64, LoxTrajectoryError>;
     fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError>;
-}
-
-#[derive(Clone, Debug, PartialEq)]
-#[repr(transparent)]
-struct RcVecF64(Rc<Vec<f64>>);
-
-impl AsRef<[f64]> for RcVecF64 {
-    fn as_ref(&self) -> &[f64] {
-        self.0.as_ref()
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CubicSplineTrajectory<T: TimeScale + Copy, O: PointMass + Copy, F: ReferenceFrame + Copy>
 {
+    scale: T,
     origin: O,
     frame: F,
-    t0: Time<T>,
-    t1: Time<T>,
-    dt_max: TimeDelta,
-    t: RcVecF64,
-    x: CubicSpline<RcVecF64, Vec<f64>>,
-    y: CubicSpline<RcVecF64, Vec<f64>>,
-    z: CubicSpline<RcVecF64, Vec<f64>>,
-    vy: CubicSpline<RcVecF64, Vec<f64>>,
-    vx: CubicSpline<RcVecF64, Vec<f64>>,
-    vz: CubicSpline<RcVecF64, Vec<f64>>,
-    fields: HashMap<String, CubicSpline<RcVecF64, Vec<f64>>>,
+    base: BaseCubicSplineTrajectory,
 }
 
 impl<T, O, F> CubicSplineTrajectory<T, O, F>
@@ -83,81 +69,19 @@ where
             return Err(LoxTrajectoryError::TooFewStates(states.len()));
         }
         let s0 = states.first().unwrap();
-        let t0 = s0.time();
-        let t1 = states.last().unwrap().time();
-        let dt_max = t1 - t0;
-        let t: Vec<f64> = states
-            .iter()
-            .map(|s| (s.time() - t0).to_decimal_seconds())
-            .collect();
-        let t = RcVecF64(Rc::new(t));
-        let x: Vec<f64> = states.iter().map(|s| s.position().x).collect();
-        let y: Vec<f64> = states.iter().map(|s| s.position().y).collect();
-        let z: Vec<f64> = states.iter().map(|s| s.position().z).collect();
-        let vx: Vec<f64> = states.iter().map(|s| s.velocity().x).collect();
-        let vy: Vec<f64> = states.iter().map(|s| s.velocity().y).collect();
-        let vz: Vec<f64> = states.iter().map(|s| s.velocity().z).collect();
-        let x = CubicSpline::new(t.clone(), x)?;
-        let y = CubicSpline::new(t.clone(), y)?;
-        let z = CubicSpline::new(t.clone(), z)?;
-        let vx = CubicSpline::new(t.clone(), vx)?;
-        let vy = CubicSpline::new(t.clone(), vy)?;
-        let vz = CubicSpline::new(t.clone(), vz)?;
+        let times: Vec<BaseTime> = states.iter().map(|&s| s.time().base_time()).collect();
+        let states: Vec<BaseCartesian> = states.iter().map(|&s| s.base()).collect();
+        let base = BaseCubicSplineTrajectory::new(&times, &states)?;
         Ok(Self {
+            scale: s0.time().scale(),
             origin: s0.origin(),
             frame: s0.reference_frame(),
-            t0,
-            t1,
-            dt_max,
-            t,
-            x,
-            y,
-            z,
-            vx,
-            vy,
-            vz,
-            fields: HashMap::default(),
+            base,
         })
     }
 
-    pub fn add_field(&mut self, field: &str, values: &[f64]) -> Result<(), LoxTrajectoryError> {
-        let t = self.t.clone();
-        let spline = CubicSpline::new(t, values.to_vec())?;
-        self.fields.insert(field.to_string(), spline);
-        Ok(())
-    }
-
-    fn time_delta(&self, epoch: Time<T>) -> Option<TimeDelta> {
-        let delta = epoch - self.t0;
-        if delta.is_negative() {
-            return None;
-        }
-        if delta > self.dt_max {
-            return None;
-        }
-        Some(delta)
-    }
-
-    pub fn time(&self, delta: TimeDelta) -> Time<T> {
-        self.t0 + delta
-    }
-
-    pub fn position(&self, delta: TimeDelta) -> DVec3 {
-        let t = delta.to_decimal_seconds();
-        DVec3::new(
-            self.x.interpolate(t),
-            self.y.interpolate(t),
-            self.z.interpolate(t),
-        )
-    }
-
-    pub fn velocity(&self, delta: TimeDelta) -> DVec3 {
-        let t = delta.to_decimal_seconds();
-        DVec3::new(
-            self.vx.interpolate(t),
-            self.vy.interpolate(t),
-            self.vz.interpolate(t),
-        )
+    pub fn scale(&self) -> T {
+        self.scale
     }
 }
 
@@ -185,72 +109,53 @@ where
     O: PointMass + Copy,
     F: ReferenceFrame + Copy,
 {
-    fn state_at_epoch(&self, epoch: Time<T>) -> Result<Cartesian<T, O, F>, LoxTrajectoryError> {
-        let dt = self
-            .time_delta(epoch)
-            .ok_or(LoxTrajectoryError::EpochOutOfRange(
-                self.t0.to_string(),
-                self.t1.to_string(),
-                epoch.to_string(),
-            ))?;
-        self.state_after_delta(dt)
+    fn state_at_time(&self, time: Time<T>) -> Result<Cartesian<T, O, F>, LoxTrajectoryError> {
+        let (_, base) = self.base.state_at_time(time.base_time())?;
+        Ok(Cartesian::new(
+            time,
+            self.origin(),
+            self.reference_frame(),
+            base.position(),
+            base.velocity(),
+        ))
     }
 
     fn state_after_delta(
         &self,
         delta: TimeDelta,
     ) -> Result<Cartesian<T, O, F>, LoxTrajectoryError> {
-        if delta.is_negative() || delta > self.dt_max {
-            return Err(LoxTrajectoryError::DeltaOutOfRange(
-                self.dt_max.to_decimal_seconds().to_string(),
-                delta.to_decimal_seconds().to_string(),
-            ));
-        }
-        let time = self.time(delta);
-        let position = self.position(delta);
-        let velocity = self.velocity(delta);
+        let (base_time, base) = self.base.state_after_delta(delta)?;
+        let time = Time::from_base_time(self.scale(), base_time);
         Ok(Cartesian::new(
             time,
             self.origin(),
             self.reference_frame(),
-            position,
-            velocity,
+            base.position(),
+            base.velocity(),
         ))
     }
 
-    fn field_at_epoch(&self, field: &str, epoch: Time<T>) -> Result<f64, LoxTrajectoryError> {
-        let dt = self
-            .time_delta(epoch)
-            .ok_or(LoxTrajectoryError::EpochOutOfRange(
-                self.t0.to_string(),
-                self.t1.to_string(),
-                epoch.to_string(),
-            ))?;
-        self.field_after_delta(field, dt)
+    fn set_field(&mut self, field: &str, data: &[f64]) -> Result<(), LoxTrajectoryError> {
+        self.base.set_field(field, data)
+    }
+
+    fn field_at_time(&self, field: &str, time: Time<T>) -> Result<f64, LoxTrajectoryError> {
+        self.base.field_at_time(field, time.base_time())
     }
 
     fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError> {
-        if delta.is_negative() || delta > self.dt_max {
-            return Err(LoxTrajectoryError::DeltaOutOfRange(
-                self.dt_max.to_decimal_seconds().to_string(),
-                delta.to_decimal_seconds().to_string(),
-            ));
-        }
-        let spl = self
-            .fields
-            .get(field)
-            .ok_or(LoxTrajectoryError::FieldNotFound(field.to_owned()))?;
-        Ok(spl.interpolate(delta.to_decimal_seconds()))
+        self.base.field_after_delta(field, delta)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use glam::DVec3;
+    use lox_bodies::Earth;
+    use lox_time::time_scales::TAI;
 
     use crate::frames::Icrf;
     use crate::two_body::Cartesian;
-    use lox_bodies::Earth;
-    use lox_time::time_scales::TAI;
 
     use super::*;
 
@@ -268,7 +173,7 @@ mod tests {
             .collect();
         let trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
         let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
-        let actual = trajectory.state_at_epoch(t).expect("should be valid");
+        let actual = trajectory.state_at_time(t).expect("should be valid");
 
         assert_eq!(actual.position().x, 2500.0);
         assert_eq!(actual.position().y, 2500.0);
@@ -296,11 +201,11 @@ mod tests {
         let field = vec![1.0, 2.0, 3.0, 4.0];
         let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
         trajectory
-            .add_field("field", &field)
+            .set_field("field", &field)
             .expect("should be valid");
         let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
         let actual = trajectory
-            .field_at_epoch("field", t)
+            .field_at_time("field", t)
             .expect("should be valid");
         assert_eq!(actual, 2.5);
     }
@@ -338,7 +243,7 @@ mod tests {
             .collect();
         let trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
         let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
-        let field = trajectory.field_at_epoch("field", t);
+        let field = trajectory.field_at_time("field", t);
         assert_eq!(
             field,
             Err(LoxTrajectoryError::FieldNotFound("field".to_owned()))
@@ -360,7 +265,7 @@ mod tests {
         let field = vec![1.0, 2.0, 3.0, 4.0];
         let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
         trajectory
-            .add_field("field", &field)
+            .set_field("field", &field)
             .expect("should be valid");
 
         let dt = TimeDelta::from_decimal_seconds(-5.0).expect("should be valid");
@@ -411,44 +316,44 @@ mod tests {
         let field = vec![1.0, 2.0, 3.0, 4.0];
         let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
         trajectory
-            .add_field("field", &field)
+            .set_field("field", &field)
             .expect("should be valid");
 
         let dt = TimeDelta::from_decimal_seconds(-5.0).expect("should be valid");
         let t = Time::default() + dt;
         assert_eq!(
-            trajectory.state_at_epoch(t),
+            trajectory.state_at_time(t),
             Err(LoxTrajectoryError::EpochOutOfRange(
-                "12:00:01.000 TAI".to_owned(),
-                "12:00:04.000 TAI".to_owned(),
-                "11:59:55.000 TAI".to_owned()
+                "12:00:01.000".to_owned(),
+                "12:00:04.000".to_owned(),
+                "11:59:55.000".to_owned()
             ))
         );
         assert_eq!(
-            trajectory.field_at_epoch("field", t),
+            trajectory.field_at_time("field", t),
             Err(LoxTrajectoryError::EpochOutOfRange(
-                "12:00:01.000 TAI".to_owned(),
-                "12:00:04.000 TAI".to_owned(),
-                "11:59:55.000 TAI".to_owned()
+                "12:00:01.000".to_owned(),
+                "12:00:04.000".to_owned(),
+                "11:59:55.000".to_owned()
             ))
         );
 
         let dt = TimeDelta::from_decimal_seconds(5.0).expect("should be valid");
         let t = Time::default() + dt;
         assert_eq!(
-            trajectory.state_at_epoch(t),
+            trajectory.state_at_time(t),
             Err(LoxTrajectoryError::EpochOutOfRange(
-                "12:00:01.000 TAI".to_owned(),
-                "12:00:04.000 TAI".to_owned(),
-                "12:00:05.000 TAI".to_owned()
+                "12:00:01.000".to_owned(),
+                "12:00:04.000".to_owned(),
+                "12:00:05.000".to_owned()
             ))
         );
         assert_eq!(
-            trajectory.field_at_epoch("field", t),
+            trajectory.field_at_time("field", t),
             Err(LoxTrajectoryError::EpochOutOfRange(
-                "12:00:01.000 TAI".to_owned(),
-                "12:00:04.000 TAI".to_owned(),
-                "12:00:05.000 TAI".to_owned()
+                "12:00:01.000".to_owned(),
+                "12:00:04.000".to_owned(),
+                "12:00:05.000".to_owned()
             ))
         );
     }

--- a/crates/lox-coords/src/trajectories.rs
+++ b/crates/lox-coords/src/trajectories.rs
@@ -27,8 +27,6 @@ pub mod base;
 pub enum LoxTrajectoryError {
     #[error("time delta must be between 0.0 seconds and {0} seconds but was {1} seconds")]
     DeltaOutOfRange(String, String),
-    #[error("`times` and `states` must have the same length but were {0} and {1}")]
-    DimensionMismatch(usize, usize),
     #[error("epoch must be between {0} and {1} but was {2}")]
     EpochOutOfRange(String, String, String),
     #[error("unknown field `{0}`")]

--- a/crates/lox-coords/src/trajectories.rs
+++ b/crates/lox-coords/src/trajectories.rs
@@ -1,0 +1,481 @@
+/*
+ * Copyright (c) 2024. Helge Eichhorn and the LOX contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use glam::DVec3;
+use thiserror::Error;
+
+use lox_bodies::PointMass;
+use lox_time::deltas::TimeDelta;
+use lox_time::time_scales::TimeScale;
+use lox_time::Time;
+use lox_utils::interpolation::cubic_spline::{CubicSpline, LoxCubicSplineError};
+
+use crate::frames::ReferenceFrame;
+use crate::two_body::Cartesian;
+use crate::CoordinateSystem;
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum LoxTrajectoryError {
+    #[error("epoch must be between {0} and {1} but was {2}")]
+    EpochOutOfRange(String, String, String),
+    #[error("time delta must be between 0.0 seconds and {0} seconds but was {1} seconds")]
+    DeltaOutOfRange(String, String),
+    #[error("`states` must have at least four element but had {0}")]
+    TooFewStates(usize),
+    #[error("unknown field `{0}`")]
+    FieldNotFound(String),
+    #[error(transparent)]
+    CubicSplineError(#[from] LoxCubicSplineError),
+}
+
+pub trait Trajectory {
+    type Time: TimeScale + Copy;
+    type Origin: PointMass + Copy;
+    type Frame: ReferenceFrame + Copy;
+
+    fn state_at_epoch(
+        &self,
+        epoch: Time<Self::Time>,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError>;
+    fn state_after_delta(
+        &self,
+        delta: TimeDelta,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError>;
+    fn field_at_epoch(
+        &self,
+        field: &str,
+        epoch: Time<Self::Time>,
+    ) -> Result<f64, LoxTrajectoryError>;
+    fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[repr(transparent)]
+struct RcVecF64(Rc<Vec<f64>>);
+
+impl AsRef<[f64]> for RcVecF64 {
+    fn as_ref(&self) -> &[f64] {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CubicSplineTrajectory<T: TimeScale + Copy, O: PointMass + Copy, F: ReferenceFrame + Copy>
+{
+    origin: O,
+    frame: F,
+    t0: Time<T>,
+    t1: Time<T>,
+    dt_max: TimeDelta,
+    t: RcVecF64,
+    x: CubicSpline<RcVecF64, Vec<f64>>,
+    y: CubicSpline<RcVecF64, Vec<f64>>,
+    z: CubicSpline<RcVecF64, Vec<f64>>,
+    vy: CubicSpline<RcVecF64, Vec<f64>>,
+    vx: CubicSpline<RcVecF64, Vec<f64>>,
+    vz: CubicSpline<RcVecF64, Vec<f64>>,
+    fields: HashMap<String, CubicSpline<RcVecF64, Vec<f64>>>,
+}
+
+impl<T, O, F> CubicSplineTrajectory<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    pub fn new(states: &[Cartesian<T, O, F>]) -> Result<Self, LoxTrajectoryError> {
+        if states.len() < 4 {
+            return Err(LoxTrajectoryError::TooFewStates(states.len()));
+        }
+        let s0 = states.first().unwrap();
+        let t0 = s0.time();
+        let t1 = states.last().unwrap().time();
+        let dt_max = t1 - t0;
+        let t: Vec<f64> = states
+            .iter()
+            .map(|s| (s.time() - t0).to_decimal_seconds())
+            .collect();
+        let t = RcVecF64(Rc::new(t));
+        let x: Vec<f64> = states.iter().map(|s| s.position().x).collect();
+        let y: Vec<f64> = states.iter().map(|s| s.position().y).collect();
+        let z: Vec<f64> = states.iter().map(|s| s.position().z).collect();
+        let vx: Vec<f64> = states.iter().map(|s| s.velocity().x).collect();
+        let vy: Vec<f64> = states.iter().map(|s| s.velocity().y).collect();
+        let vz: Vec<f64> = states.iter().map(|s| s.velocity().z).collect();
+        let x = CubicSpline::new(t.clone(), x)?;
+        let y = CubicSpline::new(t.clone(), y)?;
+        let z = CubicSpline::new(t.clone(), z)?;
+        let vx = CubicSpline::new(t.clone(), vx)?;
+        let vy = CubicSpline::new(t.clone(), vy)?;
+        let vz = CubicSpline::new(t.clone(), vz)?;
+        Ok(Self {
+            origin: s0.origin(),
+            frame: s0.reference_frame(),
+            t0,
+            t1,
+            dt_max,
+            t,
+            x,
+            y,
+            z,
+            vx,
+            vy,
+            vz,
+            fields: HashMap::default(),
+        })
+    }
+
+    pub fn add_field(&mut self, field: &str, values: &[f64]) -> Result<(), LoxTrajectoryError> {
+        let t = self.t.clone();
+        let spline = CubicSpline::new(t, values.to_vec())?;
+        self.fields.insert(field.to_string(), spline);
+        Ok(())
+    }
+
+    fn time_delta(&self, epoch: Time<T>) -> Option<TimeDelta> {
+        let delta = epoch - self.t0;
+        if delta.is_negative() {
+            return None;
+        }
+        if delta > self.dt_max {
+            return None;
+        }
+        Some(delta)
+    }
+
+    pub fn time(&self, delta: TimeDelta) -> Time<T> {
+        self.t0 + delta
+    }
+
+    pub fn position(&self, delta: TimeDelta) -> DVec3 {
+        let t = delta.to_decimal_seconds();
+        DVec3::new(
+            self.x.interpolate(t),
+            self.y.interpolate(t),
+            self.z.interpolate(t),
+        )
+    }
+
+    pub fn velocity(&self, delta: TimeDelta) -> DVec3 {
+        let t = delta.to_decimal_seconds();
+        DVec3::new(
+            self.vx.interpolate(t),
+            self.vy.interpolate(t),
+            self.vz.interpolate(t),
+        )
+    }
+}
+
+impl<T, O, F> CoordinateSystem for CubicSplineTrajectory<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    type Origin = O;
+    type Frame = F;
+
+    fn origin(&self) -> Self::Origin {
+        self.origin
+    }
+
+    fn reference_frame(&self) -> Self::Frame {
+        self.frame
+    }
+}
+
+impl<T, O, F> Trajectory for CubicSplineTrajectory<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    type Time = T;
+
+    type Origin = O;
+
+    type Frame = F;
+
+    fn state_at_epoch(
+        &self,
+        epoch: Time<Self::Time>,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError> {
+        let dt = self
+            .time_delta(epoch)
+            .ok_or(LoxTrajectoryError::EpochOutOfRange(
+                self.t0.to_string(),
+                self.t1.to_string(),
+                epoch.to_string(),
+            ))?;
+        self.state_after_delta(dt)
+    }
+
+    fn state_after_delta(
+        &self,
+        delta: TimeDelta,
+    ) -> Result<Cartesian<Self::Time, Self::Origin, Self::Frame>, LoxTrajectoryError> {
+        if delta.is_negative() || delta > self.dt_max {
+            return Err(LoxTrajectoryError::DeltaOutOfRange(
+                self.dt_max.to_decimal_seconds().to_string(),
+                delta.to_decimal_seconds().to_string(),
+            ));
+        }
+        let time = self.time(delta);
+        let position = self.position(delta);
+        let velocity = self.velocity(delta);
+        Ok(Cartesian::new(
+            time,
+            self.origin(),
+            self.reference_frame(),
+            position,
+            velocity,
+        ))
+    }
+
+    fn field_at_epoch(
+        &self,
+        field: &str,
+        epoch: Time<Self::Time>,
+    ) -> Result<f64, LoxTrajectoryError> {
+        let dt = self
+            .time_delta(epoch)
+            .ok_or(LoxTrajectoryError::EpochOutOfRange(
+                self.t0.to_string(),
+                self.t1.to_string(),
+                epoch.to_string(),
+            ))?;
+        self.field_after_delta(field, dt)
+    }
+
+    fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError> {
+        if delta.is_negative() || delta > self.dt_max {
+            return Err(LoxTrajectoryError::DeltaOutOfRange(
+                self.dt_max.to_decimal_seconds().to_string(),
+                delta.to_decimal_seconds().to_string(),
+            ));
+        }
+        let spl = self
+            .fields
+            .get(field)
+            .ok_or(LoxTrajectoryError::FieldNotFound(field.to_owned()))?;
+        Ok(spl.interpolate(delta.to_decimal_seconds()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::frames::Icrf;
+    use crate::two_body::Cartesian;
+    use lox_bodies::Earth;
+    use lox_time::time_scales::TAI;
+
+    use super::*;
+
+    #[test]
+    fn test_trajectory() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
+        let actual = trajectory.state_at_epoch(t).expect("should be valid");
+
+        assert_eq!(actual.position().x, 2500.0);
+        assert_eq!(actual.position().y, 2500.0);
+        assert_eq!(actual.position().z, 2500.0);
+        assert_eq!(actual.velocity().x, 2.5);
+        assert_eq!(actual.velocity().y, 2.5);
+        assert_eq!(actual.velocity().z, 2.5);
+        assert_eq!(actual.time(), t);
+        assert_eq!(actual.origin(), Earth);
+        assert_eq!(actual.reference_frame(), Icrf);
+    }
+
+    #[test]
+    fn test_trajectory_field() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let field = vec![1.0, 2.0, 3.0, 4.0];
+        let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        trajectory
+            .add_field("field", &field)
+            .expect("should be valid");
+        let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
+        let actual = trajectory
+            .field_at_epoch("field", t)
+            .expect("should be valid");
+        assert_eq!(actual, 2.5);
+    }
+
+    #[test]
+    fn test_trajectory_too_few_states() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let trajectory = CubicSplineTrajectory::new(&states);
+        assert_eq!(
+            trajectory,
+            Err(LoxTrajectoryError::TooFewStates(states.len()))
+        );
+    }
+
+    #[test]
+    fn test_trajectory_unknown_field() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        let t = Time::default() + TimeDelta::from_decimal_seconds(2.5).expect("should be valid");
+        let field = trajectory.field_at_epoch("field", t);
+        assert_eq!(
+            field,
+            Err(LoxTrajectoryError::FieldNotFound("field".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_trajectory_delta_out_of_range() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let field = vec![1.0, 2.0, 3.0, 4.0];
+        let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        trajectory
+            .add_field("field", &field)
+            .expect("should be valid");
+
+        let dt = TimeDelta::from_decimal_seconds(-5.0).expect("should be valid");
+        assert_eq!(
+            trajectory.state_after_delta(dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "-5".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_after_delta("field", dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "-5".to_owned()
+            ))
+        );
+
+        let dt = TimeDelta::from_decimal_seconds(5.0).expect("should be valid");
+        assert_eq!(
+            trajectory.state_after_delta(dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "5".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_after_delta("field", dt),
+            Err(LoxTrajectoryError::DeltaOutOfRange(
+                "3".to_owned(),
+                "5".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_trajectory_epoch_out_of_range() {
+        let states: Vec<Cartesian<TAI, Earth, Icrf>> = vec![1.0, 2.0, 3.0, 4.0]
+            .iter()
+            .map(|&i| {
+                let position = DVec3::new(i, i, i) * 1.0e3;
+                let velocity = DVec3::new(i, i, i);
+                let time =
+                    Time::default() + TimeDelta::from_decimal_seconds(i).expect("should be valid");
+                Cartesian::new(time, Earth, Icrf, position, velocity)
+            })
+            .collect();
+        let field = vec![1.0, 2.0, 3.0, 4.0];
+        let mut trajectory = CubicSplineTrajectory::new(&states).expect("should be valid");
+        trajectory
+            .add_field("field", &field)
+            .expect("should be valid");
+
+        let dt = TimeDelta::from_decimal_seconds(-5.0).expect("should be valid");
+        let t = Time::default() + dt;
+        assert_eq!(
+            trajectory.state_at_epoch(t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "11:59:55.000 TAI".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_at_epoch("field", t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "11:59:55.000 TAI".to_owned()
+            ))
+        );
+
+        let dt = TimeDelta::from_decimal_seconds(5.0).expect("should be valid");
+        let t = Time::default() + dt;
+        assert_eq!(
+            trajectory.state_at_epoch(t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "12:00:05.000 TAI".to_owned()
+            ))
+        );
+        assert_eq!(
+            trajectory.field_at_epoch("field", t),
+            Err(LoxTrajectoryError::EpochOutOfRange(
+                "12:00:01.000 TAI".to_owned(),
+                "12:00:04.000 TAI".to_owned(),
+                "12:00:05.000 TAI".to_owned()
+            ))
+        );
+    }
+}

--- a/crates/lox-coords/src/trajectories.rs
+++ b/crates/lox-coords/src/trajectories.rs
@@ -6,7 +6,6 @@
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use lox_time::base_time::BaseTime;
 use thiserror::Error;
 
 use lox_bodies::PointMass;
@@ -15,7 +14,7 @@ use lox_time::time_scales::TimeScale;
 use lox_time::Time;
 use lox_utils::interpolation::cubic_spline::LoxCubicSplineError;
 
-use crate::base::BaseCartesian;
+use crate::base::BaseState;
 use crate::frames::ReferenceFrame;
 use crate::two_body::Cartesian;
 use crate::CoordinateSystem;
@@ -69,15 +68,23 @@ where
             return Err(LoxTrajectoryError::TooFewStates(states.len()));
         }
         let s0 = states.first().unwrap();
-        let times: Vec<BaseTime> = states.iter().map(|&s| s.time().base_time()).collect();
-        let states: Vec<BaseCartesian> = states.iter().map(|&s| s.base()).collect();
-        let base = BaseCubicSplineTrajectory::new(&times, &states)?;
+        let states: Vec<BaseState> = states.iter().map(|&s| s.base()).collect();
+        let base = BaseCubicSplineTrajectory::new(&states)?;
         Ok(Self {
             scale: s0.time().scale(),
             origin: s0.origin(),
             frame: s0.reference_frame(),
             base,
         })
+    }
+
+    pub fn from_base(scale: T, origin: O, frame: F, base: BaseCubicSplineTrajectory) -> Self {
+        Self {
+            scale,
+            origin,
+            frame,
+            base,
+        }
     }
 
     pub fn scale(&self) -> T {

--- a/crates/lox-coords/src/trajectories/base.rs
+++ b/crates/lox-coords/src/trajectories/base.rs
@@ -51,28 +51,24 @@ pub struct BaseCubicSplineTrajectory {
 }
 
 impl BaseCubicSplineTrajectory {
-    pub fn new(times: &[BaseTime], states: &[BaseCartesian]) -> Result<Self, LoxTrajectoryError> {
-        let n = times.len();
-        if n != states.len() {
-            return Err(LoxTrajectoryError::DimensionMismatch(n, states.len()));
-        }
-        if n < 4 {
+    pub fn new(states: &[BaseState]) -> Result<Self, LoxTrajectoryError> {
+        if states.len() < 4 {
             return Err(LoxTrajectoryError::TooFewStates(states.len()));
         }
-        let t0 = *times.first().unwrap();
-        let t1 = *times.last().unwrap();
+        let (t0, _) = *states.first().unwrap();
+        let (t1, _) = *states.last().unwrap();
         let dt_max = t1 - t0;
-        let t: Vec<f64> = times
+        let t: Vec<f64> = states
             .iter()
-            .map(|&t| (t - t0).to_decimal_seconds())
+            .map(|&(t, _)| (t - t0).to_decimal_seconds())
             .collect();
         let t = RcVecF64(Rc::new(t));
-        let x: Vec<f64> = states.iter().map(|s| s.position().x).collect();
-        let y: Vec<f64> = states.iter().map(|s| s.position().y).collect();
-        let z: Vec<f64> = states.iter().map(|s| s.position().z).collect();
-        let vx: Vec<f64> = states.iter().map(|s| s.velocity().x).collect();
-        let vy: Vec<f64> = states.iter().map(|s| s.velocity().y).collect();
-        let vz: Vec<f64> = states.iter().map(|s| s.velocity().z).collect();
+        let x: Vec<f64> = states.iter().map(|&(_, s)| s.position().x).collect();
+        let y: Vec<f64> = states.iter().map(|&(_, s)| s.position().y).collect();
+        let z: Vec<f64> = states.iter().map(|&(_, s)| s.position().z).collect();
+        let vx: Vec<f64> = states.iter().map(|&(_, s)| s.velocity().x).collect();
+        let vy: Vec<f64> = states.iter().map(|&(_, s)| s.velocity().y).collect();
+        let vz: Vec<f64> = states.iter().map(|&(_, s)| s.velocity().z).collect();
         let x = CubicSpline::new(t.clone(), x)?;
         let y = CubicSpline::new(t.clone(), y)?;
         let z = CubicSpline::new(t.clone(), z)?;

--- a/crates/lox-coords/src/trajectories/base.rs
+++ b/crates/lox-coords/src/trajectories/base.rs
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2024. Helge Eichhorn and the LOX contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use glam::DVec3;
+use lox_time::base_time::BaseTime;
+use lox_time::deltas::TimeDelta;
+use lox_utils::interpolation::cubic_spline::CubicSpline;
+
+use crate::base::{BaseCartesian, BaseState};
+use crate::trajectories::LoxTrajectoryError;
+
+pub trait BaseTrajectory {
+    fn state_at_time(&self, time: BaseTime) -> Result<BaseState, LoxTrajectoryError>;
+    fn state_after_delta(&self, delta: TimeDelta) -> Result<BaseState, LoxTrajectoryError>;
+    fn set_field(&mut self, field: &str, data: &[f64]) -> Result<(), LoxTrajectoryError>;
+    fn field_at_time(&self, field: &str, time: BaseTime) -> Result<f64, LoxTrajectoryError>;
+    fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[repr(transparent)]
+struct RcVecF64(Rc<Vec<f64>>);
+
+impl AsRef<[f64]> for RcVecF64 {
+    fn as_ref(&self) -> &[f64] {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct BaseCubicSplineTrajectory {
+    t0: BaseTime,
+    t1: BaseTime,
+    dt_max: TimeDelta,
+    t: RcVecF64,
+    x: CubicSpline<RcVecF64, Vec<f64>>,
+    y: CubicSpline<RcVecF64, Vec<f64>>,
+    z: CubicSpline<RcVecF64, Vec<f64>>,
+    vy: CubicSpline<RcVecF64, Vec<f64>>,
+    vx: CubicSpline<RcVecF64, Vec<f64>>,
+    vz: CubicSpline<RcVecF64, Vec<f64>>,
+    fields: HashMap<String, CubicSpline<RcVecF64, Vec<f64>>>,
+}
+
+impl BaseCubicSplineTrajectory {
+    pub fn new(times: &[BaseTime], states: &[BaseCartesian]) -> Result<Self, LoxTrajectoryError> {
+        let n = times.len();
+        if n != states.len() {
+            return Err(LoxTrajectoryError::DimensionMismatch(n, states.len()));
+        }
+        if n < 4 {
+            return Err(LoxTrajectoryError::TooFewStates(states.len()));
+        }
+        let t0 = *times.first().unwrap();
+        let t1 = *times.last().unwrap();
+        let dt_max = t1 - t0;
+        let t: Vec<f64> = times
+            .iter()
+            .map(|&t| (t - t0).to_decimal_seconds())
+            .collect();
+        let t = RcVecF64(Rc::new(t));
+        let x: Vec<f64> = states.iter().map(|s| s.position().x).collect();
+        let y: Vec<f64> = states.iter().map(|s| s.position().y).collect();
+        let z: Vec<f64> = states.iter().map(|s| s.position().z).collect();
+        let vx: Vec<f64> = states.iter().map(|s| s.velocity().x).collect();
+        let vy: Vec<f64> = states.iter().map(|s| s.velocity().y).collect();
+        let vz: Vec<f64> = states.iter().map(|s| s.velocity().z).collect();
+        let x = CubicSpline::new(t.clone(), x)?;
+        let y = CubicSpline::new(t.clone(), y)?;
+        let z = CubicSpline::new(t.clone(), z)?;
+        let vx = CubicSpline::new(t.clone(), vx)?;
+        let vy = CubicSpline::new(t.clone(), vy)?;
+        let vz = CubicSpline::new(t.clone(), vz)?;
+        Ok(Self {
+            t0,
+            t1,
+            dt_max,
+            t,
+            x,
+            y,
+            z,
+            vx,
+            vy,
+            vz,
+            fields: HashMap::default(),
+        })
+    }
+
+    fn time_delta(&self, epoch: BaseTime) -> Option<TimeDelta> {
+        let delta = epoch - self.t0;
+        if delta.is_negative() {
+            return None;
+        }
+        if delta > self.dt_max {
+            return None;
+        }
+        Some(delta)
+    }
+
+    pub fn time(&self, delta: TimeDelta) -> BaseTime {
+        self.t0 + delta
+    }
+
+    pub fn position(&self, delta: TimeDelta) -> DVec3 {
+        let t = delta.to_decimal_seconds();
+        DVec3::new(
+            self.x.interpolate(t),
+            self.y.interpolate(t),
+            self.z.interpolate(t),
+        )
+    }
+
+    pub fn velocity(&self, delta: TimeDelta) -> DVec3 {
+        let t = delta.to_decimal_seconds();
+        DVec3::new(
+            self.vx.interpolate(t),
+            self.vy.interpolate(t),
+            self.vz.interpolate(t),
+        )
+    }
+}
+
+impl BaseTrajectory for BaseCubicSplineTrajectory {
+    fn state_at_time(&self, time: BaseTime) -> Result<BaseState, LoxTrajectoryError> {
+        let dt = self
+            .time_delta(time)
+            .ok_or(LoxTrajectoryError::EpochOutOfRange(
+                self.t0.to_string(),
+                self.t1.to_string(),
+                time.to_string(),
+            ))?;
+        self.state_after_delta(dt)
+    }
+
+    fn state_after_delta(&self, delta: TimeDelta) -> Result<BaseState, LoxTrajectoryError> {
+        if delta.is_negative() || delta > self.dt_max {
+            return Err(LoxTrajectoryError::DeltaOutOfRange(
+                self.dt_max.to_decimal_seconds().to_string(),
+                delta.to_decimal_seconds().to_string(),
+            ));
+        }
+        let time = self.time(delta);
+        let position = self.position(delta);
+        let velocity = self.velocity(delta);
+        Ok((time, BaseCartesian::new(position, velocity)))
+    }
+
+    fn set_field(&mut self, field: &str, values: &[f64]) -> Result<(), LoxTrajectoryError> {
+        let t = self.t.clone();
+        let spline = CubicSpline::new(t, values.to_vec())?;
+        self.fields.insert(field.to_string(), spline);
+        Ok(())
+    }
+
+    fn field_at_time(&self, field: &str, time: BaseTime) -> Result<f64, LoxTrajectoryError> {
+        let dt = self
+            .time_delta(time)
+            .ok_or(LoxTrajectoryError::EpochOutOfRange(
+                self.t0.to_string(),
+                self.t1.to_string(),
+                time.to_string(),
+            ))?;
+        self.field_after_delta(field, dt)
+    }
+
+    fn field_after_delta(&self, field: &str, delta: TimeDelta) -> Result<f64, LoxTrajectoryError> {
+        if delta.is_negative() || delta > self.dt_max {
+            return Err(LoxTrajectoryError::DeltaOutOfRange(
+                self.dt_max.to_decimal_seconds().to_string(),
+                delta.to_decimal_seconds().to_string(),
+            ));
+        }
+        let spl = self
+            .fields
+            .get(field)
+            .ok_or(LoxTrajectoryError::FieldNotFound(field.to_owned()))?;
+        Ok(spl.interpolate(delta.to_decimal_seconds()))
+    }
+}

--- a/crates/lox-coords/src/two_body.rs
+++ b/crates/lox-coords/src/two_body.rs
@@ -6,13 +6,15 @@
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::f64::consts::TAU;
+
 use glam::DVec3;
 
 use lox_bodies::PointMass;
 use lox_time::time_scales::TimeScale;
 use lox_time::Time;
 
-use crate::base::{BaseCartesian, BaseKeplerian, BaseTwoBody};
+use crate::base::{BaseCartesian, BaseKeplerian, BaseState, BaseTwoBody};
 use crate::frames::{InertialFrame, ReferenceFrame};
 use crate::CoordinateSystem;
 
@@ -58,6 +60,16 @@ where
         }
     }
 
+    pub fn from_base(scale: T, origin: O, frame: F, (time, state): BaseState) -> Self {
+        let time = Time::from_base_time(scale, time);
+        Self {
+            time,
+            state,
+            origin,
+            frame,
+        }
+    }
+
     pub fn time(&self) -> Time<T> {
         self.time
     }
@@ -70,8 +82,8 @@ where
         self.state.velocity()
     }
 
-    pub fn base(&self) -> BaseCartesian {
-        self.state
+    pub fn base(&self) -> BaseState {
+        (self.time.base_time(), self.state)
     }
 }
 
@@ -203,6 +215,12 @@ where
 
     pub fn true_anomaly(&self) -> f64 {
         self.state.true_anomaly()
+    }
+
+    pub fn orbital_period(&self) -> f64 {
+        let mu = self.origin().gravitational_parameter();
+        let a = self.semi_major_axis();
+        TAU * (a.powi(3) / mu).sqrt()
     }
 }
 

--- a/crates/lox-coords/src/two_body.rs
+++ b/crates/lox-coords/src/two_body.rs
@@ -69,6 +69,10 @@ where
     pub fn velocity(&self) -> DVec3 {
         self.state.velocity()
     }
+
+    pub fn base(&self) -> BaseCartesian {
+        self.state
+    }
 }
 
 impl<T, O, F> TwoBody<T, O, F> for Cartesian<T, O, F>

--- a/crates/lox-coords/src/two_body.rs
+++ b/crates/lox-coords/src/two_body.rs
@@ -67,7 +67,7 @@ where
     }
 
     pub fn velocity(&self) -> DVec3 {
-        self.state.position()
+        self.state.velocity()
     }
 }
 

--- a/crates/lox-propagators/Cargo.toml
+++ b/crates/lox-propagators/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lox-propagators"
+version = "0.1.0"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+lox-bodies.workspace = true
+lox-coords.workspace = true
+lox-time.workspace = true
+
+float_eq.workspace = true
+libm.workspace = true
+thiserror.workspace = true

--- a/crates/lox-propagators/src/base.rs
+++ b/crates/lox-propagators/src/base.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024. Helge Eichhorn and the LOX contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use lox_coords::base::{BaseState, BaseTwoBody};
+use lox_coords::trajectories::base::BaseTrajectory;
+use lox_time::base_time::BaseTime;
+use lox_time::deltas::TimeDelta;
+
+pub trait BasePropagator {
+    type Error;
+    type Output: BaseTrajectory;
+
+    // Takes a single `TimeDelta` and returns a single new state
+    fn state_from_delta(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        delta: TimeDelta,
+    ) -> Result<BaseState, Self::Error>;
+    // Takes a single `BaseTime` and returns a single new state
+    fn state_from_time(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        time: BaseTime,
+    ) -> Result<BaseState, Self::Error>;
+    // Takes a slice of `TimeDelta` and returns a `BaseTrajectory` implementation
+    fn trajectory_from_deltas(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        deltas: &[TimeDelta],
+    ) -> Result<Self::Output, Self::Error>;
+    // Takes a slice `BaseTime`` and returns a `BaseTrajectory` implementation
+    fn trajectory_from_times(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        times: &[BaseTime],
+    ) -> Result<Self::Output, Self::Error>;
+}

--- a/crates/lox-propagators/src/lib.rs
+++ b/crates/lox-propagators/src/lib.rs
@@ -1,0 +1,45 @@
+use lox_bodies::PointMass;
+use lox_coords::frames::ReferenceFrame;
+use lox_coords::trajectories::Trajectory;
+use lox_coords::two_body::Cartesian;
+use lox_time::deltas::TimeDelta;
+use lox_time::time_scales::TimeScale;
+use lox_time::Time;
+
+pub mod base;
+pub mod semi_analytical;
+mod stumpff;
+
+pub trait Propagator<T, O, F>
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    type Error;
+
+    // Takes a single `TimeDelta` and returns a single new state
+    fn state_from_delta(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        delta: TimeDelta,
+    ) -> Result<Cartesian<T, O, F>, Self::Error>;
+    // Takes a single `BaseTime` and returns a single new state
+    fn state_from_time(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        time: Time<T>,
+    ) -> Result<Cartesian<T, O, F>, Self::Error>;
+    // Takes a slice of `TimeDelta` and returns a `BaseTrajectory` implementation
+    fn trajectory_from_deltas(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        deltas: &[TimeDelta],
+    ) -> Result<impl Trajectory<T, O, F>, Self::Error>;
+    // Takes a slice `BaseTime`` and returns a `BaseTrajectory` implementation
+    fn trajectory_from_times(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        times: &[Time<T>],
+    ) -> Result<impl Trajectory<T, O, F>, Self::Error>;
+}

--- a/crates/lox-propagators/src/semi_analytical.rs
+++ b/crates/lox-propagators/src/semi_analytical.rs
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2024. Helge Eichhorn and the LOX contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use thiserror::Error;
+
+use lox_bodies::{Earth, PointMass};
+use lox_coords::base::{BaseCartesian, BaseState, BaseTwoBody};
+use lox_coords::frames::ReferenceFrame;
+use lox_coords::trajectories::base::BaseCubicSplineTrajectory;
+use lox_coords::trajectories::{CubicSplineTrajectory, LoxTrajectoryError, Trajectory};
+use lox_coords::two_body::Cartesian;
+use lox_coords::CoordinateSystem;
+use lox_time::base_time::BaseTime;
+use lox_time::deltas::TimeDelta;
+use lox_time::time_scales::TimeScale;
+
+use crate::{base::BasePropagator, stumpff, Propagator};
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum LoxValladoError {
+    #[error("did not converge")]
+    NotConverged,
+    #[error(transparent)]
+    TrajectoryError(#[from] LoxTrajectoryError),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct BaseVallado {
+    pub max_iter: i32,
+    pub gravitational_parameter: f64,
+}
+
+impl Default for BaseVallado {
+    fn default() -> Self {
+        Self {
+            max_iter: 300,
+            gravitational_parameter: Earth.gravitational_parameter(),
+        }
+    }
+}
+
+impl BasePropagator for BaseVallado {
+    type Error = LoxValladoError;
+    type Output = BaseCubicSplineTrajectory;
+
+    fn state_from_delta(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        delta: TimeDelta,
+    ) -> Result<BaseState, Self::Error> {
+        let (t0, initial_state) = initial_state;
+        let mu = self.gravitational_parameter;
+        let initial_state = initial_state.to_cartesian_state(mu);
+        let dt = delta.to_decimal_seconds();
+        let sqrt_mu = mu.sqrt();
+        let p0 = initial_state.position();
+        let v0 = initial_state.velocity();
+        let dot_p0v0 = p0.dot(v0);
+        let norm_p0 = p0.length();
+        let alpha = -v0.dot(v0) / mu + 2.0 / norm_p0;
+
+        let mut xi_new = if alpha > 0.0 {
+            sqrt_mu * dt * alpha
+        } else if alpha < 0.0 {
+            dt.signum()
+                * (-1.0 / alpha).powf(0.5)
+                * (-2.0 * mu * alpha * dt
+                    / (dot_p0v0 + dt.signum() * (-mu / alpha).sqrt() * (1.0 - norm_p0 * alpha)))
+                    .ln()
+        } else {
+            sqrt_mu * dt / norm_p0
+        };
+
+        let mut count = 0;
+        while count < self.max_iter {
+            let xi = xi_new;
+            let psi = xi * xi * alpha;
+            let c2_psi = stumpff::c2(psi);
+            let c3_psi = stumpff::c3(psi);
+            let norm_r = xi.powi(2) * c2_psi
+                + dot_p0v0 / sqrt_mu * xi * (1.0 - psi * c3_psi)
+                + norm_p0 * (1.0 - psi * c2_psi);
+            let delta_xi = (sqrt_mu * dt
+                - xi.powi(3) * c3_psi
+                - dot_p0v0 / sqrt_mu * xi.powi(2) * c2_psi
+                - norm_p0 * xi * (1.0 - psi * c3_psi))
+                / norm_r;
+            xi_new = xi + delta_xi;
+            if (xi_new - xi).abs() < 1e-7 {
+                let f = 1.0 - xi.powi(2) / norm_p0 * c2_psi;
+                let g = dt - xi.powi(3) / sqrt_mu * c3_psi;
+
+                let gdot = 1.0 - xi.powi(2) / norm_r * c2_psi;
+                let fdot = sqrt_mu / (norm_r * norm_p0) * xi * (psi * c3_psi - 1.0);
+
+                debug_assert!((f * gdot - fdot * g - 1.0).abs() < 1e-5);
+
+                let p = f * p0 + g * v0;
+                let v = fdot * p0 + gdot * v0;
+
+                let t = t0 + delta;
+                let final_state = BaseCartesian::new(p, v);
+                return Ok((t, final_state));
+            } else {
+                count += 1
+            }
+        }
+        Err(LoxValladoError::NotConverged)
+    }
+
+    fn state_from_time(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        time: BaseTime,
+    ) -> Result<BaseState, Self::Error> {
+        let (t0, _) = initial_state;
+        let delta = t0 - time;
+        self.state_from_delta(initial_state, delta)
+    }
+
+    fn trajectory_from_deltas(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        deltas: &[TimeDelta],
+    ) -> Result<Self::Output, Self::Error> {
+        let (t0, s) = initial_state;
+        let mut s = (t0, s.to_cartesian_state(self.gravitational_parameter));
+        let mut states: Vec<BaseState> = vec![s];
+        for &delta in deltas {
+            s = self.state_from_delta(s, delta)?;
+            states.push(s);
+        }
+        let trajectory = BaseCubicSplineTrajectory::new(&states)?;
+        Ok(trajectory)
+    }
+
+    fn trajectory_from_times(
+        &self,
+        initial_state: (BaseTime, impl BaseTwoBody),
+        times: &[BaseTime],
+    ) -> Result<Self::Output, Self::Error> {
+        let (t0, s) = initial_state;
+        let deltas: Vec<TimeDelta> = times.iter().map(|&t| t - t0).collect();
+        let mut s = (t0, s.to_cartesian_state(self.gravitational_parameter));
+        let mut states: Vec<BaseState> = vec![s];
+        for delta in deltas {
+            s = self.state_from_delta(s, delta)?;
+            states.push(s);
+        }
+        let trajectory = BaseCubicSplineTrajectory::new(&states)?;
+        Ok(trajectory)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Vallado {
+    pub max_iter: i32,
+}
+
+impl Vallado {
+    fn to_base(self, origin: impl PointMass) -> BaseVallado {
+        let gravitational_parameter = origin.gravitational_parameter();
+        BaseVallado {
+            max_iter: self.max_iter,
+            gravitational_parameter,
+        }
+    }
+}
+
+impl Default for Vallado {
+    fn default() -> Self {
+        Self { max_iter: 300 }
+    }
+}
+
+impl<T, O, F> Propagator<T, O, F> for Vallado
+where
+    T: TimeScale + Copy,
+    O: PointMass + Copy,
+    F: ReferenceFrame + Copy,
+{
+    type Error = LoxValladoError;
+
+    fn state_from_delta(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        delta: TimeDelta,
+    ) -> Result<Cartesian<T, O, F>, Self::Error> {
+        let base = self.to_base(initial_state.origin());
+        let final_state = base.state_from_delta(initial_state.base(), delta)?;
+        Ok(Cartesian::from_base(
+            initial_state.time().scale(),
+            initial_state.origin(),
+            initial_state.reference_frame(),
+            final_state,
+        ))
+    }
+
+    fn state_from_time(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        time: lox_time::Time<T>,
+    ) -> Result<Cartesian<T, O, F>, Self::Error> {
+        let delta = time - initial_state.time();
+        self.state_from_delta(initial_state, delta)
+    }
+
+    fn trajectory_from_deltas(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        deltas: &[TimeDelta],
+    ) -> Result<impl Trajectory<T, O, F>, Self::Error> {
+        let base = self.to_base(initial_state.origin());
+        let trajectory: BaseCubicSplineTrajectory =
+            base.trajectory_from_deltas(initial_state.base(), deltas)?;
+        Ok(CubicSplineTrajectory::from_base(
+            initial_state.time().scale(),
+            initial_state.origin(),
+            initial_state.reference_frame(),
+            trajectory,
+        ))
+    }
+
+    fn trajectory_from_times(
+        &self,
+        initial_state: Cartesian<T, O, F>,
+        times: &[lox_time::Time<T>],
+    ) -> Result<impl Trajectory<T, O, F>, Self::Error> {
+        let base = self.to_base(initial_state.origin());
+        let times: Vec<BaseTime> = times.iter().map(|t| t.base_time()).collect();
+        let trajectory: BaseCubicSplineTrajectory =
+            base.trajectory_from_times(initial_state.base(), &times)?;
+        Ok(CubicSplineTrajectory::from_base(
+            initial_state.time().scale(),
+            initial_state.origin(),
+            initial_state.reference_frame(),
+            trajectory,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use float_eq::assert_float_eq;
+
+    use lox_coords::frames::Icrf;
+    use lox_coords::two_body::{Keplerian, TwoBody};
+    use lox_time::calendar_dates::Date;
+    use lox_time::subsecond::Subsecond;
+    use lox_time::time_scales::TDB;
+    use lox_time::utc::UTC;
+    use lox_time::Time;
+
+    use super::*;
+
+    #[test]
+    fn test_vallado_propagator() {
+        let date = Date::new(2023, 3, 25).expect("Date should be valid");
+        let utc = UTC::new(21, 8, 0, Subsecond::new(0.0).unwrap()).expect("Time should be valid");
+        let time = Time::from_date_and_utc_timestamp(TDB, date, utc);
+        let semi_major = 24464560.0e-3;
+        let eccentricity = 0.7311;
+        let inclination = 0.122138;
+        let ascending_node = 1.00681;
+        let periapsis_arg = 3.10686;
+        let true_anomaly = 0.44369564302687126;
+
+        let k0 = Keplerian::new(
+            time,
+            Earth,
+            Icrf,
+            semi_major,
+            eccentricity,
+            inclination,
+            ascending_node,
+            periapsis_arg,
+            true_anomaly,
+        );
+        let s0 = k0.to_cartesian();
+        let dt = TimeDelta::from_decimal_seconds(k0.orbital_period()).expect("should be valid");
+        let t1 = time + dt;
+
+        let propagator = Vallado::default();
+        let s1 = propagator
+            .state_from_time(s0, t1)
+            .expect("propagator should converge");
+
+        let k1 = s1.to_keplerian();
+        assert_float_eq!(k1.semi_major_axis(), semi_major, rel <= 1e-8);
+        assert_float_eq!(k1.eccentricity(), eccentricity, rel <= 1e-8);
+        assert_float_eq!(k1.inclination(), inclination, rel <= 1e-8);
+        assert_float_eq!(k1.ascending_node(), ascending_node, rel <= 1e-8);
+        assert_float_eq!(k1.periapsis_argument(), periapsis_arg, rel <= 1e-8);
+        assert_float_eq!(k1.true_anomaly(), true_anomaly, rel <= 1e-8);
+    }
+}

--- a/crates/lox-propagators/src/stumpff.rs
+++ b/crates/lox-propagators/src/stumpff.rs
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024. Helge Eichhorn and the LOX contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use libm::tgamma;
+
+pub fn c2(psi: f64) -> f64 {
+    let eps = 1.0;
+    if psi > eps {
+        (1.0 - psi.sqrt().cos()) / psi
+    } else if psi < -eps {
+        ((-psi).sqrt().cosh() - 1.0) / (-psi)
+    } else {
+        let mut res = 1.0 / 2.0;
+        let mut delta = (-psi) / tgamma(2.0 + 2.0 + 1.0);
+        let mut k = 1;
+        while res + delta != res {
+            res += delta;
+            k += 1;
+            delta = (-psi).powi(k) / tgamma(2.0 * k as f64 + 2.0 + 1.0)
+        }
+        res
+    }
+}
+
+pub fn c3(psi: f64) -> f64 {
+    let eps = 1.0;
+    if psi > eps {
+        (psi.sqrt() - psi.sqrt().sin()) / (psi * psi.sqrt())
+    } else if psi < -eps {
+        ((-psi).sqrt().sinh() - ((-psi).sqrt())) / (-psi * (-psi).sqrt())
+    } else {
+        let mut res = 1.0 / 6.0;
+        let mut delta = -psi / tgamma(2.0 + 3.0 + 1.0);
+        let mut k = 1;
+        while res + delta != res {
+            res += delta;
+            k += 1;
+            delta = (-psi).powi(k) / tgamma(2.0 * k as f64 + 3.0 + 1.0)
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use float_eq::assert_float_eq;
+
+    use super::*;
+
+    #[test]
+    fn stumpff_near_zero() {
+        let psi = 0.5f64;
+        let expected_c2 = (1.0 - psi.powf(0.5).cos()) / psi;
+        let expected_c3 = (psi.powf(0.5) - psi.powf(0.5).sin()) / psi.powf(1.5);
+
+        assert_float_eq!(c2(psi), expected_c2, rel <= 1e-8);
+        assert_float_eq!(c3(psi), expected_c3, rel <= 1e-8);
+    }
+
+    #[test]
+    fn test_stumpff_functions_above_zero() {
+        let psi = 3.0f64;
+        let expected_c2 = (1.0 - psi.powf(0.5).cos()) / psi;
+        let expected_c3 = (psi.powf(0.5) - psi.powf(0.5).sin()) / psi.powf(1.5);
+
+        assert_float_eq!(c2(psi), expected_c2, rel <= 1e-10);
+        assert_float_eq!(c3(psi), expected_c3, rel <= 1e-10);
+    }
+
+    #[test]
+    fn test_stumpff_functions_under_zero() {
+        let psi = -3.0f64;
+        let expected_c2 = ((-psi).powf(0.5).cosh() - 1.0) / (-psi);
+        let expected_c3 = ((-psi).powf(0.5).sinh() - (-psi).powf(0.5)) / (-psi).powf(1.5);
+
+        assert_float_eq!(c2(psi), expected_c2, rel <= 1e-10);
+        assert_float_eq!(c3(psi), expected_c3, rel <= 1e-10);
+    }
+}

--- a/crates/lox-space/benches/time_delta.rs
+++ b/crates/lox-space/benches/time_delta.rs
@@ -15,5 +15,5 @@ fn main() {
 
 #[divan::bench]
 fn from_f64_seconds() {
-    TimeDelta::from_decimal_seconds(divan::black_box(60.3));
+    TimeDelta::from_decimal_seconds(divan::black_box(60.3)).unwrap();
 }

--- a/crates/lox-space/src/time.rs
+++ b/crates/lox-space/src/time.rs
@@ -338,7 +338,7 @@ mod tests {
         let actual = PySubsecond::new(0.123456789123456)
             .expect("subsecond should be valid")
             .__str__();
-        let expected = "123.456.789.123.456";
+        let expected = "123";
         assert_eq!(expected, actual);
     }
 }

--- a/crates/lox-time/src/deltas.rs
+++ b/crates/lox-time/src/deltas.rs
@@ -8,6 +8,7 @@
 
 use crate::subsecond::Subsecond;
 use num::ToPrimitive;
+use std::cmp::Ordering;
 use std::ops::{Add, Neg, Sub};
 
 use crate::constants::f64;
@@ -241,6 +242,21 @@ impl Sub for TimeDelta {
         Self {
             seconds: diff_seconds,
             subsecond: Subsecond(diff_subsecond),
+        }
+    }
+}
+
+impl PartialOrd for TimeDelta {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TimeDelta {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.seconds.cmp(&other.seconds) {
+            Ordering::Equal => self.subsecond.0.partial_cmp(&other.subsecond.0).unwrap(),
+            ordering => ordering,
         }
     }
 }

--- a/crates/lox-time/src/lib.rs
+++ b/crates/lox-time/src/lib.rs
@@ -112,6 +112,11 @@ impl<T: TimeScale + Copy> Time<T> {
         Self::from_epoch(scale, Epoch::J2000)
     }
 
+    /// Returns the timescale
+    pub fn scale(&self) -> T {
+        self.scale
+    }
+
     /// The underlying base timestamp.
     pub fn base_time(&self) -> BaseTime {
         self.timestamp

--- a/crates/lox-time/src/subsecond.rs
+++ b/crates/lox-time/src/subsecond.rs
@@ -65,15 +65,7 @@ impl Subsecond {
 
 impl Display for Subsecond {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{:03}.{:03}.{:03}.{:03}.{:03}",
-            self.millisecond(),
-            self.microsecond(),
-            self.nanosecond(),
-            self.picosecond(),
-            self.femtosecond()
-        )
+        write!(f, "{:03}", self.millisecond(),)
     }
 }
 
@@ -149,7 +141,7 @@ mod tests {
     #[test]
     fn test_subsecond_display() {
         let subsecond = Subsecond(0.123456789876543);
-        assert_eq!("123.456.789.876.543", subsecond.to_string());
+        assert_eq!("123", subsecond.to_string());
     }
 
     #[test]

--- a/crates/lox-time/src/utc.rs
+++ b/crates/lox-time/src/utc.rs
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_time_display() {
-        assert_eq!("12:34:56.789.123.456.789.123 UTC", TIME.to_string());
+        assert_eq!("12:34:56.789 UTC", TIME.to_string());
     }
 
     #[test]


### PR DESCRIPTION
Based on #82.
Supersedes #57.

- Split `Trajectory` into concrete base type and generic wrapper
- Add Vallado two-body propagator for concrete and generic states

## To Do

- [ ] Tests