### PR TITLE
feat(python): add Python wrapper for Modified Equinoctial Elements

### DIFF
--- a/crates/lox-space/docs/states.md
+++ b/crates/lox-space/docs/states.md
@@ -100,6 +100,12 @@ interpolated = trajectory.interpolate(t + lox.TimeDelta(100))
 
 ---
 
+::: lox_space.ModifiedEquinoctial
+    options:
+      show_source: false
+
+---
+
 ::: lox_space.Trajectory
     options:
       show_source: false

--- a/crates/lox-space/src/orbits/python.rs
+++ b/crates/lox-space/src/orbits/python.rs
@@ -514,6 +514,24 @@ impl PyCartesian {
         ))
     }
 
+    /// Convert this Cartesian state to modified equinoctial elements.
+    ///
+    /// Returns:
+    ///     Modified equinoctial elements representing this orbit.
+    fn to_modified_equinoctial(&self) -> PyResult<PyModifiedEquinoctial> {
+        let mu = self
+            .0
+            .try_gravitational_parameter()
+            .map_err(PyUndefinedOriginPropertyError)?;
+        let mee = self.0.state().to_modified_equinoctial(mu).unwrap();
+        Ok(PyModifiedEquinoctial {
+            state: mee,
+            time: PyTime(self.0.time()),
+            origin: PyOrigin(self.0.origin()),
+            frame: PyFrame(self.0.reference_frame()),
+        })
+    }
+
     fn __repr__(&self) -> String {
         let pos = self.0.position();
         let vel = self.0.velocity();
@@ -955,6 +973,20 @@ impl PyKeplerian {
         ))
     }
 
+    /// Convert these Keplerian elements to modified equinoctial elements.
+    ///
+    /// Returns:
+    ///     Modified equinoctial elements representing this orbit.
+    fn to_modified_equinoctial(&self) -> PyResult<PyModifiedEquinoctial> {
+        let mee = self.0.state().to_modified_equinoctial();
+        Ok(PyModifiedEquinoctial {
+            state: mee,
+            time: PyTime(self.0.time()),
+            origin: PyOrigin(self.0.origin()),
+            frame: PyFrame(self.0.reference_frame()),
+        })
+    }
+
     /// Return the orbital period.
     ///
     /// Returns:
@@ -978,6 +1010,194 @@ impl PyKeplerian {
             self.true_anomaly().__repr__(),
             self.origin().__repr__(),
         )
