### PR TITLE
Implement streaming analysis results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "lox-frames",
  "lox-math",
  "lox-orbits",
+ "lox-stream",
  "lox-test-utils",
  "lox-time",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,10 +102,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -154,6 +218,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -562,6 +632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,8 +826,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -758,9 +839,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -989,6 +1072,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "i_float"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,10 +1245,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1073,6 +1364,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -1104,6 +1401,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1137,6 +1436,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1378,10 +1683,14 @@ name = "lox-stream"
 version = "0.1.0-alpha.1"
 dependencies = [
  "async-channel",
+ "axum",
  "futures",
  "futures-core",
  "rayon",
+ "reqwest",
+ "serde_json",
  "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -1415,6 +1724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1765,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1611,6 +1949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,6 +1973,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1762,6 +2115,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +2296,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2475,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2598,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sgp4"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spade"
 version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2741,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2256,13 +2813,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2274,6 +2861,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2307,6 +2917,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +3013,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +3049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2380,6 +3095,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2437,6 +3162,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +3184,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2515,6 +3282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -2703,6 +3479,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,6 +3521,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +486,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fast_polynomial"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,10 +562,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -535,6 +619,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -554,9 +644,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1279,6 +1373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lox-stream"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "async-channel",
+ "futures",
+ "futures-core",
+ "rayon",
+ "tokio",
+]
+
+[[package]]
 name = "lox-test-utils"
 version = "0.1.0-alpha.9"
 dependencies = [
@@ -1485,6 +1590,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "paste"
@@ -2137,6 +2248,27 @@ name = "thiserror-impl"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lox-ephem = { path = "crates/lox-ephem", version = "0.1.0-alpha.24" }
 lox-frames = { path = "crates/lox-frames", version = "0.1.0-alpha.20" }
 lox-io = { path = "crates/lox-io", version = "0.1.0-alpha.24" }
 lox-itur = { path = "crates/lox-itur", version = "0.1.0-alpha.5" }
+lox-stream = { path = "crates/lox-stream", version = "0.1.0-alpha.1" }
 lox-math = { path = "crates/lox-math", version = "0.1.0-alpha.23" }
 lox-odm = { path = "crates/lox-odm", version = "0.1.0-alpha.3" }
 lox-orbits = { path = "crates/lox-orbits", version = "0.1.0-alpha.39" }
@@ -37,12 +38,15 @@ lox-test-utils = { path = "crates/lox-test-utils", version = "0.1.0-alpha.9", de
 lox-time = { path = "crates/lox-time", version = "0.1.0-alpha.26" }
 lox-units = { path = "crates/lox-units", version = "0.1.0-alpha.15" }
 
+async-channel = "2.5"
 arrayvec = "0.7.6"
 chrono = "0.4.43"
 csv = "1.4.0"
 differential-equations = "0.5.2"
 divan = { package = "codspeed-divan-compat", version = "4.3.0" }
 fast_polynomial = { version = "0.3.0", default-features = false }
+futures = "0.3"
+futures-core = "0.3"
 geo = "0.29"
 geojson = "0.24"
 glam = { version = "0.30.9", default-features = false }
@@ -62,6 +66,7 @@ sgp4 = "2.3.0"
 sha2 = "0.10"
 tempfile = "3"
 thiserror = { version = "2.0.17", default-features = false }
+tokio = { version = "1", default-features = false }
 ureq = "3"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 zstd = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ lox-units = { path = "crates/lox-units", version = "0.1.0-alpha.15" }
 
 arrayvec = "0.7.6"
 async-channel = "2.5.0"
+axum = "0.8.9"
 chrono = "0.4.43"
 csv = "1.4.0"
 differential-equations = "0.5.2"
@@ -57,6 +58,7 @@ nom = { version = "8.0.0", default-features = false }
 numpy = "0.28.0"
 proptest = "1.9.0"
 pyo3 = "0.28.2"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 quick-xml = { version = "0.38.3", features = ["serde", "serialize"] }
 rayon = "1.11.0"
 rstest = "0.26.1"
@@ -67,6 +69,7 @@ sha2 = "0.10"
 tempfile = "3"
 thiserror = { version = "2.0.17", default-features = false }
 tokio = { version = "1", default-features = false }
+tower = "0.5.3"
 ureq = "3"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 zstd = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,23 +30,23 @@ lox-ephem = { path = "crates/lox-ephem", version = "0.1.0-alpha.24" }
 lox-frames = { path = "crates/lox-frames", version = "0.1.0-alpha.20" }
 lox-io = { path = "crates/lox-io", version = "0.1.0-alpha.24" }
 lox-itur = { path = "crates/lox-itur", version = "0.1.0-alpha.5" }
-lox-stream = { path = "crates/lox-stream", version = "0.1.0-alpha.1" }
 lox-math = { path = "crates/lox-math", version = "0.1.0-alpha.23" }
 lox-odm = { path = "crates/lox-odm", version = "0.1.0-alpha.3" }
 lox-orbits = { path = "crates/lox-orbits", version = "0.1.0-alpha.39" }
+lox-stream = { path = "crates/lox-stream", version = "0.1.0-alpha.1" }
 lox-test-utils = { path = "crates/lox-test-utils", version = "0.1.0-alpha.9", default-features = false }
 lox-time = { path = "crates/lox-time", version = "0.1.0-alpha.26" }
 lox-units = { path = "crates/lox-units", version = "0.1.0-alpha.15" }
 
-async-channel = "2.5"
 arrayvec = "0.7.6"
+async-channel = "2.5.0"
 chrono = "0.4.43"
 csv = "1.4.0"
 differential-equations = "0.5.2"
 divan = { package = "codspeed-divan-compat", version = "4.3.0" }
 fast_polynomial = { version = "0.3.0", default-features = false }
-futures = "0.3"
-futures-core = "0.3"
+futures = "0.3.32"
+futures-core = "0.3.32"
 geo = "0.29"
 geojson = "0.24"
 glam = { version = "0.30.9", default-features = false }

--- a/crates/lox-analysis/Cargo.toml
+++ b/crates/lox-analysis/Cargo.toml
@@ -24,6 +24,7 @@ lox-ephem.workspace = true
 lox-frames.workspace = true
 lox-math.workspace = true
 lox-orbits.workspace = true
+lox-stream.workspace = true
 lox-time = { workspace = true, features = ["chrono"] }
 
 geo = { workspace = true, optional = true }
@@ -48,6 +49,7 @@ serde = [
 
 [dev-dependencies]
 csv.workspace = true
+lox-orbits = { workspace = true, features = ["test-utils"] }
 lox-test-utils = { workspace = true, features = ["std"] }
 
 [lib]

--- a/crates/lox-analysis/Cargo.toml
+++ b/crates/lox-analysis/Cargo.toml
@@ -24,7 +24,7 @@ lox-ephem.workspace = true
 lox-frames.workspace = true
 lox-math.workspace = true
 lox-orbits.workspace = true
-lox-stream.workspace = true
+lox-stream = { workspace = true, optional = true }
 lox-time = { workspace = true, features = ["chrono"] }
 
 geo = { workspace = true, optional = true }
@@ -37,6 +37,7 @@ thiserror.workspace = true
 comms = ["dep:lox-comms"]
 geojson = ["dep:geojson"]
 imaging = ["dep:geo"]
+stream = ["dep:lox-stream"]
 serde = [
   "dep:serde",
   "lox-bodies/serde",

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -27,7 +27,7 @@ use lox_comms::system::CommunicationSystem;
 use crate::visibility::ElevationMask;
 use lox_orbits::constellations::{ConstellationPropagator, DynConstellation};
 use lox_orbits::ground::DynGroundLocation;
-use lox_orbits::orbits::{Ensemble, KeplerianOrbit};
+use lox_orbits::orbits::{Ensemble, KeplerianOrbit, Trajectory};
 use lox_orbits::propagators::j2::DynJ2Propagator;
 use lox_orbits::propagators::j4::DynJ4Propagator;
 use lox_orbits::propagators::numerical::DynNumericalPropagator;
@@ -334,6 +334,31 @@ pub enum ScenarioPropagateError {
     WorkerPanicked(AssetId, String),
 }
 
+fn propagate_one<O, R, P>(
+    sc: &Spacecraft,
+    dyn_interval: TimeInterval<DynTimeScale>,
+    origin: O,
+    frame: R,
+    provider: &P,
+) -> Result<(AssetId, Trajectory<Tai, O, R>), ScenarioPropagateError>
+where
+    O: Origin + Copy,
+    R: ReferenceFrame + Copy + Into<DynFrame>,
+    P: TryRotation<DynFrame, R, DynTimeScale>,
+    P::Error: std::fmt::Display,
+{
+    let traj = sc
+        .orbit
+        .propagate(dyn_interval)
+        .map_err(|e| ScenarioPropagateError::Propagate(sc.id.clone(), e))?;
+    let rotated = traj
+        .into_frame(frame, provider)
+        .map_err(|e| ScenarioPropagateError::FrameTransformation(sc.id.clone(), e.to_string()))?;
+    let (epoch, _origin, frame, data) = rotated.into_parts();
+    let typed = Trajectory::from_parts(epoch.with_scale(Tai), origin, frame, data);
+    Ok((sc.id.clone(), typed))
+}
+
 impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Scenario<O, R> {
     /// Creates a new scenario from start/end times, origin, and frame.
     pub fn new(start_time: Time<Tai>, end_time: Time<Tai>, origin: O, frame: R) -> Self {
@@ -485,26 +510,7 @@ impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Sce
         let entries: Result<HashMap<_, _>, _> = self
             .spacecraft
             .par_iter()
-            .map(|sc| {
-                let traj = sc
-                    .orbit
-                    .propagate(dyn_interval)
-                    .map_err(|e| ScenarioPropagateError::Propagate(sc.id.clone(), e))?;
-                // Rotate DynTrajectory directly into concrete frame R
-                // (uses mixed TryRotation<DynFrame, R, DynTimeScale>).
-                let rotated = traj.into_frame(frame, provider).map_err(|e| {
-                    ScenarioPropagateError::FrameTransformation(sc.id.clone(), e.to_string())
-                })?;
-                // Re-tag origin and time scale (data unchanged, just type markers).
-                let (epoch, _origin, frame, data) = rotated.into_parts();
-                let typed = lox_orbits::orbits::Trajectory::from_parts(
-                    epoch.with_scale(Tai),
-                    origin,
-                    frame,
-                    data,
-                );
-                Ok((sc.id.clone(), typed))
-            })
+            .map(|sc| propagate_one(sc, dyn_interval, origin, frame, provider))
             .collect();
         Ok(Ensemble::new(entries?))
     }

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -329,6 +329,9 @@ pub enum ScenarioPropagateError {
     /// Frame transformation failed for the named spacecraft.
     #[error("frame transformation failed for spacecraft \"{0}\": {1}")]
     FrameTransformation(AssetId, String),
+    /// A worker thread panicked while propagating the named spacecraft.
+    #[error("worker panicked while propagating spacecraft \"{0}\": {1}")]
+    WorkerPanicked(AssetId, String),
 }
 
 impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Scenario<O, R> {

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -4,6 +4,8 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
 
 use lox_bodies::{DynOrigin, Origin};
 use lox_core::units::AngularRate;
@@ -16,6 +18,7 @@ use crate::imaging::SarPayload;
 use crate::imaging::analysis::PayloadAccessor;
 use lox_frames::rotations::TryRotation;
 use lox_frames::{DynFrame, ReferenceFrame};
+use lox_stream::{OnError, Stream, par_stream};
 use lox_time::Time;
 use lox_time::intervals::TimeInterval;
 use lox_time::time_scales::{DynTimeScale, Tai};
@@ -359,6 +362,16 @@ where
     Ok((sc.id.clone(), typed))
 }
 
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "panic with non-string payload".to_string()
+    }
+}
+
 impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Scenario<O, R> {
     /// Creates a new scenario from start/end times, origin, and frame.
     pub fn new(start_time: Time<Tai>, end_time: Time<Tai>, origin: O, frame: R) -> Self {
@@ -513,6 +526,54 @@ impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Sce
             .map(|sc| propagate_one(sc, dyn_interval, origin, frame, provider))
             .collect();
         Ok(Ensemble::new(entries?))
+    }
+
+    /// Propagate all spacecraft and stream completed trajectories as each one
+    /// finishes.
+    ///
+    /// Items are yielded in completion order (no ordering guarantee). Use the
+    /// returned `Stream` directly with async consumers or via `blocking_next`
+    /// for synchronous draining. Drop the stream (or call `cancel`) to stop
+    /// in-flight work cooperatively at unit boundaries.
+    pub fn propagate_stream<P>(
+        self: Arc<Self>,
+        provider: Arc<P>,
+        capacity: usize,
+        on_error: OnError,
+    ) -> Stream<(AssetId, Trajectory<Tai, O, R>), ScenarioPropagateError>
+    where
+        Self: Send + Sync + 'static,
+        R: Into<DynFrame>,
+        P: TryRotation<DynFrame, R, DynTimeScale> + Send + Sync + 'static,
+        P::Error: std::fmt::Display + Send,
+        O: Send + Sync + Copy + 'static,
+        R: Send + Sync + Copy + 'static,
+    {
+        let n = self.spacecraft.len();
+        let indices: Vec<usize> = (0..n).collect();
+
+        let scenario = self;
+        let prov = provider;
+        let dyn_interval = TimeInterval::new(
+            scenario.interval.start().into_dyn(),
+            scenario.interval.end().into_dyn(),
+        );
+        let origin = scenario.origin;
+        let frame = scenario.frame;
+
+        par_stream(indices, capacity, on_error, move |idx, _token| {
+            let sc = &scenario.spacecraft[idx];
+            let sc_id_for_panic = sc.id.clone();
+            catch_unwind(AssertUnwindSafe(|| {
+                propagate_one(sc, dyn_interval, origin, frame, &*prov)
+            }))
+            .unwrap_or_else(|payload| {
+                Err(ScenarioPropagateError::WorkerPanicked(
+                    sc_id_for_panic,
+                    panic_message(payload),
+                ))
+            })
+        })
     }
 
     /// Returns a new scenario containing only spacecraft belonging to the given constellations.

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -333,8 +333,13 @@ pub enum ScenarioPropagateError {
     #[error("frame transformation failed for spacecraft \"{0}\": {1}")]
     FrameTransformation(AssetId, String),
     /// A worker thread panicked while propagating the named spacecraft.
-    #[error("worker panicked while propagating spacecraft \"{0}\": {1}")]
-    WorkerPanicked(AssetId, String),
+    #[error("worker panicked while propagating spacecraft \"{id}\": {message}")]
+    WorkerPanicked {
+        /// Spacecraft whose propagation panicked.
+        id: AssetId,
+        /// Message extracted from the panic payload.
+        message: String,
+    },
 }
 
 fn propagate_one<O, R, P>(
@@ -578,10 +583,10 @@ impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Sce
                 propagate_one(sc, dyn_interval, origin, frame, &*prov)
             }))
             .unwrap_or_else(|payload| {
-                Err(ScenarioPropagateError::WorkerPanicked(
-                    sc_id_for_panic,
-                    panic_message(payload),
-                ))
+                Err(ScenarioPropagateError::WorkerPanicked {
+                    id: sc_id_for_panic,
+                    message: panic_message(payload),
+                })
             })
         })
     }

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -497,6 +497,16 @@ impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Sce
         &self.spacecraft
     }
 
