### PR TITLE
Qualify into trait

### DIFF
--- a/crates/lox-time/src/subsecond.rs
+++ b/crates/lox-time/src/subsecond.rs
@@ -189,7 +189,8 @@ mod tests {
     #[test]
     fn test_subsecond_into_f64() {
         let subsecond = Subsecond(0.0);
-        assert_eq!(0.0, subsecond.into());
+        let as_f64: f64 = subsecond.into();
+        assert_eq!(0.0, as_f64);
     }
 
     #[test]


### PR DESCRIPTION
I am not sure if this is the right way forward, but it's a temporary way to fix master:

```
error[E0283]: type annotations needed
   --> crates/lox-time/src/subsecond.rs:192:35
    |
192 |         assert_eq!(0.0, subsecond.into());
    |                                   ^^^^
    |
note: multiple `impl`s satisfying `subsecond::Subsecond: Into<_>` found
   --> crates/lox-time/src/subsecond.rs:115:1
    |
115 | impl Into<f64> for Subsecond {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and another `impl` found in the `core` crate:
            - impl<T, U> Into<U> for T
              where U: From<T>;
help: try using a fully qualified path to specify the expected types
    |
192 |         assert_eq!(0.0, <subsecond::Subsecond as Into<T>>::into(subsecond));
    |                         ++++++++++++++++++++++++++++++++++++++++         ~

error[E0283]: type annotations needed
   --> crates/lox-time/src/subsecond.rs:192:35
    |
192 |         assert_eq!(0.0, subsecond.into());
    |         --------------------------^^^^--- type must be known at this point
    |
    = note: multiple `impl`s satisfying `f64: PartialEq<_>` found in the following crates: `core`, `serde_json`:
            - impl PartialEq<serde_json::value::Value> for f64;
            - impl<host> PartialEq for f64
              where the constant `host` has type `bool`;
help: try using a fully qualified path to specify the expected types
    |
192 |         assert_eq!(0.0, <subsecond::Subsecond as Into<T>>::into(subsecond));
    |                         ++++++++++++++++++++++++++++++++++++++++         ~
```