+    }
+}
+
+/// Represents an orbit using Modified Equinoctial Elements (MEE).
+///
+/// Modified Equinoctial Elements are non-singular for circular (e = 0) and equatorial (i = 0)
+/// orbits. They also fully support parabolic (e = 1) orbits.
+///
+/// Args:
+///     time: Epoch of the elements.
+///     p: Semi-latus rectum (semi-parameter) as Distance.
+///     f: Eccentricity vector component 1.
+///     g: Eccentricity vector component 2.
+///     h: Node vector component 1.
+///     k: Node vector component 2.
+///     l: True longitude as Angle.
+///     origin: Central body (default: Earth).
+///     frame: Reference frame (default: ICRF).
+#[pyclass(
+    name = "ModifiedEquinoctial",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
+#[derive(Debug, Clone)]
+pub struct PyModifiedEquinoctial {
+    pub(crate) state: lox_core::elements::modified_equinoctial::ModifiedEquinoctial,
+    pub(crate) time: PyTime,
+    pub(crate) origin: PyOrigin,
+    pub(crate) frame: PyFrame,
+}
+
+#[pymethods]
+impl PyModifiedEquinoctial {
+    #[new]
+    #[pyo3(signature = (
+        time,
+        p,
+        f,
+        g,
+        h,
+        k,
+        l,
+        origin=None,
+        frame=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        time: PyTime,
+        p: PyDistance,
+        f: f64,
+        g: f64,
+        h: f64,
+        k: f64,
+        l: PyAngle,
+        origin: Option<&Bound<'_, PyAny>>,
+        frame: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Self> {
+        let origin = origin
+            .map(PyOrigin::try_from)
+            .transpose()?
+            .unwrap_or(PyOrigin(lox_bodies::Earth.into()));
+        let frame = frame
+            .map(PyFrame::try_from)
+            .transpose()?
+            .unwrap_or(PyFrame(DynFrame::Icrf));
+
+        let state = lox_core::elements::modified_equinoctial::ModifiedEquinoctial::new(
+            p.0, f, g, h, k, l.0,
+        );
+
+        Ok(Self {
+            state,
+            time,
+            origin,
+            frame,
+        })
+    }
+
+    /// Return the epoch of this orbit.
+    fn time(&self) -> PyTime {
+        self.time.clone()
+    }
+
+    /// Return the semi-latus rectum (semi-parameter) `p`.
+    fn p(&self) -> PyDistance {
+        PyDistance(self.state.p())
+    }
+
+    /// Return `f` = e·cos(ω + Ω).
+    fn f(&self) -> f64 {
+        self.state.f()
+    }
+
+    /// Return `g` = e·sin(ω + Ω).
+    fn g(&self) -> f64 {
+        self.state.g()
+    }
+
+    /// Return `h` = tan(i/2)·cos(Ω).
+    fn h(&self) -> f64 {
+        self.state.h()
+    }
+
+    /// Return `k` = tan(i/2)·sin(Ω).
+    fn k(&self) -> f64 {
+        self.state.k()
+    }
+
+    /// Return the true longitude `l` = Ω + ω + ν.
+    fn l(&self) -> PyAngle {
+        PyAngle(self.state.l())
+    }
+
+    /// Return the orbital eccentricity.
+    fn eccentricity(&self) -> f64 {
+        self.state.eccentricity()
+    }
+
+    /// Return the orbital inclination.
+    fn inclination(&self) -> PyAngle {
+        PyAngle(Angle::radians(self.state.inclination()))
+    }
+
+    /// Return the central body (origin) of this orbit.
+    fn origin(&self) -> PyOrigin {
+        self.origin.clone()
+    }
+
+    /// Return the reference frame.
+    fn frame(&self) -> PyFrame {
+        self.frame.clone()
+    }
+
+    /// Convert these modified equinoctial elements to a Cartesian state.
+    ///
+    /// Returns:
+    ///     Cartesian state representing this orbit.
+    fn to_cartesian(&self) -> PyResult<PyCartesian> {
+        let mu = self
+            .origin
+            .0
+            .try_gravitational_parameter()
+            .map_err(PyUndefinedOriginPropertyError)?;
+        let cart = self.state.to_cartesian(mu).unwrap();
+        Ok(PyCartesian(crate::orbits::DynCartesianOrbit::from_state(
+            cart,
+            self.time.0,
+            self.origin.0,
+            self.frame.0,
+        )))
+    }
+
+    /// Convert these modified equinoctial elements to Keplerian orbital elements.
+    ///
+    /// Returns:
+    ///     Keplerian elements representing this orbit.
+    fn to_keplerian(&self) -> PyResult<PyKeplerian> {
+        let kep = self.state.to_keplerian().map_err(
+            |e: lox_core::elements::modified_equinoctial::ModifiedEquinoctialError| {
+                PyValueError::new_err(e.to_string())
+            },
+        )?;
+        Ok(PyKeplerian(crate::orbits::DynKeplerianOrbit::from_state(
+            kep,
+            self.time.0,
+            self.origin.0,
+            self.frame.0,
+        )))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ModifiedEquinoctial({}, {}, {}, {}, {}, {}, {}, origin={}, frame={})",
+            self.time().__repr__(),
+            self.p().__repr__(),
+            repr_f64(self.f()),
+            repr_f64(self.g()),
+            repr_f64(self.h()),
+            repr_f64(self.k()),
+            self.l().__repr__(),
+            self.origin().__repr__(),
+            self.frame().__repr__(),
+        )
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
     }
 }
 

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -25,8 +25,9 @@ use crate::itur::python::register_itur_functions;
 use crate::math::python::PySeries;
 use crate::orbits::python::{
     PyCartesian, PyEvent, PyGroundLocation, PyGroundPropagator, PyInterval, PyJ2Propagator,
-    PyJ4Propagator, PyKeplerian, PyNumericalPropagator, PySgp4, PyTle, PyTrajectory, PyVallado,
-    find_events, find_windows, py_complement_intervals, py_intersect_intervals, py_union_intervals,
+    PyJ4Propagator, PyKeplerian, PyModifiedEquinoctial, PyNumericalPropagator, PySgp4, PyTle,
+    PyTrajectory, PyVallado, find_events, find_windows, py_complement_intervals,
+    py_intersect_intervals, py_union_intervals,
 };
 use crate::time::python::{
     deltas::{NonFiniteTimeDeltaError, PyTimeDelta},
@@ -123,6 +124,7 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyJ4Propagator>()?;
     m.add_class::<PyNumericalPropagator>()?;
     m.add_class::<PyKeplerian>()?;
+    m.add_class::<PyModifiedEquinoctial>()?;
     m.add_class::<PySgp4>()?;
     m.add_class::<PyTle>()?;
     m.add_class::<PyTrajectory>()?;

--- a/crates/lox-space/tests/test_states.py
+++ b/crates/lox-space/tests/test_states.py
@@ -319,3 +319,119 @@ def test_circular_both_size_raises():
             semi_major_axis=7178.0 * lox.km,
             altitude=800.0 * lox.km,
         )