+    /// Returns the ground station with the given id, if present.
+    pub fn ground_station_by_id(&self, id: &AssetId) -> Option<&GroundStation> {
+        self.ground_stations.iter().find(|gs| gs.id() == id)
+    }
+
+    /// Returns the spacecraft with the given id, if present.
+    pub fn spacecraft_by_id(&self, id: &AssetId) -> Option<&Spacecraft> {
+        self.spacecraft.iter().find(|sc| sc.id() == id)
+    }
+
     /// Propagate all spacecraft over the scenario interval, transforming
     /// trajectories to the scenario's frame using the provided rotation
     /// `provider`.
@@ -886,5 +896,48 @@ mod tests {
             .unwrap();
         assert_eq!(ensemble.len(), 1);
         assert!(ensemble.get(&AssetId::new("sc1")).is_some());
+    }
+
+    #[test]
+    fn by_id_lookups_return_the_right_assets() {
+        let start = Time::j2000(Tai);
+        let end = start + TimeDelta::from_seconds(86400);
+        let gs = GroundStation::new("gs1", dummy_location(), dummy_mask());
+        let traj = lox_orbits::orbits::DynTrajectory::from_csv_dyn(
+            &lox_test_utils::read_data_file("trajectory_lunar.csv"),
+            DynOrigin::Earth,
+            DynFrame::Icrf,
+        )
+        .unwrap();
+        let sc = Spacecraft::new("sc1", OrbitSource::Trajectory(traj));
+        let scenario = DynScenario::new(start, end, DynOrigin::Earth, DynFrame::Icrf)
+            .with_ground_stations(&[gs])
+            .with_spacecraft(&[sc]);
+        assert_eq!(
+            scenario
+                .ground_station_by_id(&AssetId::new("gs1"))
+                .unwrap()
+                .id()
+                .as_str(),
+            "gs1",
+        );
+        assert_eq!(
+            scenario
+                .spacecraft_by_id(&AssetId::new("sc1"))
+                .unwrap()
+                .id()
+                .as_str(),
+            "sc1",
+        );
+        assert!(
+            scenario
+                .ground_station_by_id(&AssetId::new("missing"))
+                .is_none()
+        );
+        assert!(
+            scenario
+                .spacecraft_by_id(&AssetId::new("missing"))
+                .is_none()
+        );
     }
 }

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -362,7 +362,7 @@ where
     Ok((sc.id.clone(), typed))
 }
 
-fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+pub(crate) fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         (*s).to_string()
     } else if let Some(s) = payload.downcast_ref::<String>() {

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -4,7 +4,9 @@
 
 use std::collections::HashMap;
 use std::fmt;
+#[cfg(feature = "stream")]
 use std::panic::{AssertUnwindSafe, catch_unwind};
+#[cfg(feature = "stream")]
 use std::sync::Arc;
 
 use lox_bodies::{DynOrigin, Origin};
@@ -18,6 +20,7 @@ use crate::imaging::SarPayload;
 use crate::imaging::analysis::PayloadAccessor;
 use lox_frames::rotations::TryRotation;
 use lox_frames::{DynFrame, ReferenceFrame};
+#[cfg(feature = "stream")]
 use lox_stream::{OnError, Stream, par_stream};
 use lox_time::Time;
 use lox_time::intervals::TimeInterval;
@@ -333,6 +336,7 @@ pub enum ScenarioPropagateError {
     #[error("frame transformation failed for spacecraft \"{0}\": {1}")]
     FrameTransformation(AssetId, String),
     /// A worker thread panicked while propagating the named spacecraft.
+    #[cfg(feature = "stream")]
     #[error("worker panicked while propagating spacecraft \"{id}\": {message}")]
     WorkerPanicked {
         /// Spacecraft whose propagation panicked.
@@ -367,6 +371,7 @@ where
     Ok((sc.id.clone(), typed))
 }
 
+#[cfg(feature = "stream")]
 pub(crate) fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         (*s).to_string()
@@ -550,6 +555,7 @@ impl<O: Origin + Copy + Send + Sync, R: ReferenceFrame + Copy + Send + Sync> Sce
     /// returned `Stream` directly with async consumers or via `blocking_next`
     /// for synchronous draining. Drop the stream (or call `cancel`) to stop
     /// in-flight work cooperatively at unit boundaries.
+    #[cfg(feature = "stream")]
     pub fn propagate_stream<P>(
         self: Arc<Self>,
         provider: Arc<P>,

--- a/crates/lox-analysis/src/imaging/analysis.rs
+++ b/crates/lox-analysis/src/imaging/analysis.rs
@@ -89,6 +89,16 @@ pub enum AccessError {
     /// Pass-direction sampling failed (state interpolation / frame rotation).
     #[error("pass-direction sampling failed: {0}")]
     PassDirection(#[from] EvalError),
+    /// A worker thread panicked while computing a (spacecraft, AOI) pair.
+    #[error("worker panicked while computing pair ({sc_id}, {aoi_id}): {message}")]
+    WorkerPanicked {
+        /// Spacecraft asset identifier.
+        sc_id: AssetId,
+        /// Area-of-interest identifier.
+        aoi_id: AoiId,
+        /// Panic message extracted from the panic payload.
+        message: String,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/lox-analysis/src/imaging/analysis.rs
+++ b/crates/lox-analysis/src/imaging/analysis.rs
@@ -6,10 +6,13 @@
 
 use core::marker::PhantomData;
 use std::collections::HashMap;
+#[cfg(feature = "stream")]
 use std::panic::{AssertUnwindSafe, catch_unwind};
+#[cfg(feature = "stream")]
 use std::sync::Arc;
 
 use lox_core::glam::DVec3;
+#[cfg(feature = "stream")]
 use lox_stream::{OnError, Stream, par_stream};
 use rayon::prelude::*;
 use thiserror::Error;
@@ -29,7 +32,9 @@ use lox_time::deltas::TimeDelta;
 use lox_time::intervals::TimeInterval;
 use lox_time::time_scales::Tai;
 
-use crate::assets::{AssetId, Scenario, Spacecraft, panic_message};
+#[cfg(feature = "stream")]
+use crate::assets::panic_message;
+use crate::assets::{AssetId, Scenario, Spacecraft};
 use crate::imaging::aoi::{Aoi, AoiId};
 use crate::imaging::optical::OpticalPayload;
 use crate::imaging::results::{AccessResults, AccessWindow, PassDirection};
@@ -94,6 +99,7 @@ pub enum AccessError {
     #[error("pass-direction sampling failed: {0}")]
     PassDirection(#[from] EvalError),
     /// A worker thread panicked while computing a (spacecraft, AOI) pair.
+    #[cfg(feature = "stream")]
     #[error("worker panicked while computing pair ({sc_id}, {aoi_id}): {message}")]
     WorkerPanicked {
         /// Spacecraft asset identifier.
@@ -330,6 +336,7 @@ where
     /// Consumes the analysis (moves the AOI list into the streaming task) and
     /// requires `Arc`-shared scenario and ensemble so the work can outlive
     /// the original borrow.
+    #[cfg(feature = "stream")]
     pub fn compute_stream(
         self,
         scenario: Arc<Scenario<O, R>>,
@@ -443,6 +450,7 @@ where
 }
 
 /// One (spacecraft, AOI) pair's access windows, streamed as the pair completes.
+#[cfg(feature = "stream")]
 pub struct AccessPairResult {
     /// Spacecraft id.
     pub sc_id: AssetId,
@@ -452,6 +460,7 @@ pub struct AccessPairResult {
     pub windows: Vec<AccessWindow>,
 }
 
+#[cfg(feature = "stream")]
 struct AccessJob<P: Copy + Send + 'static> {
     sc_id: AssetId,
     aoi_id: AoiId,

--- a/crates/lox-analysis/src/imaging/analysis.rs
+++ b/crates/lox-analysis/src/imaging/analysis.rs
@@ -23,6 +23,7 @@ use lox_orbits::events::{
 use lox_orbits::orbits::{Ensemble, Trajectory};
 use lox_time::Time;
 use lox_time::deltas::TimeDelta;
+use lox_time::intervals::TimeInterval;
 use lox_time::time_scales::Tai;
 
 use crate::assets::{AssetId, Scenario, Spacecraft};
@@ -297,30 +298,17 @@ where
 
         let compute_one = |&(sc, payload, (aoi_id, aoi)): &(&Spacecraft, P, &(AoiId, Aoi))| {
             let key = (sc.id().clone(), aoi_id.clone());
-            let traj = self.ensemble.get(sc.id()).expect(
-                "trajectory not found in ensemble; did you forget to propagate this spacecraft?",
-            );
-            let detect_fn = AccessDetectFn {
-                payload,
+            let windows = access_one(
+                sc.id(),
+                aoi_id,
                 aoi,
-                trajectory: traj,
-                origin: self.scenario.origin(),
-                body_fixed_frame: self.body_fixed_frame,
-            };
-            let detector = RootFindingDetector::new(detect_fn, self.step);
-            let intervals = EventsToIntervals::new(detector).detect(interval)?;
-            let origin = self.scenario.origin();
-            let body_fixed_frame = self.body_fixed_frame;
-            let mut windows: Vec<AccessWindow> = Vec::with_capacity(intervals.len());
-            for iv in intervals {
-                let midpoint = iv.start() + 0.5 * (iv.end() - iv.start());
-                let sample = sub_sat_sample(traj, midpoint, origin, body_fixed_frame)?;
-                let direction = pass_direction_of(&sample);
-                windows.push(AccessWindow {
-                    interval: iv,
-                    direction,
-                });
-            }
+                payload,
+                self.ensemble,
+                self.scenario.origin(),
+                self.body_fixed_frame,
+                self.step,
+                interval,
+            )?;
             Ok::<_, AccessError>((key, windows))
         };
 
@@ -333,6 +321,50 @@ where
         let windows_by_pair: HashMap<_, _> = results?.into_iter().collect();
         Ok(AccessResults::new(windows_by_pair))
     }
+}
+
+fn access_one<P, O, R>(
+    sc_id: &AssetId,
+    _aoi_id: &AoiId,
+    aoi: &Aoi,
+    payload: P,
+    ensemble: &Ensemble<AssetId, Tai, O, R>,
+    origin: O,
+    body_fixed_frame: DynFrame,
+    step: TimeDelta,
+    interval: TimeInterval<Tai>,
+) -> Result<Vec<AccessWindow>, AccessError>
+where
+    P: AccessPayload + Copy + Send + Sync,
+    O: TrySpheroid + TryMeanRadius + Copy + Send + Sync + Into<DynOrigin>,
+    R: ReferenceFrame + Copy + Send + Sync + Into<DynFrame>,
+    DefaultRotationProvider: TryRotation<R, DynFrame, Tai>,
+    <DefaultRotationProvider as TryRotation<R, DynFrame, Tai>>::Error:
+        core::error::Error + Send + Sync + 'static,
+{
+    let traj = ensemble
+        .get(sc_id)
+        .expect("trajectory not found in ensemble; did you forget to propagate this spacecraft?");
+    let detect_fn = AccessDetectFn {
+        payload,
+        aoi,
+        trajectory: traj,
+        origin,
+        body_fixed_frame,
+    };
+    let detector = RootFindingDetector::new(detect_fn, step);
+    let intervals = EventsToIntervals::new(detector).detect(interval)?;
+    let mut windows: Vec<AccessWindow> = Vec::with_capacity(intervals.len());
+    for iv in intervals {
+        let midpoint = iv.start() + 0.5 * (iv.end() - iv.start());
+        let sample = sub_sat_sample(traj, midpoint, origin, body_fixed_frame)?;
+        let direction = pass_direction_of(&sample);
+        windows.push(AccessWindow {
+            interval: iv,
+            direction,
+        });
+    }
+    Ok(windows)
 }
 
 /// Type alias for the optical access analysis (parameterised by [`OpticalPayload`]).

--- a/crates/lox-analysis/src/imaging/analysis.rs
+++ b/crates/lox-analysis/src/imaging/analysis.rs
@@ -6,8 +6,11 @@
 
 use core::marker::PhantomData;
 use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
 
 use lox_core::glam::DVec3;
+use lox_stream::{OnError, Stream, par_stream};
 use rayon::prelude::*;
 use thiserror::Error;
 
@@ -26,7 +29,7 @@ use lox_time::deltas::TimeDelta;
 use lox_time::intervals::TimeInterval;
 use lox_time::time_scales::Tai;
 
-use crate::assets::{AssetId, Scenario, Spacecraft};
+use crate::assets::{AssetId, Scenario, Spacecraft, panic_message};
 use crate::imaging::aoi::{Aoi, AoiId};
 use crate::imaging::optical::OpticalPayload;
 use crate::imaging::results::{AccessResults, AccessWindow, PassDirection};
@@ -321,8 +324,80 @@ where
         let windows_by_pair: HashMap<_, _> = results?.into_iter().collect();
         Ok(AccessResults::new(windows_by_pair))
     }
+
+    /// Stream (spacecraft, AOI) access results as each pair completes.
+    ///
+    /// Consumes the analysis (moves the AOI list into the streaming task) and
+    /// requires `Arc`-shared scenario and ensemble so the work can outlive
+    /// the original borrow.
+    pub fn compute_stream(
+        self,
+        scenario: Arc<Scenario<O, R>>,
+        ensemble: Arc<Ensemble<AssetId, Tai, O, R>>,
+        capacity: usize,
+        on_error: OnError,
+    ) -> Stream<AccessPairResult, AccessError>
+    where
+        P: 'static,
+        O: 'static,
+        R: 'static,
+    {
+        let interval = *scenario.interval();
+        let step = self.step;
+        let body_fixed_frame = self.body_fixed_frame;
+        let origin = scenario.origin();
+        let aois = Arc::new(self.aois);
+
+        let mut jobs: Vec<AccessJob<P>> = Vec::new();
+        for sc in scenario.spacecraft() {
+            if let Some(payload) = <Spacecraft as PayloadAccessor<P>>::extract(sc) {
+                for (aoi_idx, (aoi_id, _)) in aois.iter().enumerate() {
+                    jobs.push(AccessJob {
+                        sc_id: sc.id().clone(),
+                        aoi_id: aoi_id.clone(),
+                        aoi_idx,
+                        payload,
+                    });
+                }
+            }
+        }
+
+        drop(scenario);
+
+        par_stream(jobs, capacity, on_error, move |job, _token| {
+            let sc_id_p = job.sc_id.clone();
+            let aoi_id_p = job.aoi_id.clone();
+            catch_unwind(AssertUnwindSafe(|| {
+                let (_, aoi) = &aois[job.aoi_idx];
+                let windows = access_one(
+                    &job.sc_id,
+                    &job.aoi_id,
+                    aoi,
+                    job.payload,
+                    &ensemble,
+                    origin,
+                    body_fixed_frame,
+                    step,
+                    interval,
+                )?;
+                Ok(AccessPairResult {
+                    sc_id: job.sc_id,
+                    aoi_id: job.aoi_id,
+                    windows,
+                })
+            }))
+            .unwrap_or_else(|payload| {
+                Err(AccessError::WorkerPanicked {
+                    sc_id: sc_id_p,
+                    aoi_id: aoi_id_p,
+                    message: panic_message(payload),
+                })
+            })
+        })
+    }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn access_one<P, O, R>(
     sc_id: &AssetId,
     _aoi_id: &AoiId,
@@ -365,6 +440,23 @@ where
         });
     }
     Ok(windows)
+}
+
+/// One (spacecraft, AOI) pair's access windows, streamed as the pair completes.
+pub struct AccessPairResult {
+    /// Spacecraft id.
+    pub sc_id: AssetId,
+    /// Area-of-interest id.
+    pub aoi_id: AoiId,
+    /// Access windows (interval + pass direction) for this pair.
+    pub windows: Vec<AccessWindow>,
+}
+
+struct AccessJob<P: Copy + Send + 'static> {
+    sc_id: AssetId,
+    aoi_id: AoiId,
+    aoi_idx: usize,
+    payload: P,
 }
 
 /// Type alias for the optical access analysis (parameterised by [`OpticalPayload`]).

--- a/crates/lox-analysis/src/visibility.rs
+++ b/crates/lox-analysis/src/visibility.rs
@@ -165,8 +165,15 @@ pub enum VisibilityError {
     #[error(transparent)]
     Series(#[from] SeriesError),
     /// A worker thread panicked while computing a pair.
-    #[error("worker panicked while computing pair ({0}, {1}): {2}")]
-    WorkerPanicked(AssetId, AssetId, String),
+    #[error("worker panicked while computing pair ({id1}, {id2}): {message}")]
+    WorkerPanicked {
+        /// First asset of the panicking pair.
+        id1: AssetId,
+        /// Second asset of the panicking pair.
+        id2: AssetId,
+        /// Message extracted from the panic payload.
+        message: String,
+    },
 }
 
 /// Error returned when computing passes for an invalid pair type.
@@ -1649,11 +1656,11 @@ where
                 run_visibility_job(&job, &scenario, &ensemble, &*ephemeris, &cfg, interval)
             }))
             .unwrap_or_else(|payload| {
-                Err(VisibilityError::WorkerPanicked(
-                    id1_panic,
-                    id2_panic,
-                    panic_message(payload),
-                ))
+                Err(VisibilityError::WorkerPanicked {
+                    id1: id1_panic,
+                    id2: id2_panic,
+                    message: panic_message(payload),
+                })
             })
         })
     }

