### PR TITLE
Add support for ddd KVN dates

### DIFF
--- a/crates/lox-io/src/ndm.rs
+++ b/crates/lox-io/src/ndm.rs
@@ -31,8 +31,7 @@
 //! covariance matrix section. But this will cause the comments for the
 //! following section, the maneuver parameters list, to be discarded.
 //!
-//! The KVN parsing currently does not support user-defined fields and ddd date
-//! format types.
+//! The KVN parsing currently does not support user-defined fields.
 //!
 //! Check the respective submodules for more information.
 


### PR DESCRIPTION
I would have preferred to import `lox-time` and convert with `from_day_of_year`, but `lox-time` already depends on `lox-io` so it would be a circular dependency. 

A more involved solution would be to break up `lox-io` on smaller crates and only have the NDM stuff depend on `lox-time`. 

Open to suggestions

Closes #120 

1.5