+
+
+# --- ModifiedEquinoctial tests ---
+
+
+def test_modified_equinoctial_roundtrip():
+    """Test ModifiedEquinoctial construction and properties."""
+    time = lox.UTC(2024, 1, 1).to_scale("TDB")
+    # Circular equatorial orbit (~621.86 km altitude)
+    mee = lox.ModifiedEquinoctial(
+        time,
+        p=7000.0 * lox.km,
+        f=0.0,
+        g=0.0,
+        h=0.0,
+        k=0.0,
+        l=90.0 * lox.deg,
+        origin="Earth",
+        frame="ICRF",
+    )
+    
+    assert mee.p().to_kilometers() == pytest.approx(7000.0)
+    assert mee.f() == pytest.approx(0.0)
+    assert mee.g() == pytest.approx(0.0)
+    assert mee.h() == pytest.approx(0.0)
+    assert mee.k() == pytest.approx(0.0)
+    assert mee.l().to_degrees() == pytest.approx(90.0)
+    assert mee.eccentricity() == pytest.approx(0.0)
+    assert mee.inclination().to_degrees() == pytest.approx(0.0)
+    assert mee.origin().name() == "Earth"
+    assert repr(mee.frame()) == 'Frame("ICRF")'
+    assert repr(mee).startswith("ModifiedEquinoctial(")
+    assert str(mee) == repr(mee)
+
+    # Convert to Cartesian
+    cart = mee.to_cartesian()
+    # For circular equatorial orbit, position should be at y axis, velocity at -x axis
+    pos = cart.position()
+    vel = cart.velocity()
+    npt.assert_allclose(pos, [0.0, 7000e3, 0.0], atol=1e-5)
+
+    # Convert back to MEE
+    mee2 = cart.to_modified_equinoctial()
+    assert mee2.p().to_kilometers() == pytest.approx(mee.p().to_kilometers())
+    assert mee2.f() == pytest.approx(mee.f())
+    assert mee2.g() == pytest.approx(mee.g())
+    assert mee2.h() == pytest.approx(mee.h())
+    assert mee2.k() == pytest.approx(mee.k())
+    assert mee2.l().to_degrees() == pytest.approx(mee.l().to_degrees())
+
+def test_modified_equinoctial_to_keplerian():
+    """Test conversion to Keplerian elements."""
+    time = lox.UTC(2024, 1, 1).to_scale("TDB")
+    mee = lox.ModifiedEquinoctial(
+        time,
+        p=7178.0 * lox.km,
+        f=0.001,
+        g=0.0,
+        h=0.0,
+        k=0.0,
+        l=0.0 * lox.deg,
+    )
+    kep = mee.to_keplerian()
+    
+    # sma = p / (1 - e^2)
+    e = mee.eccentricity()
+    sma = mee.p().to_meters() / (1.0 - e**2)
+    assert kep.semi_major_axis().to_meters() == pytest.approx(sma)
+    assert kep.eccentricity() == pytest.approx(0.001)
+    
+    # And convert back
+    mee_back = kep.to_modified_equinoctial()
+    assert mee_back.p().to_kilometers() == pytest.approx(mee.p().to_kilometers())
+    assert mee_back.f() == pytest.approx(mee.f())
+    assert mee_back.g() == pytest.approx(mee.g())
+
+def test_modified_equinoctial_errors():
+    """Test error handling in ModifiedEquinoctial conversions."""
+    time = lox.UTC(2024, 1, 1).to_scale("TDB")
+    
+    # Origin without gravitational parameter
+    mee_no_mu = lox.ModifiedEquinoctial(
+        time,
+        p=7000.0 * lox.km,
+        f=0.0,
+        g=0.0,
+        h=0.0,
+        k=0.0,
+        l=0.0 * lox.deg,
+        origin="Itokawa",
+    )
+    with pytest.raises(Exception, match="undefined property 'gravitational parameter'"):
+        mee_no_mu.to_cartesian()
+        
+    # Cartesian -> MEE with Itokawa origin
+    cart = lox.Cartesian(
+        time,
+        position=[7000e3, 0.0, 0.0],
+        velocity=[0.0, 7000.0, 0.0],
+        origin="Itokawa"
+    )
+    with pytest.raises(Exception, match="undefined property 'gravitational parameter'"):
+        cart.to_modified_equinoctial()
+
+    # Invalid shape for Keplerian conversion should fail
+    mee_invalid = lox.ModifiedEquinoctial(
+        time,
+        p=-7000.0 * lox.km,
+        f=0.5,
+        g=0.0,
+        h=0.0,
+        k=0.0,
+        l=0.0 * lox.deg,
+    )
+    with pytest.raises(ValueError, match="negative semi-major axis"):
+        mee_invalid.to_keplerian()

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -1115,6 +1115,9 @@ class Cartesian:
     def to_keplerian(self) -> Keplerian:
         """Convert this Cartesian state to Keplerian orbital elements."""
         ...