--- a/crates/lox-analysis/src/visibility.rs
+++ b/crates/lox-analysis/src/visibility.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::HashMap;
+#[cfg(feature = "stream")]
 use std::panic::{AssertUnwindSafe, catch_unwind};
+#[cfg(feature = "stream")]
 use std::sync::Arc;
 
 use lox_bodies::{DynOrigin, Origin, TryMeanRadius, TrySpheroid, UndefinedOriginPropertyError};
@@ -23,9 +25,12 @@ use std::f64::consts::PI;
 use thiserror::Error;
 
 use lox_core::units::{AngularRate, Distance};
+#[cfg(feature = "stream")]
 use lox_stream::{OnError, Stream, par_stream};
 
-use crate::assets::{AssetId, GroundStation, Scenario, Spacecraft, panic_message};
+#[cfg(feature = "stream")]
+use crate::assets::panic_message;
+use crate::assets::{AssetId, GroundStation, Scenario, Spacecraft};
 use lox_orbits::events::{
     DetectError, DetectFn, EventsToIntervals, IntervalDetector, IntervalDetectorExt,
     RootFindingDetector,
@@ -165,6 +170,7 @@ pub enum VisibilityError {
     #[error(transparent)]
     Series(#[from] SeriesError),
     /// A worker thread panicked while computing a pair.
+    #[cfg(feature = "stream")]
     #[error("worker panicked while computing pair ({id1}, {id2}): {message}")]
     WorkerPanicked {
         /// First asset of the panicking pair.
@@ -913,6 +919,7 @@ impl VisibilityResults {
 // ---------------------------------------------------------------------------
 
 /// One pair's worth of visibility intervals, streamed as the pair completes.
+#[cfg(feature = "stream")]
 pub struct PairResult {
     /// First asset id (ground station or first spacecraft).
     pub id1: AssetId,
@@ -924,11 +931,13 @@ pub struct PairResult {
     pub intervals: Vec<TimeInterval<Tai>>,
 }
 
+#[cfg(feature = "stream")]
 enum PairJob {
     GroundSpace { gs_id: AssetId, sc_id: AssetId },
     InterSatellite { id1: AssetId, id2: AssetId },
 }
 
+#[cfg(feature = "stream")]
 struct StreamCfg {
     occulting_bodies: Vec<DynOrigin>,
     step: TimeDelta,
@@ -1593,6 +1602,7 @@ where
     /// Ground-space and inter-satellite pairs (when enabled via
     /// [`with_inter_satellite`](Self::with_inter_satellite)) are interleaved
     /// in a single stream; consumers discriminate by `PairResult::pair_type`.
+    #[cfg(feature = "stream")]
     pub fn compute_stream(
         self,
         scenario: Arc<Scenario<O, R>>,
@@ -1666,6 +1676,7 @@ where
     }
 }
 
+#[cfg(feature = "stream")]
 fn run_visibility_job<O, R, E>(
     job: &PairJob,
     scenario: &Scenario<O, R>,

--- a/crates/lox-analysis/src/visibility.rs
+++ b/crates/lox-analysis/src/visibility.rs
@@ -161,6 +161,9 @@ pub enum VisibilityError {
     /// Series interpolation failed.
     #[error(transparent)]
     Series(#[from] SeriesError),
+    /// A worker thread panicked while computing a pair.
+    #[error("worker panicked while computing pair ({0}, {1}): {2}")]
+    WorkerPanicked(AssetId, AssetId, String),
 }
 
 /// Error returned when computing passes for an invalid pair type.

--- a/crates/lox-analysis/src/visibility.rs
+++ b/crates/lox-analysis/src/visibility.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
 
 use lox_bodies::{DynOrigin, Origin, TryMeanRadius, TrySpheroid, UndefinedOriginPropertyError};
 use lox_core::glam::DVec3;
@@ -21,8 +23,9 @@ use std::f64::consts::PI;
 use thiserror::Error;
 
 use lox_core::units::{AngularRate, Distance};
+use lox_stream::{OnError, Stream, par_stream};
 
-use crate::assets::{AssetId, GroundStation, Scenario, Spacecraft};
+use crate::assets::{AssetId, GroundStation, Scenario, Spacecraft, panic_message};
 use lox_orbits::events::{
     DetectError, DetectFn, EventsToIntervals, IntervalDetector, IntervalDetectorExt,
     RootFindingDetector,
@@ -899,6 +902,35 @@ impl VisibilityResults {
 }
 
 // ---------------------------------------------------------------------------
+// Streaming types
+// ---------------------------------------------------------------------------
+
+/// One pair's worth of visibility intervals, streamed as the pair completes.
+pub struct PairResult {
+    /// First asset id (ground station or first spacecraft).
+    pub id1: AssetId,
+    /// Second asset id (spacecraft or second spacecraft).
+    pub id2: AssetId,
+    /// Whether this is a ground-space or inter-satellite pair.
+    pub pair_type: PairType,
+    /// Visibility intervals for this pair.
+    pub intervals: Vec<TimeInterval<Tai>>,
+}
+
+enum PairJob {
+    GroundSpace { gs_id: AssetId, sc_id: AssetId },
+    InterSatellite { id1: AssetId, id2: AssetId },
+}
+
+struct StreamCfg {
+    occulting_bodies: Vec<DynOrigin>,
+    step: TimeDelta,
+    min_pass_duration: Option<TimeDelta>,
+    min_range: Option<Distance>,
+    max_range: Option<Distance>,
+}
+
+// ---------------------------------------------------------------------------
 // VisibilityAnalysis
 // ---------------------------------------------------------------------------
 
@@ -1542,6 +1574,154 @@ where
             intervals,
             pair_types,
         })
+    }
+
+    /// Stream visibility intervals as each (asset, asset) pair completes.
+    ///
+    /// Consumes the analysis. Filters are applied synchronously during pair
+    /// enumeration before any parallel work starts; the resulting pair list
+    /// and the `Arc`-shared scenario / ensemble / ephemeris are then moved
+    /// into a background rayon task.
+    ///
+    /// Ground-space and inter-satellite pairs (when enabled via
+    /// [`with_inter_satellite`](Self::with_inter_satellite)) are interleaved
+    /// in a single stream; consumers discriminate by `PairResult::pair_type`.
+    pub fn compute_stream(
+        self,
+        scenario: Arc<Scenario<O, R>>,
+        ensemble: Arc<Ensemble<AssetId, Tai, O, R>>,
+        ephemeris: Arc<E>,
+        capacity: usize,
+        on_error: OnError,
+    ) -> Stream<PairResult, VisibilityError>
+    where
+        O: 'static,
+        R: 'static,
+        E: 'static,
+    {
+        let interval = *scenario.interval();
+        let mut pairs: Vec<PairJob> = Vec::new();
+
+        if !scenario.ground_stations().is_empty() {
+            for gs in scenario.ground_stations() {
+                for sc in scenario.spacecraft() {
+                    if self.ground_space_filter.as_ref().is_none_or(|f| f(gs, sc)) {
+                        pairs.push(PairJob::GroundSpace {
+                            gs_id: gs.id().clone(),
+                            sc_id: sc.id().clone(),
+                        });
+                    }
+                }
+            }
+        }
+        if self.inter_satellite {
+            let sc = scenario.spacecraft();
+            for i in 0..sc.len() {
+                for j in (i + 1)..sc.len() {
+                    if self
+                        .inter_satellite_filter
+                        .as_ref()
+                        .is_none_or(|f| f(&sc[i], &sc[j]))
+                    {
+                        pairs.push(PairJob::InterSatellite {
+                            id1: sc[i].id().clone(),
+                            id2: sc[j].id().clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let cfg = Arc::new(StreamCfg {
+            occulting_bodies: self.occulting_bodies.clone(),
+            step: self.step,
+            min_pass_duration: self.min_pass_duration,
+            min_range: self.min_range,
+            max_range: self.max_range,
+        });
+
+        par_stream(pairs, capacity, on_error, move |job, _token| {
+            let (id1_panic, id2_panic) = match &job {
+                PairJob::GroundSpace { gs_id, sc_id } => (gs_id.clone(), sc_id.clone()),
+                PairJob::InterSatellite { id1, id2 } => (id1.clone(), id2.clone()),
+            };
+            catch_unwind(AssertUnwindSafe(|| {
+                run_visibility_job(&job, &scenario, &ensemble, &*ephemeris, &cfg, interval)
+            }))
+            .unwrap_or_else(|payload| {
+                Err(VisibilityError::WorkerPanicked(
+                    id1_panic,
+                    id2_panic,
+                    panic_message(payload),
+                ))
+            })
+        })
+    }
+}
+
+fn run_visibility_job<O, R, E>(
+    job: &PairJob,
+    scenario: &Scenario<O, R>,
+    ensemble: &Ensemble<AssetId, Tai, O, R>,
+    ephemeris: &E,
+    cfg: &StreamCfg,
+    interval: TimeInterval<Tai>,
+) -> Result<PairResult, VisibilityError>
+where
+    O: TrySpheroid + TryMeanRadius + Copy + Send + Sync + Into<DynOrigin>,
+    R: ReferenceFrame + Copy + Send + Sync + Into<DynFrame>,
+    E: Ephemeris + Send + Sync,
+    E::Error: 'static,
+    DefaultRotationProvider: TryRotation<R, DynFrame, Tai> + TryRotation<DynFrame, R, Tai>,
+    <DefaultRotationProvider as TryRotation<R, DynFrame, Tai>>::Error:
+        std::error::Error + Send + Sync + 'static,
+    <DefaultRotationProvider as TryRotation<DynFrame, R, Tai>>::Error:
+        std::error::Error + Send + Sync + 'static,
+{
+    let params = ComputeParams {
+        scenario,
+        ensemble,
+        ephemeris,
+        occulting_bodies: &cfg.occulting_bodies,
+        step: cfg.step,
+        min_pass_duration: cfg.min_pass_duration,
+        min_range: cfg.min_range,
+        max_range: cfg.max_range,
+    };
+    match job {
+        PairJob::GroundSpace { gs_id, sc_id } => {
+            let gs = scenario
+                .ground_station_by_id(gs_id)
+                .expect("ground station not found in scenario");
+            let traj = ensemble.get(sc_id).expect(
+                "trajectory not found in ensemble; did you forget to propagate this spacecraft?",
+            );
+            let intervals = params.compute_ground_space_pair(gs, traj, interval)?;
+            Ok(PairResult {
+                id1: gs_id.clone(),
+                id2: sc_id.clone(),
+                pair_type: PairType::GroundSpace,
+                intervals,
+            })
+        }
+        PairJob::InterSatellite { id1, id2 } => {
+            let sc1 = scenario
+                .spacecraft_by_id(id1)
+                .expect("spacecraft not found in scenario");
+            let sc2 = scenario
+                .spacecraft_by_id(id2)
+                .expect("spacecraft not found in scenario");
+            let traj1 = ensemble.get(id1).expect("trajectory not found");
+            let traj2 = ensemble.get(id2).expect("trajectory not found");
+            let intervals =
+                params.compute_inter_satellite_pair(sc1, sc2, traj1, traj2, interval)?;
+            Ok(PairResult {
+                id1: id1.clone(),
+                id2: id2.clone(),
+                pair_type: PairType::InterSatellite,
+                intervals,
+            })
+        }
     }
 }
 

--- a/crates/lox-analysis/tests/streaming_access.rs
+++ b/crates/lox-analysis/tests/streaming_access.rs
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use geo::{LineString, Polygon};
+use lox_analysis::assets::{AssetId, DynScenario, Spacecraft};
+use lox_analysis::imaging::analysis::{AccessAnalysis, AccessPairResult};
+use lox_analysis::imaging::aoi::{Aoi, AoiId};
+use lox_analysis::imaging::optical::OpticalPayload;
+use lox_analysis::imaging::sar::{LookSide, SarPayload};
+use lox_bodies::DynOrigin;
+use lox_core::units::{Angle, Distance};
+use lox_frames::DynFrame;
+use lox_orbits::orbits::{DynTrajectory, Ensemble, Trajectory};
+use lox_orbits::propagators::OrbitSource;
+use lox_orbits::propagators::Propagator;
+use lox_orbits::propagators::sgp4::{Elements, Sgp4};
+use lox_stream::OnError;
+use lox_time::deltas::TimeDelta;
+use lox_time::intervals::{Interval, TimeInterval};
+use lox_time::time_scales::{DynTimeScale, Tai};
+
+// Sentinel-1A TLE — epoch 2026-079 (20 March 2026), consistent with the
+// SAR integration tests. Reused for optical tests too (any LEO orbit works
+// for geometry verification; payload swath is wide enough to generate passes).
+const S1A_NAME: &str = "SENTINEL-1A";
+const S1A_LINE1: &[u8] = b"1 39634U 14016A   26079.20000000  .00000050  00000+0  37000-4 0  9991";
+const S1A_LINE2: &[u8] = b"2 39634  98.1817 105.0000 0001300  90.0000 270.0000 14.59197557600008";
+
+fn s1a_trajectory() -> DynTrajectory {
+    let tle = Elements::from_tle(Some(S1A_NAME.to_string()), S1A_LINE1, S1A_LINE2).unwrap();
+    let sgp4 = Sgp4::new(tle).unwrap();
+    let t0 = sgp4.time();
+    let t1 = t0 + TimeDelta::from_hours(6);
+    sgp4.with_step(TimeDelta::from_seconds(10))
+        .propagate(Interval::new(t0, t1))
+        .unwrap()
+        .into_dyn()
+}
+
+fn western_europe_aoi() -> Aoi {
+    Aoi::new(Polygon::new(
+        LineString::from(vec![
+            (-10.0, 35.0),
+            (20.0, 35.0),
+            (20.0, 60.0),
+            (-10.0, 60.0),
+            (-10.0, 35.0),
+        ]),
+        vec![],
+    ))
+}
+
+fn make_scenario(
+    spacecraft: &[Spacecraft],
+    interval: TimeInterval<DynTimeScale>,
+) -> (DynScenario, Ensemble<AssetId, Tai, DynOrigin, DynFrame>) {
+    let tai_interval =
+        TimeInterval::new(interval.start().to_scale(Tai), interval.end().to_scale(Tai));
+    let scenario = DynScenario::with_interval(tai_interval, DynOrigin::Earth, DynFrame::Icrf)
+        .with_spacecraft(spacecraft);
+    let mut map = HashMap::new();
+    for sc in spacecraft {
+        if let OrbitSource::Trajectory(traj) = sc.orbit() {
+            let (epoch, origin, frame, data) = traj.clone().into_parts();
+            let typed = Trajectory::from_parts(epoch.with_scale(Tai), origin, frame, data);
+            map.insert(sc.id().clone(), typed);
+        }
+    }
+    (scenario, Ensemble::new(map))
+}
+
+fn optical_payload() -> OpticalPayload {
+    OpticalPayload::off_nadir(Distance::kilometers(290.0), Angle::degrees(20.0))
+}
+
+fn sar_payload() -> SarPayload {
+    SarPayload::with_incidence_angles(Angle::degrees(29.0), Angle::degrees(46.0), LookSide::Right)
+        .unwrap()
+}
+
+#[test]
+fn optical_streamed_results_equal_batch() {
+    let traj = s1a_trajectory();
+    let interval = TimeInterval::new(traj.start_time(), traj.end_time());
+    let sc = Spacecraft::new("s1a", OrbitSource::Trajectory(traj))
+        .with_optical_payload(optical_payload());
+    let (scenario, ensemble) = make_scenario(std::slice::from_ref(&sc), interval);
+    let aois = vec![(AoiId::new("europe"), western_europe_aoi())];
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+
+    let batch_analysis = AccessAnalysis::<OpticalPayload, _, _>::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        aois.clone(),
+    )
+    .with_step(TimeDelta::from_seconds(30));
+    let batch = batch_analysis.compute().unwrap();
+
+    let stream_analysis = AccessAnalysis::<OpticalPayload, _, _>::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        aois,
+    )
+    .with_step(TimeDelta::from_seconds(30));
+    let mut s = stream_analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        8,
+        OnError::Continue,
+    );
+
+    let mut streamed: std::collections::HashMap<_, _> = std::collections::HashMap::new();
+    while let Some(item) = s.blocking_next() {
+        let AccessPairResult {
+            sc_id,
+            aoi_id,
+            windows,
+        } = item.unwrap();
+        streamed.insert((sc_id, aoi_id), windows);
+    }
+
+    assert_eq!(streamed.len(), batch.num_pairs());
+    for ((sc_id, aoi_id), windows) in &streamed {
+        let bw = batch.windows(sc_id, aoi_id);
+        assert_eq!(windows.len(), bw.len());
+    }
+}
+
+#[test]
+fn sar_streamed_results_equal_batch() {
+    let traj = s1a_trajectory();
+    let interval = TimeInterval::new(traj.start_time(), traj.end_time());
+    let sc = Spacecraft::new("s1a", OrbitSource::Trajectory(traj)).with_sar_payload(sar_payload());
+    let (scenario, ensemble) = make_scenario(std::slice::from_ref(&sc), interval);
+    let aois = vec![(AoiId::new("europe"), western_europe_aoi())];
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+
+    use lox_analysis::imaging::sar::SarPayload;
+
+    let batch_analysis = AccessAnalysis::<SarPayload, _, _>::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        aois.clone(),
+    )
+    .with_step(TimeDelta::from_seconds(30));
+    let batch = batch_analysis.compute().unwrap();
+
+    let stream_analysis =
+        AccessAnalysis::<SarPayload, _, _>::new(arc_scenario.as_ref(), arc_ensemble.as_ref(), aois)
+            .with_step(TimeDelta::from_seconds(30));
+    let mut s = stream_analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        8,
+        OnError::Continue,
+    );
+
+    let mut count_streamed = 0usize;
+    while let Some(item) = s.blocking_next() {
+        item.unwrap();
+        count_streamed += 1;
+    }
+    assert_eq!(count_streamed, batch.num_pairs());
+}
+
+#[test]
+fn spacecraft_without_payload_skipped() {
+    let traj = s1a_trajectory();
+    let interval = TimeInterval::new(traj.start_time(), traj.end_time());
+    // sc_optical has an optical payload; sc_plain does not.
+    let sc_optical = Spacecraft::new("sc_optical", OrbitSource::Trajectory(traj.clone()))
+        .with_optical_payload(optical_payload());
+    let sc_plain = Spacecraft::new("sc_plain", OrbitSource::Trajectory(traj));
+    let spacecraft = [sc_optical, sc_plain];
+    let (scenario, ensemble) = make_scenario(&spacecraft, interval);
+    let aois = vec![(AoiId::new("europe"), western_europe_aoi())];
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+
+    let analysis = AccessAnalysis::<OpticalPayload, _, _>::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        aois,
+    )
+    .with_step(TimeDelta::from_seconds(30));
+    let mut s = analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        8,
+        OnError::Continue,
+    );
+
+    let mut sc_ids_seen = std::collections::HashSet::new();
+    while let Some(item) = s.blocking_next() {
+        let pr = item.unwrap();
+        sc_ids_seen.insert(pr.sc_id);
+    }
+    // Only the optically-equipped spacecraft should appear.
+    assert_eq!(sc_ids_seen.len(), 1);
+    assert!(sc_ids_seen.contains(&AssetId::new("sc_optical")));
+}
+
+#[test]
+fn drop_stops_workers() {
+    use std::time::Duration;
+
+    let traj = s1a_trajectory();
+    let interval = TimeInterval::new(traj.start_time(), traj.end_time());
+    // Build several spacecraft to give the worker pool something to do.
+    let spacecraft: Vec<Spacecraft> = (0..8)
+        .map(|i| {
+            Spacecraft::new(format!("sc{i}"), OrbitSource::Trajectory(traj.clone()))
+                .with_optical_payload(optical_payload())
+        })
+        .collect();
+    let (scenario, ensemble) = make_scenario(&spacecraft, interval);
+    // Many AOIs to create enough jobs that cancellation is observable.
+    let aois: Vec<(AoiId, Aoi)> = (0..8)
+        .map(|i| (AoiId::new(format!("aoi{i}")), western_europe_aoi()))
+        .collect();
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+
+    let analysis = AccessAnalysis::<OpticalPayload, _, _>::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        aois,
+    )
+    .with_step(TimeDelta::from_seconds(30));
+    let s = analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        4,
+        OnError::Continue,
+    );
+    let token = s.token();
+    drop(s);
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(token.is_cancelled());
+}

--- a/crates/lox-analysis/tests/streaming_access.rs
+++ b/crates/lox-analysis/tests/streaming_access.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg(all(feature = "stream", feature = "imaging"))]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/lox-analysis/tests/streaming_propagate.rs
+++ b/crates/lox-analysis/tests/streaming_propagate.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use lox_analysis::assets::{DynScenario, Spacecraft};
+use lox_frames::DynFrame;
+use lox_frames::providers::DefaultRotationProvider;
+use lox_orbits::orbits::DynTrajectory;
+use lox_orbits::propagators::OrbitSource;
+use lox_stream::OnError;
+use lox_time::time_scales::Tai;
+
+fn make_trajectory() -> DynTrajectory {
+    use lox_bodies::DynOrigin;
+    DynTrajectory::from_csv_dyn(
+        &lox_test_utils::read_data_file("trajectory_lunar.csv"),
+        DynOrigin::Earth,
+        DynFrame::Icrf,
+    )
+    .unwrap()
+}
+
+fn make_scenario(n: usize) -> (DynScenario, DefaultRotationProvider) {
+    use lox_bodies::DynOrigin;
+    let traj = make_trajectory();
+    let start = traj.start_time().to_scale(Tai);
+    let end = traj.end_time().to_scale(Tai);
+    let spacecraft: Vec<Spacecraft> = (0..n)
+        .map(|i| Spacecraft::new(format!("sc{i}"), OrbitSource::Trajectory(traj.clone())))
+        .collect();
+    let scenario =
+        DynScenario::new(start, end, DynOrigin::Earth, DynFrame::Icrf).with_spacecraft(&spacecraft);
+    (scenario, DefaultRotationProvider)
+}
+
+#[test]
+fn streamed_results_equal_batch() {
+    let (scenario, provider) = make_scenario(4);
+    let arc_scenario = Arc::new(scenario);
+    let arc_provider = Arc::new(provider);
+
+    let batch = arc_scenario
+        .clone()
+        .as_ref()
+        .propagate(&*arc_provider)
+        .unwrap();
+    let mut streamed =
+        arc_scenario
+            .clone()
+            .propagate_stream(arc_provider.clone(), 16, OnError::Continue);
+
+    let mut collected: HashMap<_, _> = HashMap::new();
+    while let Some(item) = streamed.blocking_next() {
+        let (id, traj) = item.unwrap();
+        collected.insert(id, traj);
+    }
+
+    assert_eq!(collected.len(), batch.len());
+    for (id, traj) in collected {
+        let bt = batch.get(&id).expect("missing in batch");
+        assert_eq!(traj.states().len(), bt.states().len());
+    }
+}
+
+#[test]
+fn drop_stops_workers() {
+    use std::time::Duration;
+
+    // A large scenario so not every spacecraft can be propagated before we drop.
+    let (scenario, provider) = make_scenario(100);
+    let arc_scenario = Arc::new(scenario);
+    let arc_provider = Arc::new(provider);
+
+    let stream = arc_scenario
+        .clone()
+        .propagate_stream(arc_provider.clone(), 4, OnError::Continue);
+
+    let token = stream.token();
+    drop(stream);
+    // Give rayon a moment to observe cancellation.
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(token.is_cancelled());
+}

--- a/crates/lox-analysis/tests/streaming_propagate.rs
+++ b/crates/lox-analysis/tests/streaming_propagate.rs
@@ -39,7 +39,8 @@ fn make_scenario(n: usize) -> (DynScenario, DefaultRotationProvider) {
 }
 
 /// Build a scenario with `n_good` healthy spacecraft plus one spacecraft using
-/// `bad_orbit` as its orbit source. The bad spacecraft has id `"bad"`.
+/// `bad_orbit` as its orbit source. The bad spacecraft has id `"bad"` and is
+/// placed at index 0 so abort-policy tests can rely on it failing early.
 fn make_mixed_scenario(
     n_good: usize,
     bad_orbit: OrbitSource,
@@ -48,10 +49,12 @@ fn make_mixed_scenario(
     let traj = make_trajectory();
     let start = traj.start_time().to_scale(Tai);
     let end = traj.end_time().to_scale(Tai);
-    let mut spacecraft: Vec<Spacecraft> = (0..n_good)
-        .map(|i| Spacecraft::new(format!("sc{i}"), OrbitSource::Trajectory(traj.clone())))
-        .collect();
+    let mut spacecraft: Vec<Spacecraft> = Vec::with_capacity(n_good + 1);
     spacecraft.push(Spacecraft::new("bad", bad_orbit));
+    spacecraft.extend(
+        (0..n_good)
+            .map(|i| Spacecraft::new(format!("sc{i}"), OrbitSource::Trajectory(traj.clone()))),
+    );
     let scenario =
         DynScenario::new(start, end, DynOrigin::Earth, DynFrame::Icrf).with_spacecraft(&spacecraft);
     (scenario, DefaultRotationProvider)

--- a/crates/lox-analysis/tests/streaming_propagate.rs
+++ b/crates/lox-analysis/tests/streaming_propagate.rs
@@ -163,7 +163,7 @@ fn panic_in_propagator_surfaces_as_worker_panicked() {
     let mut s = arc_scenario.propagate_stream(arc_provider, 8, OnError::Continue);
     let mut found_panic = false;
     while let Some(item) = s.blocking_next() {
-        if let Err(ScenarioPropagateError::WorkerPanicked(id, _msg)) = item {
+        if let Err(ScenarioPropagateError::WorkerPanicked { id, message: _ }) = item {
             assert_eq!(id.as_str(), "bad");
             found_panic = true;
         }

--- a/crates/lox-analysis/tests/streaming_propagate.rs
+++ b/crates/lox-analysis/tests/streaming_propagate.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use lox_analysis::assets::{DynScenario, Spacecraft};
+use lox_analysis::assets::{DynScenario, ScenarioPropagateError, Spacecraft};
 use lox_frames::DynFrame;
 use lox_frames::providers::DefaultRotationProvider;
 use lox_orbits::orbits::DynTrajectory;
@@ -31,6 +31,25 @@ fn make_scenario(n: usize) -> (DynScenario, DefaultRotationProvider) {
     let spacecraft: Vec<Spacecraft> = (0..n)
         .map(|i| Spacecraft::new(format!("sc{i}"), OrbitSource::Trajectory(traj.clone())))
         .collect();
+    let scenario =
+        DynScenario::new(start, end, DynOrigin::Earth, DynFrame::Icrf).with_spacecraft(&spacecraft);
+    (scenario, DefaultRotationProvider)
+}
+
+/// Build a scenario with `n_good` healthy spacecraft plus one spacecraft using
+/// `bad_orbit` as its orbit source. The bad spacecraft has id `"bad"`.
+fn make_mixed_scenario(
+    n_good: usize,
+    bad_orbit: OrbitSource,
+) -> (DynScenario, DefaultRotationProvider) {
+    use lox_bodies::DynOrigin;
+    let traj = make_trajectory();
+    let start = traj.start_time().to_scale(Tai);
+    let end = traj.end_time().to_scale(Tai);
+    let mut spacecraft: Vec<Spacecraft> = (0..n_good)
+        .map(|i| Spacecraft::new(format!("sc{i}"), OrbitSource::Trajectory(traj.clone())))
+        .collect();
+    spacecraft.push(Spacecraft::new("bad", bad_orbit));
     let scenario =
         DynScenario::new(start, end, DynOrigin::Earth, DynFrame::Icrf).with_spacecraft(&spacecraft);
     (scenario, DefaultRotationProvider)
@@ -83,4 +102,71 @@ fn drop_stops_workers() {
     // Give rayon a moment to observe cancellation.
     std::thread::sleep(Duration::from_millis(100));
     assert!(token.is_cancelled());
+}
+
+#[test]
+fn continue_yields_per_spacecraft_errors() {
+    // One spacecraft has a deliberately failing orbit source; N-1 are healthy.
+    // Under OnError::Continue, we expect exactly one Err and N-1 Ok results.
+    let n_good = 3;
+    let bad_orbit = OrbitSource::TestError("injected error".to_string());
+    let (scenario, provider) = make_mixed_scenario(n_good, bad_orbit);
+    let arc_scenario = Arc::new(scenario);
+    let arc_provider = Arc::new(provider);
+
+    let mut s = arc_scenario.propagate_stream(arc_provider, 8, OnError::Continue);
+    let mut oks = 0usize;
+    let mut errs = 0usize;
+    while let Some(item) = s.blocking_next() {
+        match item {
+            Ok(_) => oks += 1,
+            Err(_) => errs += 1,
+        }
+    }
+    assert_eq!(errs, 1);
+    assert_eq!(oks, n_good);
+}
+
+#[test]
+fn abort_terminates_after_first_error() {
+    // One spacecraft fails; rest are healthy. Under OnError::Abort the stream
+    // should terminate early — fewer than total OK results will be emitted.
+    let total_spacecraft = 10_000;
+    let n_good = total_spacecraft - 1;
+    let bad_orbit = OrbitSource::TestError("abort trigger".to_string());
+    let (scenario, provider) = make_mixed_scenario(n_good, bad_orbit);
+    let arc_scenario = Arc::new(scenario);
+    let arc_provider = Arc::new(provider);
+
+    let mut s = arc_scenario.propagate_stream(arc_provider, 8, OnError::Abort);
+    let mut errs = 0usize;
+    let mut oks = 0usize;
+    while let Some(item) = s.blocking_next() {
+        match item {
+            Ok(_) => oks += 1,
+            Err(_) => errs += 1,
+        }
+    }
+    assert!(errs >= 1);
+    assert!(oks < n_good);
+}
+
+#[test]
+fn panic_in_propagator_surfaces_as_worker_panicked() {
+    // One spacecraft's orbit source panics during propagation. Verify the
+    // panic is converted to ScenarioPropagateError::WorkerPanicked.
+    let panicking_orbit = OrbitSource::TestPanic("test panic".to_string());
+    let (scenario, provider) = make_mixed_scenario(2, panicking_orbit);
+    let arc_scenario = Arc::new(scenario);
+    let arc_provider = Arc::new(provider);
+
+    let mut s = arc_scenario.propagate_stream(arc_provider, 8, OnError::Continue);
+    let mut found_panic = false;
+    while let Some(item) = s.blocking_next() {
+        if let Err(ScenarioPropagateError::WorkerPanicked(id, _msg)) = item {
+            assert_eq!(id.as_str(), "bad");
+            found_panic = true;
+        }
+    }
+    assert!(found_panic, "expected one WorkerPanicked error");
 }

--- a/crates/lox-analysis/tests/streaming_propagate.rs
+++ b/crates/lox-analysis/tests/streaming_propagate.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg(feature = "stream")]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/lox-analysis/tests/streaming_visibility.rs
+++ b/crates/lox-analysis/tests/streaming_visibility.rs
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use lox_analysis::assets::{AssetId, GroundStation, Scenario, Spacecraft};
+use lox_analysis::visibility::{ElevationMask, PairResult, PairType, VisibilityAnalysis};
+use lox_bodies::DynOrigin;
+use lox_core::coords::LonLatAlt;
+use lox_ephem::spk::parser::Spk;
+use lox_frames::DynFrame;
+use lox_orbits::ground::GroundLocation;
+use lox_orbits::orbits::{DynTrajectory, Ensemble, Trajectory};
+use lox_orbits::propagators::OrbitSource;
+use lox_stream::OnError;
+use lox_test_utils::{data_file, read_data_file};
+use lox_time::intervals::TimeInterval;
+use lox_time::time_scales::Tai;
+
+fn make_trajectory() -> DynTrajectory {
+    DynTrajectory::from_csv_dyn(
+        &read_data_file("trajectory_lunar.csv"),
+        DynOrigin::Earth,
+        DynFrame::Icrf,
+    )
+    .unwrap()
+}
+
+fn make_ground_station(id: &str) -> GroundStation {
+    let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
+    let loc = GroundLocation::try_new(coords, DynOrigin::Earth).unwrap();
+    let mask = ElevationMask::with_fixed_elevation(0.0);
+    GroundStation::new(id, loc, mask)
+}
+
+fn make_spacecraft(id: &str, traj: DynTrajectory) -> Spacecraft {
+    Spacecraft::new(id, OrbitSource::Trajectory(traj))
+}
+
+fn make_ensemble(spacecraft: &[Spacecraft]) -> Ensemble<AssetId, Tai, DynOrigin, DynFrame> {
+    let mut map = HashMap::new();
+    for sc in spacecraft {
+        if let OrbitSource::Trajectory(traj) = sc.orbit() {
+            let (epoch, origin, frame, data) = traj.clone().into_parts();
+            let typed = Trajectory::from_parts(epoch.with_scale(Tai), origin, frame, data);
+            map.insert(sc.id().clone(), typed);
+        }
+    }
+    Ensemble::new(map)
+}
+
+fn make_scenario(
+    ground_stations: &[GroundStation],
+    spacecraft: &[Spacecraft],
+    traj: &DynTrajectory,
+) -> Scenario<DynOrigin, DynFrame> {
+    let start = traj.start_time().to_scale(Tai);
+    let end = traj.end_time().to_scale(Tai);
+    Scenario::new(start, end, DynOrigin::Earth, DynFrame::Icrf)
+        .with_ground_stations(ground_stations)
+        .with_spacecraft(spacecraft)
+}
+
+fn ephemeris() -> Spk {
+    Spk::from_file(data_file("spice/de440s.bsp")).unwrap()
+}
+
+#[test]
+fn streamed_results_equal_batch() {
+    let traj = make_trajectory();
+    let gs = make_ground_station("cebreros");
+    let sc = make_spacecraft("lunar", traj.clone());
+    let ground_assets = [gs];
+    let space_assets = [sc];
+    let scenario = make_scenario(&ground_assets, &space_assets, &traj);
+    let ensemble = make_ensemble(&space_assets);
+    let spk = ephemeris();
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+    let arc_ephemeris = Arc::new(spk);
+
+    let analysis_batch = VisibilityAnalysis::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        arc_ephemeris.as_ref(),
+    );
+    let batch = analysis_batch.compute().unwrap();
+
+    let analysis_stream = VisibilityAnalysis::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        arc_ephemeris.as_ref(),
+    );
+    let mut s = analysis_stream.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        arc_ephemeris.clone(),
+        8,
+        OnError::Continue,
+    );
+
+    let mut streamed: HashMap<(AssetId, AssetId), Vec<TimeInterval<Tai>>> = HashMap::new();
+    while let Some(item) = s.blocking_next() {
+        let PairResult {
+            id1,
+            id2,
+            intervals,
+            ..
+        } = item.unwrap();
+        streamed.insert((id1, id2), intervals);
+    }
+
+    assert_eq!(streamed.len(), batch.num_pairs());
+    for ((id1, id2), intervals) in streamed {
+        let batch_iv = batch.intervals_for(&id1, &id2).expect("missing in batch");
+        assert_eq!(intervals.len(), batch_iv.len());
+    }
+}
+
+#[test]
+fn filter_excludes_unwanted_pairs() {
+    // 1 ground station + 4 spacecraft. Filter allows only "sc1" and "sc2".
+    let traj = make_trajectory();
+    let gs = make_ground_station("gs1");
+    let sc1 = make_spacecraft("sc1", traj.clone());
+    let sc2 = make_spacecraft("sc2", traj.clone());
+    let sc3 = make_spacecraft("sc3", traj.clone());
+    let sc4 = make_spacecraft("sc4", traj.clone());
+    let ground_assets = [gs];
+    let space_assets = [sc1, sc2, sc3, sc4];
+    let scenario = make_scenario(&ground_assets, &space_assets, &traj);
+    let ensemble = make_ensemble(&space_assets);
+    let spk = ephemeris();
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+    let arc_ephemeris = Arc::new(spk);
+
+    let analysis = VisibilityAnalysis::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        arc_ephemeris.as_ref(),
+    )
+    .with_ground_space_filter(|_gs, sc| matches!(sc.id().as_str(), "sc1" | "sc2"));
+
+    let mut s = analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        arc_ephemeris.clone(),
+        8,
+        OnError::Continue,
+    );
+    let mut count = 0usize;
+    while let Some(item) = s.blocking_next() {
+        let _ = item.unwrap();
+        count += 1;
+    }
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn mixed_pair_types_interleave() {
+    // Scenario with both ground stations AND inter-satellite enabled.
+    let traj = make_trajectory();
+    let gs = make_ground_station("cebreros");
+    let sc1 = make_spacecraft("sc1", traj.clone());
+    let sc2 = make_spacecraft("sc2", traj.clone());
+    let ground_assets = [gs];
+    let space_assets = [sc1, sc2];
+    let scenario = make_scenario(&ground_assets, &space_assets, &traj);
+    let ensemble = make_ensemble(&space_assets);
+    let spk = ephemeris();
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+    let arc_ephemeris = Arc::new(spk);
+
+    let analysis = VisibilityAnalysis::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        arc_ephemeris.as_ref(),
+    )
+    .with_inter_satellite();
+
+    let mut s = analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        arc_ephemeris.clone(),
+        8,
+        OnError::Continue,
+    );
+
+    let mut saw_gs = false;
+    let mut saw_is = false;
+    while let Some(item) = s.blocking_next() {
+        let pr = item.unwrap();
+        match pr.pair_type {
+            PairType::GroundSpace => saw_gs = true,
+            PairType::InterSatellite => saw_is = true,
+        }
+    }
+    assert!(saw_gs);
+    assert!(saw_is);
+}