+    def to_modified_equinoctial(self) -> ModifiedEquinoctial:
+        """Convert this Cartesian state to modified equinoctial elements."""
+        ...
     def rotation_lvlh(self) -> np.ndarray:
         """Compute the rotation matrix from inertial to LVLH frame."""
         ...
@@ -1296,8 +1299,92 @@ class Keplerian:
     def to_cartesian(self) -> Cartesian:
         """Convert these Keplerian elements to a Cartesian state."""
         ...
+    def to_modified_equinoctial(self) -> ModifiedEquinoctial:
+        """Convert these Keplerian elements to modified equinoctial elements."""
+        ...
     def orbital_period(self) -> TimeDelta:
         """Return the orbital period."""
+        ...
+
+class ModifiedEquinoctial:
+    """Represents an orbit using Modified Equinoctial Elements (MEE).
+
+    Modified Equinoctial Elements are non-singular for circular (e = 0) and equatorial (i = 0)
+    orbits. They also fully support parabolic (e = 1) orbits.
+
+    Args:
+        time: Epoch of the elements.
+        p: Semi-latus rectum (semi-parameter) as Distance.
+        f: Eccentricity vector component 1.
+        g: Eccentricity vector component 2.
+        h: Node vector component 1.
+        k: Node vector component 2.
+        l: True longitude as Angle.
+        origin: Central body (default: Earth).
+        frame: Reference frame (default: ICRF).
+
+    Examples:
+        >>> t = lox.Time("TAI", 2024, 1, 1)
+        >>> mee = lox.ModifiedEquinoctial(
+        ...     t,
+        ...     p=7000.0 * lox.km,
+        ...     f=0.001,
+        ...     g=0.001,
+        ...     h=0.0,
+        ...     k=0.0,
+        ...     l=0.0 * lox.deg,
+        ... )
+    """
+    def __new__(
+        cls,
+        time: Time,
+        p: Distance,
+        f: float,
+        g: float,
+        h: float,
+        k: float,
+        l: Angle,
+        origin: str | int | Origin | None = None,
+        frame: str | Frame | None = None,
+    ) -> Self: ...
+    def time(self) -> Time:
+        """Return the epoch of this orbit."""
+        ...
+    def origin(self) -> Origin:
+        """Return the central body (origin) of this orbit."""
+        ...
+    def frame(self) -> Frame:
+        """Return the reference frame."""
+        ...
+    def p(self) -> Distance:
+        """Return the semi-latus rectum (semi-parameter) `p`."""
+        ...
+    def f(self) -> float:
+        """Return `f` = e·cos(ω + Ω)."""
+        ...
+    def g(self) -> float:
+        """Return `g` = e·sin(ω + Ω)."""
+        ...
+    def h(self) -> float:
+        """Return `h` = tan(i/2)·cos(Ω)."""
+        ...
+    def k(self) -> float:
+        """Return `k` = tan(i/2)·sin(Ω)."""
+        ...
+    def l(self) -> Angle:
+        """Return the true longitude `l` = Ω + ω + ν."""
+        ...
+    def eccentricity(self) -> float:
+        """Return the orbital eccentricity."""
+        ...
+    def inclination(self) -> Angle:
+        """Return the orbital inclination."""
+        ...
+    def to_cartesian(self) -> Cartesian:
+        """Convert these modified equinoctial elements to a Cartesian state."""
+        ...
+    def to_keplerian(self) -> Keplerian:
+        """Convert these modified equinoctial elements to Keplerian orbital elements."""
         ...
 
 class Trajectory:


### PR DESCRIPTION
Closes #390 

AI disclosure:
* There's an explicit entry for Python bindings in https://github.com/lox-space/lox/blob/83227e47aa816d0df3be82f24a0aae55b8a30c19/AGENTS.md#python-wrapper-checklist so this PR was completely generated by Gemini 3.1 Pro.
* That said, I went manually through every line to ensure consistency with the rest of the codebase. It's mostly boilerplate anyways :smiley: 