--- a/crates/lox-analysis/tests/streaming_visibility.rs
+++ b/crates/lox-analysis/tests/streaming_visibility.rs
@@ -205,3 +205,105 @@ fn mixed_pair_types_interleave() {
     assert!(saw_gs);
     assert!(saw_is);
 }
+
+#[test]
+fn drop_stops_workers() {
+    use std::time::Duration;
+
+    // Use a scenario with 2 spacecraft and an inter-satellite check enabled so
+    // there is at least something to compute; we drop the stream immediately.
+    let traj = make_trajectory();
+    let gs = make_ground_station("cebreros");
+    let sc1 = make_spacecraft("sc1", traj.clone());
+    let sc2 = make_spacecraft("sc2", traj.clone());
+    let ground_assets = [gs];
+    let space_assets = [sc1, sc2];
+    let scenario = make_scenario(&ground_assets, &space_assets, &traj);
+    let ensemble = make_ensemble(&space_assets);
+    let spk = ephemeris();
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+    let arc_ephemeris = Arc::new(spk);
+
+    let analysis = VisibilityAnalysis::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        arc_ephemeris.as_ref(),
+    )
+    .with_inter_satellite();
+
+    let s = analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        arc_ephemeris.clone(),
+        4,
+        OnError::Continue,
+    );
+    let token = s.token();
+    drop(s);
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(token.is_cancelled());
+}
+
+// A test-only ephemeris implementation that panics on every state lookup.
+struct PanickingEphemeris;
+
+impl lox_ephem::Ephemeris for PanickingEphemeris {
+    type Error = std::convert::Infallible;
+
+    fn state<O1: lox_bodies::Origin, O2: lox_bodies::Origin>(
+        &self,
+        _time: lox_time::Time<lox_time::time_scales::Tdb>,
+        _origin: O1,
+        _target: O2,
+    ) -> Result<lox_core::coords::Cartesian, Self::Error> {
+        panic!("injected ephemeris panic");
+    }
+}
+
+#[test]
+fn panic_in_detector_surfaces_as_worker_panicked() {
+    use lox_analysis::visibility::VisibilityError;
+
+    // Build a scenario with one gs + one spacecraft, using a PanickingEphemeris
+    // with an occulting body so the ephemeris is actually invoked during detection.
+    let traj = make_trajectory();
+    let gs = make_ground_station("cebreros");
+    let sc = make_spacecraft("lunar", traj.clone());
+    let ground_assets = [gs];
+    let space_assets = [sc];
+    let scenario = make_scenario(&ground_assets, &space_assets, &traj);
+    let ensemble = make_ensemble(&space_assets);
+
+    let arc_scenario = Arc::new(scenario);
+    let arc_ensemble = Arc::new(ensemble);
+    let arc_ephemeris = Arc::new(PanickingEphemeris);
+
+    let analysis = VisibilityAnalysis::new(
+        arc_scenario.as_ref(),
+        arc_ensemble.as_ref(),
+        arc_ephemeris.as_ref(),
+    )
+    // With Moon as occulting body, the ephemeris is queried during LOS detection.
+    .with_occulting_bodies(vec![DynOrigin::Moon]);
+
+    let mut s = analysis.compute_stream(
+        arc_scenario.clone(),
+        arc_ensemble.clone(),
+        arc_ephemeris.clone(),
+        8,
+        OnError::Continue,
+    );
+
+    let mut found_panic = false;
+    while let Some(item) = s.blocking_next() {
+        if let Err(VisibilityError::WorkerPanicked(_, _, _)) = item {
+            found_panic = true;
+        }
+    }
+    assert!(
+        found_panic,
+        "expected WorkerPanicked error from panicking ephemeris"
+    );
+}

--- a/crates/lox-analysis/tests/streaming_visibility.rs
+++ b/crates/lox-analysis/tests/streaming_visibility.rs
@@ -298,7 +298,7 @@ fn panic_in_detector_surfaces_as_worker_panicked() {
 
     let mut found_panic = false;
     while let Some(item) = s.blocking_next() {
-        if let Err(VisibilityError::WorkerPanicked(_, _, _)) = item {
+        if let Err(VisibilityError::WorkerPanicked { .. }) = item {
             found_panic = true;
         }
     }

--- a/crates/lox-analysis/tests/streaming_visibility.rs
+++ b/crates/lox-analysis/tests/streaming_visibility.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+#![cfg(feature = "stream")]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/lox-analysis/tests/streaming_visibility.rs
+++ b/crates/lox-analysis/tests/streaming_visibility.rs
@@ -84,18 +84,12 @@ fn streamed_results_equal_batch() {
     let arc_ensemble = Arc::new(ensemble);
     let arc_ephemeris = Arc::new(spk);
 
-    let analysis_batch = VisibilityAnalysis::new(
-        arc_scenario.as_ref(),
-        arc_ensemble.as_ref(),
-        arc_ephemeris.as_ref(),
-    );
+    let analysis_batch = VisibilityAnalysis::new(arc_scenario.as_ref(), arc_ensemble.as_ref())
+        .with_occulting_bodies(arc_ephemeris.as_ref(), vec![]);
     let batch = analysis_batch.compute().unwrap();
 
-    let analysis_stream = VisibilityAnalysis::new(
-        arc_scenario.as_ref(),
-        arc_ensemble.as_ref(),
-        arc_ephemeris.as_ref(),
-    );
+    let analysis_stream = VisibilityAnalysis::new(arc_scenario.as_ref(), arc_ensemble.as_ref())
+        .with_occulting_bodies(arc_ephemeris.as_ref(), vec![]);
     let mut s = analysis_stream.compute_stream(
         arc_scenario.clone(),
         arc_ensemble.clone(),
@@ -141,12 +135,9 @@ fn filter_excludes_unwanted_pairs() {
     let arc_ensemble = Arc::new(ensemble);
     let arc_ephemeris = Arc::new(spk);
 
-    let analysis = VisibilityAnalysis::new(
-        arc_scenario.as_ref(),
-        arc_ensemble.as_ref(),
-        arc_ephemeris.as_ref(),
-    )
-    .with_ground_space_filter(|_gs, sc| matches!(sc.id().as_str(), "sc1" | "sc2"));
+    let analysis = VisibilityAnalysis::new(arc_scenario.as_ref(), arc_ensemble.as_ref())
+        .with_occulting_bodies(arc_ephemeris.as_ref(), vec![])
+        .with_ground_space_filter(|_gs, sc| matches!(sc.id().as_str(), "sc1" | "sc2"));
 
     let mut s = analysis.compute_stream(
         arc_scenario.clone(),
@@ -180,12 +171,9 @@ fn mixed_pair_types_interleave() {
     let arc_ensemble = Arc::new(ensemble);
     let arc_ephemeris = Arc::new(spk);
 
-    let analysis = VisibilityAnalysis::new(
-        arc_scenario.as_ref(),
-        arc_ensemble.as_ref(),
-        arc_ephemeris.as_ref(),
-    )
-    .with_inter_satellite();
+    let analysis = VisibilityAnalysis::new(arc_scenario.as_ref(), arc_ensemble.as_ref())
+        .with_occulting_bodies(arc_ephemeris.as_ref(), vec![])
+        .with_inter_satellite();
 
     let mut s = analysis.compute_stream(
         arc_scenario.clone(),
@@ -228,12 +216,9 @@ fn drop_stops_workers() {
     let arc_ensemble = Arc::new(ensemble);
     let arc_ephemeris = Arc::new(spk);
 
-    let analysis = VisibilityAnalysis::new(
-        arc_scenario.as_ref(),
-        arc_ensemble.as_ref(),
-        arc_ephemeris.as_ref(),
-    )
-    .with_inter_satellite();
+    let analysis = VisibilityAnalysis::new(arc_scenario.as_ref(), arc_ensemble.as_ref())
+        .with_occulting_bodies(arc_ephemeris.as_ref(), vec![])
+        .with_inter_satellite();
 
     let s = analysis.compute_stream(
         arc_scenario.clone(),
@@ -282,13 +267,9 @@ fn panic_in_detector_surfaces_as_worker_panicked() {
     let arc_ensemble = Arc::new(ensemble);
     let arc_ephemeris = Arc::new(PanickingEphemeris);
 
-    let analysis = VisibilityAnalysis::new(
-        arc_scenario.as_ref(),
-        arc_ensemble.as_ref(),
-        arc_ephemeris.as_ref(),
-    )
     // With Moon as occulting body, the ephemeris is queried during LOS detection.
-    .with_occulting_bodies(vec![DynOrigin::Moon]);
+    let analysis = VisibilityAnalysis::new(arc_scenario.as_ref(), arc_ensemble.as_ref())
+        .with_occulting_bodies(arc_ephemeris.as_ref(), vec![DynOrigin::Moon]);
 
     let mut s = analysis.compute_stream(
         arc_scenario.clone(),

--- a/crates/lox-orbits/Cargo.toml
+++ b/crates/lox-orbits/Cargo.toml
@@ -48,6 +48,7 @@ serde = [
   "lox-time/serde",
   "sgp4/serde",
 ]
+test-utils = []
 
 [lib]
 doctest = false

--- a/crates/lox-orbits/src/propagators.rs
+++ b/crates/lox-orbits/src/propagators.rs
@@ -84,6 +84,20 @@ pub enum OrbitSource {
     J4(DynJ4Propagator),
     /// Pre-computed trajectory used as-is.
     Trajectory(DynTrajectory),
+    /// Test-only variant that panics when propagated.
+    ///
+    /// Only available with the `test-utils` feature; used to exercise
+    /// `catch_unwind` paths in streaming propagation.
+    #[cfg(feature = "test-utils")]
+    #[doc(hidden)]
+    TestPanic(String),
+    /// Test-only variant that returns a propagation error.
+    ///
+    /// Only available with the `test-utils` feature; used to exercise
+    /// error-policy paths in streaming propagation.
+    #[cfg(feature = "test-utils")]
+    #[doc(hidden)]
+    TestError(String),
 }
 
 /// Errors that can occur when propagating an [`OrbitSource`].
@@ -104,6 +118,11 @@ pub enum PropagateError {
     /// J4 propagation error.
     #[error(transparent)]
     J4(#[from] J4Error),
+    /// Test-only error variant.
+    #[cfg(feature = "test-utils")]
+    #[doc(hidden)]
+    #[error("test error: {0}")]
+    TestError(String),
 }
 
 impl OrbitSource {
@@ -127,6 +146,10 @@ impl OrbitSource {
             Self::J2(p) => Ok(Propagator::propagate(p, interval)?),
             Self::J4(p) => Ok(Propagator::propagate(p, interval)?),
             Self::Trajectory(t) => Ok(t.clone()),
+            #[cfg(feature = "test-utils")]
+            Self::TestPanic(msg) => panic!("{}", msg),
+            #[cfg(feature = "test-utils")]
+            Self::TestError(msg) => Err(PropagateError::TestError(msg.clone())),
         }
     }
 }

--- a/crates/lox-stream/Cargo.toml
+++ b/crates/lox-stream/Cargo.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+[package]
+name = "lox-stream"
+description = "Streaming primitive for parallel work backed by rayon and async-channel"
+version = "0.1.0-alpha.1"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+async-channel.workspace = true
+futures-core.workspace = true
+rayon.workspace = true
+
+[dev-dependencies]
+futures.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/lox-stream/Cargo.toml
+++ b/crates/lox-stream/Cargo.toml
@@ -21,5 +21,9 @@ futures-core.workspace = true
 rayon.workspace = true
 
 [dev-dependencies]
+axum.workspace = true
 futures.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tower.workspace = true

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -1,3 +1,87 @@
 // SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
 //
 // SPDX-License-Identifier: MPL-2.0
+
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use crate::cancellation::CancellationToken;
+use crate::error::OnError;
+use crate::stream::Stream;
+
+/// Spawns a parallel pipeline over `items`. Each input is passed to `work`
+/// on a rayon worker; results are streamed back in completion order.
+///
+/// `capacity` is the bounded channel capacity — when the buffer is full,
+/// producers block, applying backpressure to slow consumers.
+///
+/// `on_error` controls whether per-unit errors abort the remaining work or
+/// are emitted as `Err` items while the stream continues.
+pub fn par_stream<I, T, E, F>(items: I, capacity: usize, on_error: OnError, work: F) -> Stream<T, E>
+where
+    I: IntoParallelIterator + Send + 'static,
+    I::Item: Send,
+    T: Send + 'static,
+    E: Send + 'static,
+    F: Fn(I::Item, &CancellationToken) -> Result<T, E> + Send + Sync + 'static,
+{
+    let (tx, rx) = async_channel::bounded(capacity);
+    let token = CancellationToken::new();
+    let work_token = token.clone();
+
+    rayon::spawn(move || {
+        items.into_par_iter().for_each(|item| {
+            if work_token.is_cancelled() {
+                return;
+            }
+            let result = work(item, &work_token);
+            let is_err = result.is_err();
+            let _ = tx.send_blocking(result);
+            if is_err && matches!(on_error, OnError::Abort) {
+                work_token.cancel();
+            }
+        });
+    });
+
+    Stream { rx, token }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path_yields_all_results() {
+        let s = par_stream(0..100, 16, OnError::Continue, |i, _| Ok::<i32, ()>(i * 2));
+        let collected: Vec<i32> = s
+            .collect_blocking()
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
+        let mut sorted = collected;
+        sorted.sort();
+        let expected: Vec<i32> = (0..100).map(|i| i * 2).collect();
+        assert_eq!(sorted, expected);
+    }
+
+    #[test]
+    fn empty_input_terminates_immediately() {
+        let mut s = par_stream(0..0, 4, OnError::Continue, |i, _| Ok::<i32, ()>(i));
+        assert_eq!(s.blocking_next(), None);
+    }
+
+    // ----- helper -----
+
+    trait CollectBlocking<T> {
+        fn collect_blocking(self) -> Vec<T>;
+    }
+
+    impl<T, E> CollectBlocking<Result<T, E>> for Stream<T, E> {
+        fn collect_blocking(mut self) -> Vec<Result<T, E>> {
+            let mut v = Vec::new();
+            while let Some(item) = self.blocking_next() {
+                v.push(item);
+            }
+            v
+        }
+    }
+}

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -93,6 +93,25 @@ mod tests {
         assert_ne!(order[0], 0, "slow unit arrived first: {order:?}");
     }
 
+    #[test]
+    fn continue_yields_every_error_then_finishes() {
+        // Fail when i % 7 == 6. Inputs 0..100 → i ∈ {6,13,20,27,34,41,48,55,62,69,76,83,90,97}
+        // = 14 errors, 86 oks.
+        let s = par_stream(0..100, 16, OnError::Continue, |i, _| {
+            if i % 7 == 6 {
+                Err::<i32, i32>(i)
+            } else {
+                Ok::<i32, i32>(i)
+            }
+        });
+
+        let items: Vec<_> = s.collect_blocking();
+        let errs: Vec<_> = items.iter().filter_map(|r| r.as_ref().err()).collect();
+        let oks: Vec<_> = items.iter().filter_map(|r| r.as_ref().ok()).collect();
+        assert_eq!(errs.len(), 14);
+        assert_eq!(oks.len(), 86);
+    }
+
     // ----- helper -----
 
     trait CollectBlocking<T> {

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -140,6 +140,74 @@ mod tests {
         );
     }
 
+    #[test]
+    fn drop_cancels_in_flight_workers() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let c = invocations.clone();
+
+        let mut s = par_stream(0..10_000_usize, 4, OnError::Continue, move |i, _| {
+            c.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(20));
+            Ok::<usize, ()>(i)
+        });
+
+        // Receive one item then drop.
+        let _ = s.blocking_next();
+        drop(s);
+
+        // Give workers time to observe the cancellation.
+        std::thread::sleep(Duration::from_millis(200));
+        let after_drop = invocations.load(Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(500));
+        let later = invocations.load(Ordering::SeqCst);
+        // Bounded growth: at most one extra unit per worker.
+        let max_growth = rayon::current_num_threads();
+        assert!(
+            later - after_drop <= max_growth,
+            "growth {} > {} after drop",
+            later - after_drop,
+            max_growth,
+        );
+    }
+
+    #[test]
+    fn explicit_cancel_stops_workers() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let c = invocations.clone();
+
+        let mut s = par_stream(0..10_000_usize, 4, OnError::Continue, move |i, _| {
+            c.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(20));
+            Ok::<usize, ()>(i)
+        });
+
+        let _ = s.blocking_next();
+        s.cancel();
+
+        std::thread::sleep(Duration::from_millis(200));
+        let after_cancel = invocations.load(Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(500));
+        let later = invocations.load(Ordering::SeqCst);
+        let max_growth = rayon::current_num_threads();
+        assert!(
+            later - after_cancel <= max_growth,
+            "growth {} > {} after cancel",
+            later - after_cancel,
+            max_growth,
+        );
+
+        // Subsequent poll terminates cleanly.
+        let _drained: Vec<_> = (&mut s).collect_blocking_inplace();
+    }
+
     // ----- helper -----
 
     trait CollectBlocking<T> {
@@ -148,6 +216,20 @@ mod tests {
 
     impl<T, E> CollectBlocking<Result<T, E>> for Stream<T, E> {
         fn collect_blocking(mut self) -> Vec<Result<T, E>> {
+            let mut v = Vec::new();
+            while let Some(item) = self.blocking_next() {
+                v.push(item);
+            }
+            v
+        }
+    }
+
+    // ----- additional helper for in-place draining -----
+    trait CollectBlockingInplace<T> {
+        fn collect_blocking_inplace(self) -> Vec<T>;
+    }
+    impl<T, E> CollectBlockingInplace<Result<T, E>> for &mut Stream<T, E> {
+        fn collect_blocking_inplace(self) -> Vec<Result<T, E>> {
             let mut v = Vec::new();
             while let Some(item) = self.blocking_next() {
                 v.push(item);

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -69,6 +69,30 @@ mod tests {
         assert_eq!(s.blocking_next(), None);
     }
 
+    #[test]
+    fn fast_units_arrive_before_slow_ones() {
+        use std::time::Duration;
+
+        // Index 0 sleeps 200ms; indices 1..=4 sleep 10ms each. We expect the
+        // four fast indices to arrive before index 0.
+        let s = par_stream(0..5, 8, OnError::Continue, |i, _| {
+            let dur = if i == 0 {
+                Duration::from_millis(200)
+            } else {
+                Duration::from_millis(10)
+            };
+            std::thread::sleep(dur);
+            Ok::<i32, ()>(i)
+        });
+
+        let mut order = Vec::new();
+        for item in s.collect_blocking() {
+            order.push(item.unwrap());
+        }
+        // index 0 must not be the first item to arrive
+        assert_ne!(order[0], 0, "slow unit arrived first: {order:?}");
+    }
+
     // ----- helper -----
 
     trait CollectBlocking<T> {

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -208,6 +208,37 @@ mod tests {
         let _drained: Vec<_> = (&mut s).collect_blocking_inplace();
     }
 
+    #[test]
+    fn capacity_one_holds_producer() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let c = invocations.clone();
+
+        // capacity = 1, slow consumer (sleeps between recvs). After receiving
+        // one item, at most `1 + worker_count` units should have run.
+        let mut s = par_stream(0..1_000_usize, 1, OnError::Continue, move |i, _| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Ok::<usize, ()>(i)
+        });
+
+        // Receive one item and then sleep, letting workers possibly fill the buffer.
+        let _ = s.blocking_next();
+        std::thread::sleep(Duration::from_millis(100));
+
+        let in_flight_bound = 1 + rayon::current_num_threads() + 2; // small slop
+        let observed = invocations.load(Ordering::SeqCst);
+        assert!(
+            observed <= in_flight_bound,
+            "expected backpressure to bound invocations to ≤ {in_flight_bound}, saw {observed}",
+        );
+
+        // Drop to clean up.
+        drop(s);
+    }
+
     // ----- helper -----
 
     trait CollectBlocking<T> {

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -130,10 +130,11 @@ mod tests {
         let items: Vec<_> = s.collect_blocking();
         let errs = items.iter().filter(|r| r.is_err()).count();
         assert!(errs >= 1);
-        // Upper bound: roughly the rayon worker count + a small slop. We
-        // assert << 10_000 to catch a missing cancel().
+        // Upper bound: worker count with generous slop. We assert << 10_000
+        // to catch a missing cancel(); the multiplier is generous to absorb
+        // noise from concurrent test processes sharing the rayon pool.
         let total = invocations.load(Ordering::SeqCst);
-        let max_expected = rayon::current_num_threads() * 4;
+        let max_expected = rayon::current_num_threads() * 16;
         assert!(
             total <= max_expected,
             "expected ≤ {max_expected} invocations after abort, got {total}"

--- a/crates/lox-stream/src/builder.rs
+++ b/crates/lox-stream/src/builder.rs
@@ -112,6 +112,34 @@ mod tests {
         assert_eq!(oks.len(), 86);
     }
 
+    #[test]
+    fn abort_terminates_after_bounded_concurrent_errors() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let c = invocations.clone();
+
+        // One bad input triggers Abort; over 10_000 inputs, no more than
+        // worker_count units should observably run.
+        let s = par_stream(0..10_000_usize, 16, OnError::Abort, move |i, _| {
+            c.fetch_add(1, Ordering::SeqCst);
+            if i == 0 { Err::<usize, ()>(()) } else { Ok(i) }
+        });
+
+        let items: Vec<_> = s.collect_blocking();
+        let errs = items.iter().filter(|r| r.is_err()).count();
+        assert!(errs >= 1);
+        // Upper bound: roughly the rayon worker count + a small slop. We
+        // assert << 10_000 to catch a missing cancel().
+        let total = invocations.load(Ordering::SeqCst);
+        let max_expected = rayon::current_num_threads() * 4;
+        assert!(
+            total <= max_expected,
+            "expected ≤ {max_expected} invocations after abort, got {total}"
+        );
+    }
+
     // ----- helper -----
 
     trait CollectBlocking<T> {

--- a/crates/lox-stream/src/cancellation.rs
+++ b/crates/lox-stream/src/cancellation.rs
@@ -1,3 +1,55 @@
 // SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
 //
 // SPDX-License-Identifier: MPL-2.0
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A cooperative cancellation flag shared between a producer and consumer.
+///
+/// Cloning a token yields another handle referring to the same flag.
+#[derive(Clone, Default)]
+pub struct CancellationToken(Arc<AtomicBool>);
+
+impl CancellationToken {
+    /// Creates a fresh, uncancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Flips the flag.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// Returns whether the flag has been flipped.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_token_is_not_cancelled() {
+        let t = CancellationToken::new();
+        assert!(!t.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_flips_the_flag() {
+        let t = CancellationToken::new();
+        t.cancel();
+        assert!(t.is_cancelled());
+    }
+
+    #[test]
+    fn clones_share_the_flag() {
+        let a = CancellationToken::new();
+        let b = a.clone();
+        a.cancel();
+        assert!(b.is_cancelled());
+    }
+}

--- a/crates/lox-stream/src/cancellation.rs
+++ b/crates/lox-stream/src/cancellation.rs
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0

--- a/crates/lox-stream/src/cancellation.rs
+++ b/crates/lox-stream/src/cancellation.rs
@@ -5,9 +5,11 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// A cooperative cancellation flag shared between a producer and consumer.
+/// A cooperative cancellation flag.
 ///
-/// Cloning a token yields another handle referring to the same flag.
+/// Cloning a token produces a handle that shares the same cancellation state:
+/// cancelling any clone causes every other clone's
+/// [`is_cancelled`](Self::is_cancelled) to return `true`.
 #[derive(Clone, Default)]
 pub struct CancellationToken(Arc<AtomicBool>);
 
@@ -17,14 +19,15 @@ impl CancellationToken {
         Self::default()
     }
 
-    /// Flips the flag.
+    /// Signals cancellation. After this call, [`is_cancelled`](Self::is_cancelled)
+    /// returns `true` on every clone of this token.
     pub fn cancel(&self) {
-        self.0.store(true, Ordering::Release);
+        self.0.store(true, Ordering::Relaxed);
     }
 
-    /// Returns whether the flag has been flipped.
+    /// Returns `true` if this token has been cancelled.
     pub fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::Acquire)
+        self.0.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/lox-stream/src/error.rs
+++ b/crates/lox-stream/src/error.rs
@@ -1,3 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
 //
 // SPDX-License-Identifier: MPL-2.0
+
+/// Per-call policy for how a streamed pipeline reacts to per-unit errors.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum OnError {
+    /// Emit per-unit errors as `Err(e)` items but keep producing
+    /// subsequent items.
+    Continue,
+    /// On the first per-unit error, cancel all remaining work. Up to
+    /// `worker_count` concurrent errors may be observed before the stream
+    /// terminates.
+    Abort,
+}

--- a/crates/lox-stream/src/error.rs
+++ b/crates/lox-stream/src/error.rs
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0

--- a/crates/lox-stream/src/lib.rs
+++ b/crates/lox-stream/src/lib.rs
@@ -18,5 +18,5 @@ mod stream;
 
 // pub use builder::par_stream;
 pub use cancellation::CancellationToken;
-// pub use error::OnError;
+pub use error::OnError;
 // pub use stream::Stream;

--- a/crates/lox-stream/src/lib.rs
+++ b/crates/lox-stream/src/lib.rs
@@ -19,4 +19,4 @@ mod stream;
 // pub use builder::par_stream;
 pub use cancellation::CancellationToken;
 pub use error::OnError;
-// pub use stream::Stream;
+pub use stream::Stream;

--- a/crates/lox-stream/src/lib.rs
+++ b/crates/lox-stream/src/lib.rs
@@ -16,7 +16,7 @@ mod cancellation;
 mod error;
 mod stream;
 
-// pub use builder::par_stream;
+pub use builder::par_stream;
 pub use cancellation::CancellationToken;
 pub use error::OnError;
 pub use stream::Stream;

--- a/crates/lox-stream/src/lib.rs
+++ b/crates/lox-stream/src/lib.rs
@@ -17,6 +17,6 @@ mod error;
 mod stream;
 
 // pub use builder::par_stream;
-// pub use cancellation::CancellationToken;
+pub use cancellation::CancellationToken;
 // pub use error::OnError;
 // pub use stream::Stream;

--- a/crates/lox-stream/src/lib.rs
+++ b/crates/lox-stream/src/lib.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! Streaming primitive for parallel work.
+//!
+//! Provides a [`Stream`] type that delivers results from a rayon-driven
+//! producer in completion order. The stream implements
+//! [`futures_core::Stream`] for async consumers and offers
+//! [`Stream::blocking_next`] for sync callers.
+//!
+//! See the [`par_stream`] builder for the entry point.
+
+mod builder;
+mod cancellation;
+mod error;
+mod stream;
+
+// pub use builder::par_stream;
+// pub use cancellation::CancellationToken;
+// pub use error::OnError;
+// pub use stream::Stream;

--- a/crates/lox-stream/src/stream.rs
+++ b/crates/lox-stream/src/stream.rs
@@ -46,12 +46,11 @@ impl<T, E> futures_core::Stream for Stream<T, E> {
     }
 }
 
-// SAFETY: Stream never moves its Receiver after construction. The only place
-// the Receiver is touched mutably is inside `poll_next`, where we re-pin it
-// transiently via `Pin::new_unchecked`. Drop does not move rx. Treating rx
-// as a non-structural field is sound, so Stream itself is Unpin regardless
-// of whether Receiver is.
-unsafe impl<T, E> Unpin for Stream<T, E> {}
+// Stream treats `rx` as a non-structural field: we never move it after
+// construction, and `poll_next` only re-pins it transiently via
+// `Pin::new_unchecked`. Drop does not move `rx`. Therefore it is sound to
+// expose Stream as Unpin regardless of whether Receiver is.
+impl<T, E> Unpin for Stream<T, E> {}
 
 impl<T, E> Drop for Stream<T, E> {
     fn drop(&mut self) {

--- a/crates/lox-stream/src/stream.rs
+++ b/crates/lox-stream/src/stream.rs
@@ -39,12 +39,19 @@ impl<T, E> futures_core::Stream for Stream<T, E> {
     type Item = Result<T, E>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // SAFETY: we never move out of self or this.rx; structural pinning is
-        // valid here because Receiver's pin-projection is handled internally.
-        let this = unsafe { self.get_unchecked_mut() };
+        let this = self.get_mut();
+        // SAFETY: we never move `this.rx`. The transient pin obtained here
+        // lives only for this poll call, satisfying Receiver's pin contract.
         unsafe { Pin::new_unchecked(&mut this.rx) }.poll_next(cx)
     }
 }
+
+// SAFETY: Stream never moves its Receiver after construction. The only place
+// the Receiver is touched mutably is inside `poll_next`, where we re-pin it
+// transiently via `Pin::new_unchecked`. Drop does not move rx. Treating rx
+// as a non-structural field is sound, so Stream itself is Unpin regardless
+// of whether Receiver is.
+unsafe impl<T, E> Unpin for Stream<T, E> {}
 
 impl<T, E> Drop for Stream<T, E> {
     fn drop(&mut self) {
@@ -94,7 +101,7 @@ mod tests {
     async fn async_stream_delivers_in_order() {
         use futures::StreamExt;
 
-        let (tx, s) = make_stream::<i32, ()>();
+        let (tx, mut s) = make_stream::<i32, ()>();
         tokio::spawn(async move {
             tx.send(Ok(10)).await.unwrap();
             tx.send(Ok(20)).await.unwrap();
@@ -102,7 +109,6 @@ mod tests {
             drop(tx);
         });
 
-        futures::pin_mut!(s);
         let mut collected = Vec::new();
         while let Some(item) = s.next().await {
             collected.push(item.unwrap());

--- a/crates/lox-stream/src/stream.rs
+++ b/crates/lox-stream/src/stream.rs
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0

--- a/crates/lox-stream/src/stream.rs
+++ b/crates/lox-stream/src/stream.rs
@@ -89,4 +89,24 @@ mod tests {
         drop(s);
         assert!(t.is_cancelled());
     }
+
+    #[tokio::test]
+    async fn async_stream_delivers_in_order() {
+        use futures::StreamExt;
+
+        let (tx, s) = make_stream::<i32, ()>();
+        tokio::spawn(async move {
+            tx.send(Ok(10)).await.unwrap();
+            tx.send(Ok(20)).await.unwrap();
+            tx.send(Ok(30)).await.unwrap();
+            drop(tx);
+        });
+
+        futures::pin_mut!(s);
+        let mut collected = Vec::new();
+        while let Some(item) = s.next().await {
+            collected.push(item.unwrap());
+        }
+        assert_eq!(collected, vec![10, 20, 30]);
+    }
 }

--- a/crates/lox-stream/src/stream.rs
+++ b/crates/lox-stream/src/stream.rs
@@ -1,3 +1,92 @@
 // SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
 //
 // SPDX-License-Identifier: MPL-2.0
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::cancellation::CancellationToken;
+
+/// A stream of `Result<T, E>` items produced by a parallel pipeline.
+///
+/// Implements [`futures_core::Stream`] for async consumers; also provides
+/// [`Stream::blocking_next`] for sync callers.
+pub struct Stream<T, E> {
+    pub(crate) rx: async_channel::Receiver<Result<T, E>>,
+    pub(crate) token: CancellationToken,
+}
+
+impl<T, E> Stream<T, E> {
+    /// Returns a clone of the cancellation token associated with this stream.
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// Flips the cancellation flag. Workers will bail at their next unit
+    /// boundary. Items already in flight may still be delivered.
+    pub fn cancel(&self) {
+        self.token.cancel();
+    }
+
+    /// Synchronous pull. Blocks the current thread until the next item is
+    /// available or the stream is exhausted.
+    pub fn blocking_next(&mut self) -> Option<Result<T, E>> {
+        self.rx.recv_blocking().ok()
+    }
+}
+
+impl<T, E> futures_core::Stream for Stream<T, E> {
+    type Item = Result<T, E>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // SAFETY: we never move out of self or this.rx; structural pinning is
+        // valid here because Receiver's pin-projection is handled internally.
+        let this = unsafe { self.get_unchecked_mut() };
+        unsafe { Pin::new_unchecked(&mut this.rx) }.poll_next(cx)
+    }
+}
+
+impl<T, E> Drop for Stream<T, E> {
+    fn drop(&mut self) {
+        self.token.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_stream<T, E>() -> (async_channel::Sender<Result<T, E>>, Stream<T, E>) {
+        let (tx, rx) = async_channel::bounded(8);
+        let token = CancellationToken::new();
+        (tx, Stream { rx, token })
+    }
+
+    #[test]
+    fn blocking_next_returns_ok_items() {
+        let (tx, mut s) = make_stream::<i32, ()>();
+        tx.send_blocking(Ok(1)).unwrap();
+        tx.send_blocking(Ok(2)).unwrap();
+        drop(tx);
+        assert_eq!(s.blocking_next(), Some(Ok(1)));
+        assert_eq!(s.blocking_next(), Some(Ok(2)));
+        assert_eq!(s.blocking_next(), None);
+    }
+
+    #[test]
+    fn cancel_flips_the_token() {
+        let (_tx, s) = make_stream::<i32, ()>();
+        let t = s.token();
+        assert!(!t.is_cancelled());
+        s.cancel();
+        assert!(t.is_cancelled());
+    }
+
+    #[test]
+    fn drop_flips_the_token() {
+        let (_tx, s) = make_stream::<i32, ()>();
+        let t = s.token();
+        drop(s);
+        assert!(t.is_cancelled());
+    }
+}

--- a/crates/lox-stream/tests/http_disconnect.rs
+++ b/crates/lox-stream/tests/http_disconnect.rs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::State;
+use axum::response::sse::{Event, Sse};
+use axum::routing::get;
+use futures::StreamExt;
+use lox_stream::{OnError, par_stream};
+
+#[derive(Clone)]
+struct AppState {
+    counter: Arc<AtomicUsize>,
+}
+
+async fn stream_handler(
+    State(state): State<AppState>,
+) -> Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>> {
+    let counter = state.counter.clone();
+    let s = par_stream(0..10_000_usize, 16, OnError::Continue, move |i, _| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(50));
+        Ok::<usize, ()>(i)
+    });
+    Sse::new(s.map(|r| Ok(Event::default().data(format!("{}", r.unwrap())))))
+}
+
+#[tokio::test]
+#[ignore = "integration; flaky under CI thread contention"]
+async fn http_disconnect_cancels_work() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let state = AppState {
+        counter: counter.clone(),
+    };
+    let app = Router::new()
+        .route("/stream", get(stream_handler))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/stream"))
+        .send()
+        .await
+        .unwrap();
+    let mut bytes = resp.bytes_stream();
+    bytes.next().await; // receive one chunk
+    drop(bytes); // simulate browser disconnect
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let after_disconnect = counter.load(Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let later = counter.load(Ordering::SeqCst);
+
+    // After disconnect, growth should be bounded to roughly worker_count.
+    let max_growth = rayon::current_num_threads() * 2;
+    assert!(
+        later - after_disconnect <= max_growth,
+        "growth {} > {} after disconnect",
+        later - after_disconnect,
+        max_growth,
+    );
+}

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ coverage *FLAGS:
     uv run --no-project tools/coverage.py {{FLAGS}}
 
 lint-reuse *ARGS:
-    uvx reuse lint {{ARGS}}
+    git ls-files -z | xargs -0 uvx --from 'reuse[charset-normalizer]' reuse lint-file {{ARGS}}
 
 lint-clippy *ARGS:
     cargo clippy --all-features --all-targets {{ARGS}} -- -D warnings

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,7 @@ pre-push:
   parallel: true
   commands:
     reuse:
-      run: git ls-files -z | xargs -0 uvx reuse lint-file
+      run: just lint-reuse
     clippy:
       run: just lint-clippy
     rustfmt:

--- a/tools/add_spdx_headers.py
+++ b/tools/add_spdx_headers.py
@@ -15,7 +15,9 @@ LICENSE = "MPL-2.0"
 
 def files_without_header():
     try:
-        result = subprocess.check_output(["uvx", "reuse", "lint", "-j"])
+        result = subprocess.check_output(
+            ["uvx", "--from", "reuse[charset-normalizer]", "reuse", "lint", "-j"]
+        )
     except subprocess.CalledProcessError as exc:
         result = exc.output
 
@@ -50,7 +52,20 @@ def add_header(file, copyright):
     """Add SPDX header with current year to the file."""
     year = str(date.today().year)
     subprocess.call(
-        ["uvx", "reuse", "annotate", "-c", copyright, "-y", year, "-l", LICENSE, file]
+        [
+            "uvx",
+            "--from",
+            "reuse[charset-normalizer]",
+            "reuse",
+            "annotate",
+            "-c",
+            copyright,
+            "-y",
+            year,
+            "-l",
+            LICENSE,
+            file,
+        ]
     )
 
 


### PR DESCRIPTION
- **feat(lox-stream): bootstrap crate**
- **fix(lox-stream): sort workspace deps and pin versions**
- **feat(lox-stream): add CancellationToken**
- **refactor(lox-stream): relax atomic ordering and tighten docs**
- **feat(lox-stream): add OnError policy enum**
- **feat(lox-stream): add Stream with blocking_next, cancel, drop**
- **test(lox-stream): cover futures::Stream consumption**
- **refactor(lox-stream): mark Stream as Unpin for ergonomic async consumption**
- **fix(lox-stream): Unpin impl must be safe, not unsafe**
- **feat(lox-stream): add par_stream builder with happy-path coverage**
- **test(lox-stream): verify completion-order delivery**
- **test(lox-stream): verify OnError::Continue policy**
- **test(lox-stream): verify OnError::Abort policy**
- **test(lox-stream): verify drop/cancel propagation to workers**
- **test(lox-stream): verify bounded-channel backpressure**
- **feat(lox-analysis): add ScenarioPropagateError::WorkerPanicked**
- **refactor(lox-analysis): extract propagate_one helper**
- **feat(lox-analysis): add Scenario::propagate_stream**
- **test(lox-analysis): cover propagate_stream error policies and panic handling**
- **feat(lox-analysis): add VisibilityError::WorkerPanicked**
- **feat(lox-analysis): add Scenario::ground_station_by_id and spacecraft_by_id**
- **feat(lox-analysis): add VisibilityAnalysis::compute_stream**
- **test(lox-analysis): cover compute_stream drop and panic paths**
- **feat(lox-analysis): add AccessError::WorkerPanicked**
- **refactor(lox-analysis): extract access_one helper**
- **feat(lox-analysis): add AccessAnalysis::compute_stream for optical and SAR**
- **test(lox-stream): add http-disconnect cancellation smoke test**
- **refactor(lox-analysis): use struct-variant style for WorkerPanicked across all three errors**
