### PR TITLE
Lumped link budgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,7 @@ dependencies = [
  "lox-itur",
  "lox-test-utils",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/lox-comms/CHANGELOG.md
+++ b/crates/lox-comms/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -6,6 +12,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(lox-comms)* Antenna variants renamed: `Simple`/`Complex` → `Constant`/`Patterned` (inner structs follow: `ConstantAntenna`/`PatternedAntenna`)
+- *(lox-comms)* Receiver variants renamed: `Simple`/`Complex` → `NoiseTemperature`/`Cascade` (inner structs: `NoiseTempReceiver`/`CascadeReceiver`)
+- *(lox-comms)* `Transmitter` lifted from struct into an enum; original struct becomes `AmplifierTransmitter`
+- *(lox-comms)* `CommunicationSystem.antenna` is now `Option<Antenna>`; lumped (`Eirp`/`Gt`) variants pair with `None`
+- *(lox-comms)* `LinkStats::calculate` returns `Result<_, LinkBudgetError>` and takes a `bandwidth: Frequency` parameter (no longer takes `Channel`)
+- *(lox-comms)* `LinkStats` split: modulation-derived fields move to a new `ModulatedLinkStats` produced via `Channel::apply(link)`
+- *(lox-comms)* `LinkStats.carrier_rx_power` and `LinkStats.noise_power` are now `Option<Decibel>` (`None` for lumped-G/T receivers)
+- *(lox-comms)* Boltzmann constant updated to the SI-2019 exact value `1.380_649e-23`
+- *(lox-comms)* `Antenna`, `Transmitter`, `Receiver`, `AntennaPattern`, `Modulation`, `LinkDirection`, and `LinkBudgetError` marked `#[non_exhaustive]`
+
+### Added
+
+- *(lox-comms)* `EirpTransmitter` and `Transmitter::Eirp` lumped variant
+- *(lox-comms)* `GtReceiver` and `Receiver::Gt` lumped variant
+- *(lox-comms)* `LinkBudgetError` enum for validation failures
+- *(lox-comms)* `CommunicationSystem::eirp_only`, `gt_only`, `amplifier_with`, `receiver_with` tier constructors
+- *(lox-comms)* `Channel::apply(LinkStats) -> ModulatedLinkStats`
+- *(lox-comms)* `CommunicationSystem::eirp_at(angle)` and `gt_at(angle)` accessors
 
 ## [0.1.0-alpha.14](https://github.com/lox-space/lox/compare/lox-comms-v0.1.0-alpha.13...lox-comms-v0.1.0-alpha.14) - 2026-05-26
 

--- a/crates/lox-comms/Cargo.toml
+++ b/crates/lox-comms/Cargo.toml
@@ -19,12 +19,14 @@ readme = "README.md"
 [dependencies]
 lox-core = { workspace = true, features = ["std"] }
 lox-itur = { workspace = true }
-lox-test-utils = { workspace = true, features = ["derive"] }
 
 serde = { workspace = true, optional = true }
 
 [features]
 serde = ["dep:serde", "lox-core/serde", "lox-itur/serde"]
+
+[dev-dependencies]
+lox-test-utils = { workspace = true, features = ["derive"] }
 
 [lib]
 doctest = false

--- a/crates/lox-comms/Cargo.toml
+++ b/crates/lox-comms/Cargo.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 [dependencies]
 lox-core = { workspace = true, features = ["std"] }
 lox-itur = { workspace = true }
+thiserror = { workspace = true, features = ["std"] }
 
 serde = { workspace = true, optional = true }
 

--- a/crates/lox-comms/src/antenna.rs
+++ b/crates/lox-comms/src/antenna.rs
@@ -93,3 +93,72 @@ impl AntennaGain for Antenna {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use lox_core::glam::DVec3;
+    use lox_core::units::{Angle, Decibel, DecibelUnits, Distance, FrequencyUnits};
+    use lox_test_utils::assert_approx_eq;
+
+    use crate::pattern::{AntennaPattern, ParabolicPattern};
+
+    use super::*;
+
+    fn parabolic() -> PatternedAntenna {
+        PatternedAntenna {
+            pattern: AntennaPattern::Parabolic(ParabolicPattern::new(Distance::meters(0.98), 0.45)),
+            boresight: DVec3::Z,
+        }
+    }
+
+    #[test]
+    fn test_constant_antenna_gain_dispatch() {
+        let a = ConstantAntenna {
+            gain: 10.0.db(),
+            beamwidth: Angle::degrees(5.0),
+        };
+        let g = a.gain(29.0.ghz(), Angle::radians(0.0));
+        assert_approx_eq!(g.as_f64(), 10.0, atol <= 1e-10);
+        assert_approx_eq!(
+            a.beamwidth(29.0.ghz()).unwrap().to_degrees(),
+            5.0,
+            atol <= 1e-10
+        );
+    }
+
+    #[test]
+    fn test_patterned_antenna_gain_and_beamwidth() {
+        let a = parabolic();
+        let f = 29.0.ghz();
+        let peak = a.peak_gain(f);
+        let on_axis = a.gain(f, Angle::radians(0.0));
+        // On-axis gain equals peak gain
+        assert_approx_eq!(on_axis.as_f64(), peak.as_f64(), atol <= 1e-10);
+        // Beamwidth is defined for the parabolic pattern
+        assert!(a.beamwidth(f).is_some());
+    }
+
+    #[test]
+    fn test_antenna_enum_constant_dispatch() {
+        let a = Antenna::Constant(ConstantAntenna {
+            gain: Decibel::new(20.0),
+            beamwidth: Angle::degrees(2.0),
+        });
+        let g = a.gain(29.0.ghz(), Angle::radians(0.0));
+        assert_approx_eq!(g.as_f64(), 20.0, atol <= 1e-10);
+        assert_approx_eq!(
+            a.beamwidth(29.0.ghz()).unwrap().to_degrees(),
+            2.0,
+            atol <= 1e-10
+        );
+    }
+
+    #[test]
+    fn test_antenna_enum_patterned_dispatch() {
+        let a = Antenna::Patterned(parabolic());
+        let f = 29.0.ghz();
+        let on_axis = a.gain(f, Angle::radians(0.0));
+        assert!(on_axis.as_f64() > 40.0);
+        assert!(a.beamwidth(f).is_some());
+    }
+}

--- a/crates/lox-comms/src/antenna.rs
+++ b/crates/lox-comms/src/antenna.rs
@@ -19,7 +19,7 @@ pub trait AntennaGain {
     fn beamwidth(&self, frequency: Frequency) -> Option<Angle>;
 }
 
-/// A constant antenna with constant gain and beamwidth.
+/// Antenna with angle-independent gain and a nominal beamwidth.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConstantAntenna {

--- a/crates/lox-comms/src/antenna.rs
+++ b/crates/lox-comms/src/antenna.rs
@@ -19,17 +19,17 @@ pub trait AntennaGain {
     fn beamwidth(&self, frequency: Frequency) -> Option<Angle>;
 }
 
-/// A simple antenna with constant gain and beamwidth.
+/// A constant antenna with constant gain and beamwidth.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SimpleAntenna {
+pub struct ConstantAntenna {
     /// Peak gain in dBi.
     pub gain: Decibel,
     /// Half-power beamwidth.
     pub beamwidth: Angle,
 }
 
-impl AntennaGain for SimpleAntenna {
+impl AntennaGain for ConstantAntenna {
     fn gain(&self, _frequency: Frequency, _angle: Angle) -> Decibel {
         self.gain
     }
@@ -42,14 +42,14 @@ impl AntennaGain for SimpleAntenna {
 /// An antenna with a physics-based gain pattern and a boresight vector.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ComplexAntenna {
+pub struct PatternedAntenna {
     /// The gain pattern model.
     pub pattern: AntennaPattern,
     /// Boresight direction vector (unit vector in the antenna's local frame).
     pub boresight: DVec3,
 }
 
-impl AntennaGain for ComplexAntenna {
+impl AntennaGain for PatternedAntenna {
     fn gain(&self, frequency: Frequency, angle: Angle) -> Decibel {
         self.pattern.gain(frequency, angle)
     }
@@ -59,36 +59,37 @@ impl AntennaGain for ComplexAntenna {
     }
 }
 
-impl ComplexAntenna {
+impl PatternedAntenna {
     /// Returns the peak gain in dBi at the given frequency.
     pub fn peak_gain(&self, frequency: Frequency) -> Decibel {
         self.pattern.peak_gain(frequency)
     }
 }
 
-/// An antenna, either simple (constant gain) or complex (pattern-based).
+/// An antenna, either constant-gain or pattern-based.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum Antenna {
     /// Constant-gain antenna.
-    Simple(SimpleAntenna),
+    Constant(ConstantAntenna),
     /// Pattern-based antenna with boresight direction.
-    Complex(ComplexAntenna),
+    Patterned(PatternedAntenna),
 }
 
 impl AntennaGain for Antenna {
     fn gain(&self, frequency: Frequency, angle: Angle) -> Decibel {
         match self {
-            Antenna::Simple(a) => a.gain(frequency, angle),
-            Antenna::Complex(a) => a.gain(frequency, angle),
+            Antenna::Constant(a) => a.gain(frequency, angle),
+            Antenna::Patterned(a) => a.gain(frequency, angle),
         }
     }
 
     fn beamwidth(&self, frequency: Frequency) -> Option<Angle> {
         match self {
-            Antenna::Simple(a) => a.beamwidth(frequency),
-            Antenna::Complex(a) => a.beamwidth(frequency),
+            Antenna::Constant(a) => a.beamwidth(frequency),
+            Antenna::Patterned(a) => a.beamwidth(frequency),
         }
     }
 }

--- a/crates/lox-comms/src/channel.rs
+++ b/crates/lox-comms/src/channel.rs
@@ -181,6 +181,28 @@ impl Channel {
         self.chip_rate
             .map(|cr| c_n0 - Decibel::from_linear(cr.to_hertz()))
     }
+
+    /// Layers modulation/FEC figures onto a modulation-agnostic [`crate::link_budget::LinkStats`].
+    ///
+    /// Computes `Es/N0`, `Eb/N0`, and link margin from the channel's modulation, FEC,
+    /// symbol rate, required `Eb/N0`, and required margin.
+    pub fn apply(
+        &self,
+        link: crate::link_budget::LinkStats,
+    ) -> crate::link_budget::ModulatedLinkStats {
+        let es_n0 = self.es_n0(link.c_n0);
+        let eb_n0 = self.eb_n0(link.c_n0);
+        let margin = self.link_margin(eb_n0);
+        crate::link_budget::ModulatedLinkStats {
+            link,
+            channel: self.clone(),
+            symbol_rate: self.symbol_rate,
+            es_n0,
+            eb_n0,
+            margin,
+            interference: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/lox-comms/src/channel.rs
+++ b/crates/lox-comms/src/channel.rs
@@ -9,6 +9,7 @@ use lox_core::units::{Decibel, Frequency};
 /// Digital modulation scheme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum Modulation {
     /// Binary Phase-Shift Keying (1 bit/symbol).
     Bpsk,
@@ -47,6 +48,7 @@ impl Modulation {
 /// Link direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum LinkDirection {
     /// Ground-to-space link.
     Uplink,

--- a/crates/lox-comms/src/error.rs
+++ b/crates/lox-comms/src/error.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! Errors produced by link-budget calculations.
+
+use lox_core::units::Frequency;
+
+/// Errors that can arise when computing a link budget.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum LinkBudgetError {
+    /// The transmitting system has no transmitter configured.
+    MissingTransmitter,
+    /// The receiving system has no receiver configured.
+    MissingReceiver,
+    /// A component-tier transmitter/receiver requires an antenna but none was provided.
+    MissingAntenna,
+    /// A lumped (`Eirp`/`Gt`) transmitter/receiver must not be paired with an antenna.
+    UnexpectedAntenna,
+    /// Transmitter and receiver frequencies disagree.
+    FrequencyMismatch {
+        /// Transmitter frequency.
+        tx: Frequency,
+        /// Receiver frequency.
+        rx: Frequency,
+    },
+}
+
+impl std::fmt::Display for LinkBudgetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LinkBudgetError::MissingTransmitter => {
+                write!(f, "transmitting system has no transmitter configured")
+            }
+            LinkBudgetError::MissingReceiver => {
+                write!(f, "receiving system has no receiver configured")
+            }
+            LinkBudgetError::MissingAntenna => {
+                write!(f, "component-tier transmitter/receiver requires an antenna")
+            }
+            LinkBudgetError::UnexpectedAntenna => write!(
+                f,
+                "lumped (Eirp/Gt) transmitter/receiver must not be paired with an antenna"
+            ),
+            LinkBudgetError::FrequencyMismatch { tx, rx } => write!(
+                f,
+                "transmitter frequency {} Hz differs from receiver frequency {} Hz",
+                tx.to_hertz(),
+                rx.to_hertz()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LinkBudgetError {}
+
+#[cfg(test)]
+mod tests {
+    use lox_core::units::FrequencyUnits;
+
+    use super::*;
+
+    #[test]
+    fn test_display_missing_transmitter() {
+        let s = LinkBudgetError::MissingTransmitter.to_string();
+        assert!(s.contains("transmitter"));
+    }
+
+    #[test]
+    fn test_display_frequency_mismatch() {
+        let err = LinkBudgetError::FrequencyMismatch {
+            tx: 29.0.ghz(),
+            rx: 30.0.ghz(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("29000000000"));
+        assert!(s.contains("30000000000"));
+    }
+
+    #[test]
+    fn test_is_error() {
+        fn assert_is_error<E: std::error::Error>(_: &E) {}
+        assert_is_error(&LinkBudgetError::MissingReceiver);
+    }
+}

--- a/crates/lox-comms/src/error.rs
+++ b/crates/lox-comms/src/error.rs
@@ -73,9 +73,28 @@ mod tests {
             tx: 29.0.ghz(),
             rx: 30.0.ghz(),
         };
-        let s = err.to_string();
-        assert!(s.contains("29000000000"));
-        assert!(s.contains("30000000000"));
+        assert_eq!(
+            err.to_string(),
+            "transmitter frequency 29000000000 Hz differs from receiver frequency 30000000000 Hz"
+        );
+    }
+
+    #[test]
+    fn test_display_missing_receiver() {
+        let s = LinkBudgetError::MissingReceiver.to_string();
+        assert!(s.contains("receiver"));
+    }
+
+    #[test]
+    fn test_display_missing_antenna() {
+        let s = LinkBudgetError::MissingAntenna.to_string();
+        assert!(s.contains("antenna"));
+    }
+
+    #[test]
+    fn test_display_unexpected_antenna() {
+        let s = LinkBudgetError::UnexpectedAntenna.to_string();
+        assert!(s.contains("antenna"));
     }
 
     #[test]

--- a/crates/lox-comms/src/error.rs
+++ b/crates/lox-comms/src/error.rs
@@ -5,22 +5,33 @@
 //! Errors produced by link-budget calculations.
 
 use lox_core::units::Frequency;
+use thiserror::Error;
 
 /// Errors that can arise when computing a link budget.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
 pub enum LinkBudgetError {
     /// The transmitting system has no transmitter configured.
+    #[error("transmitting system has no transmitter configured")]
     MissingTransmitter,
     /// The receiving system has no receiver configured.
+    #[error("receiving system has no receiver configured")]
     MissingReceiver,
     /// A component-tier transmitter/receiver requires an antenna but none was provided.
+    #[error("component-tier transmitter/receiver requires an antenna")]
     MissingAntenna,
     /// A lumped (`Eirp`/`Gt`) transmitter/receiver must not be paired with an antenna.
+    #[error("lumped (Eirp/Gt) transmitter/receiver must not be paired with an antenna")]
     UnexpectedAntenna,
     /// Absolute carrier and noise powers are required but are unavailable.
+    #[error("absolute carrier and noise powers are unavailable for this link")]
     AbsolutePowerUnavailable,
     /// Transmitter and receiver frequencies disagree.
+    #[error(
+        "transmitter frequency {} Hz differs from receiver frequency {} Hz",
+        tx.to_hertz(),
+        rx.to_hertz()
+    )]
     FrequencyMismatch {
         /// Transmitter frequency.
         tx: Frequency,
@@ -28,38 +39,6 @@ pub enum LinkBudgetError {
         rx: Frequency,
     },
 }
-
-impl std::fmt::Display for LinkBudgetError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LinkBudgetError::MissingTransmitter => {
-                write!(f, "transmitting system has no transmitter configured")
-            }
-            LinkBudgetError::MissingReceiver => {
-                write!(f, "receiving system has no receiver configured")
-            }
-            LinkBudgetError::MissingAntenna => {
-                write!(f, "component-tier transmitter/receiver requires an antenna")
-            }
-            LinkBudgetError::UnexpectedAntenna => write!(
-                f,
-                "lumped (Eirp/Gt) transmitter/receiver must not be paired with an antenna"
-            ),
-            LinkBudgetError::AbsolutePowerUnavailable => write!(
-                f,
-                "absolute carrier and noise powers are unavailable for this link"
-            ),
-            LinkBudgetError::FrequencyMismatch { tx, rx } => write!(
-                f,
-                "transmitter frequency {} Hz differs from receiver frequency {} Hz",
-                tx.to_hertz(),
-                rx.to_hertz()
-            ),
-        }
-    }
-}
-
-impl std::error::Error for LinkBudgetError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/lox-comms/src/error.rs
+++ b/crates/lox-comms/src/error.rs
@@ -18,6 +18,8 @@ pub enum LinkBudgetError {
     MissingAntenna,
     /// A lumped (`Eirp`/`Gt`) transmitter/receiver must not be paired with an antenna.
     UnexpectedAntenna,
+    /// Absolute carrier and noise powers are required but are unavailable.
+    AbsolutePowerUnavailable,
     /// Transmitter and receiver frequencies disagree.
     FrequencyMismatch {
         /// Transmitter frequency.
@@ -42,6 +44,10 @@ impl std::fmt::Display for LinkBudgetError {
             LinkBudgetError::UnexpectedAntenna => write!(
                 f,
                 "lumped (Eirp/Gt) transmitter/receiver must not be paired with an antenna"
+            ),
+            LinkBudgetError::AbsolutePowerUnavailable => write!(
+                f,
+                "absolute carrier and noise powers are unavailable for this link"
             ),
             LinkBudgetError::FrequencyMismatch { tx, rx } => write!(
                 f,
@@ -95,6 +101,12 @@ mod tests {
     fn test_display_unexpected_antenna() {
         let s = LinkBudgetError::UnexpectedAntenna.to_string();
         assert!(s.contains("antenna"));
+    }
+
+    #[test]
+    fn test_display_absolute_power_unavailable() {
+        let s = LinkBudgetError::AbsolutePowerUnavailable.to_string();
+        assert!(s.contains("absolute carrier and noise powers"));
     }
 
     #[test]

--- a/crates/lox-comms/src/lib.rs
+++ b/crates/lox-comms/src/lib.rs
@@ -24,7 +24,11 @@ pub use error::LinkBudgetError;
 
 use lox_core::units::Kelvin;
 
-/// Boltzmann constant in J/K (CODATA 2018 / SI 2019 exact value).
+/// Boltzmann constant in J/K.
+///
+/// # References
+///
+/// BIPM SI Brochure (2019), Table 1 of exact defining constants: k = 1.380 649 × 10⁻²³ J K⁻¹.
 pub const BOLTZMANN_CONSTANT: f64 = 1.380_649e-23;
 
 /// Reference room temperature in Kelvin (per ITU-R).

--- a/crates/lox-comms/src/lib.rs
+++ b/crates/lox-comms/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod antenna;
 pub mod channel;
+pub mod error;
 pub mod link_budget;
 pub mod pattern;
 pub mod pfd;
@@ -19,10 +20,12 @@ pub mod system;
 pub mod transmitter;
 pub mod utils;
 
+pub use error::LinkBudgetError;
+
 use lox_core::units::Kelvin;
 
-/// Boltzmann constant in J/K.
-pub const BOLTZMANN_CONSTANT: f64 = 1.380_648_52e-23;
+/// Boltzmann constant in J/K (CODATA 2018 / SI 2019 exact value).
+pub const BOLTZMANN_CONSTANT: f64 = 1.380_649e-23;
 
 /// Reference room temperature in Kelvin (per ITU-R).
 pub const ROOM_TEMPERATURE: Kelvin = 290.0;

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -134,17 +134,21 @@ pub struct ModulatedLinkStats {
 impl ModulatedLinkStats {
     /// Returns interference statistics for the given interferer power.
     ///
-    /// For lumped-`Gt` links, the underlying noise power is unknown, so interference
-    /// is treated as the dominant noise contribution (noise floor = 0). The resulting
-    /// figures are upper-bound estimates rather than exact values.
-    pub fn with_interference(&self, interference_power_w: f64) -> InterferenceStats {
-        let noise_linear = self.link.noise_power.map(|n| n.to_linear()).unwrap_or(0.0);
-        let carrier = self.link.carrier_rx_power.unwrap_or_else(|| {
-            // Synthesise a carrier power from C/N0 + bandwidth + noise so the
-            // interference arithmetic stays self-consistent. Only used for lumped
-            // links where noise is treated as zero in the absence of T_sys.
-            self.link.c_n0 + Decibel::from_linear(noise_linear.max(1e-30))
-        });
+    /// Returns an error when absolute carrier or noise power is unavailable
+    /// (for example for lumped-`Gt` links).
+    pub fn with_interference(
+        &self,
+        interference_power_w: f64,
+    ) -> Result<InterferenceStats, LinkBudgetError> {
+        let noise_linear = self
+            .link
+            .noise_power
+            .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?
+            .to_linear();
+        let carrier = self
+            .link
+            .carrier_rx_power
+            .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?;
 
         let total_ni = noise_linear + interference_power_w;
         let c_n0i0 = carrier - Decibel::from_linear(total_ni)
@@ -155,12 +159,12 @@ impl ModulatedLinkStats {
         let threshold = self.eb_n0 - self.margin;
         let margin_with_interference = eb_n0i0 - threshold;
 
-        InterferenceStats {
+        Ok(InterferenceStats {
             interference_power_w,
             c_n0i0,
             eb_n0i0,
             margin_with_interference,
-        }
+        })
     }
 }
 
@@ -335,7 +339,7 @@ mod tests {
         )
         .unwrap();
         let m = channel.apply(link);
-        let interference = m.with_interference(1e-12);
+        let interference = m.with_interference(1e-12).unwrap();
         assert!(interference.margin_with_interference.as_f64() <= m.margin.as_f64());
         assert!(interference.eb_n0i0.as_f64() <= m.eb_n0.as_f64());
     }
@@ -366,5 +370,42 @@ mod tests {
         assert!(stats.carrier_rx_power.is_none());
         assert!(stats.noise_power.is_none());
         assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.2);
+    }
+
+    #[test]
+    fn test_lumped_modulated_with_interference_is_error() {
+        use crate::receiver::GtReceiver;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 29.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let channel = Channel {
+            link_type: LinkDirection::Downlink,
+            symbol_rate: 5.0.mhz(),
+            required_eb_n0: 10.0.db(),
+            margin: 3.0.db(),
+            modulation: Modulation::Qpsk,
+            roll_off: 0.0,
+            fec: 0.5,
+            chip_rate: None,
+        };
+        let link = LinkStats::calculate(
+            &tx,
+            &rx,
+            Distance::kilometers(1000.0),
+            channel.bandwidth(),
+            EnvironmentalLosses::none(),
+            Angle::radians(0.0),
+            Angle::radians(0.0),
+        )
+        .unwrap();
+        let err = channel.apply(link).with_interference(1e-12).unwrap_err();
+        assert_eq!(err, LinkBudgetError::AbsolutePowerUnavailable);
     }
 }

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -97,7 +97,7 @@ impl LinkStats {
             .as_ref()
             .expect("RX system must have a receiver");
 
-        let frequency = tx.frequency;
+        let frequency = tx.frequency();
         let eirp = tx.eirp(&tx_system.antenna, tx_angle);
         let gt = receiver.gain_to_noise_temperature(&rx_system.antenna, rx_angle);
         let fspl = free_space_path_loss(range, frequency);
@@ -180,7 +180,7 @@ mod tests {
     use crate::antenna::{Antenna, ConstantAntenna};
     use crate::channel::{LinkDirection, Modulation};
     use crate::receiver::{NoiseTempReceiver, Receiver};
-    use crate::transmitter::Transmitter;
+    use crate::transmitter::{AmplifierTransmitter, Transmitter};
 
     use super::*;
 
@@ -191,7 +191,12 @@ mod tests {
                 beamwidth: Angle::degrees(0.7),
             }),
             receiver: None,
-            transmitter: Some(Transmitter::new(29.0.ghz(), 10.0, 1.0.db(), 0.0.db())),
+            transmitter: Some(Transmitter::Amplifier(AmplifierTransmitter::new(
+                29.0.ghz(),
+                10.0,
+                1.0.db(),
+                0.0.db(),
+            ))),
         };
         let rx_sys = CommunicationSystem {
             antenna: Antenna::Constant(ConstantAntenna {

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -177,7 +177,7 @@ mod tests {
     use lox_core::units::{DecibelUnits, FrequencyUnits};
     use lox_test_utils::assert_approx_eq;
 
-    use crate::antenna::{Antenna, SimpleAntenna};
+    use crate::antenna::{Antenna, ConstantAntenna};
     use crate::channel::{LinkDirection, Modulation};
     use crate::receiver::{Receiver, SimpleReceiver};
     use crate::transmitter::Transmitter;
@@ -186,7 +186,7 @@ mod tests {
 
     fn test_link() -> (CommunicationSystem, CommunicationSystem, Channel) {
         let tx_sys = CommunicationSystem {
-            antenna: Antenna::Simple(SimpleAntenna {
+            antenna: Antenna::Constant(ConstantAntenna {
                 gain: 46.0.db(),
                 beamwidth: Angle::degrees(0.7),
             }),
@@ -194,7 +194,7 @@ mod tests {
             transmitter: Some(Transmitter::new(29.0.ghz(), 10.0, 1.0.db(), 0.0.db())),
         };
         let rx_sys = CommunicationSystem {
-            antenna: Antenna::Simple(SimpleAntenna {
+            antenna: Antenna::Constant(ConstantAntenna {
                 gain: 30.0.db(),
                 beamwidth: Angle::degrees(3.0),
             }),

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -6,6 +6,7 @@
 
 use lox_core::units::{Angle, Decibel, Distance, Frequency};
 
+use crate::LinkBudgetError;
 use crate::channel::Channel;
 use crate::system::CommunicationSystem;
 use crate::utils::free_space_path_loss;
@@ -26,136 +27,131 @@ pub struct InterferenceStats {
     pub margin_with_interference: Decibel,
 }
 
-/// Complete link budget statistics.
+/// Modulation-agnostic link budget output.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LinkStats {
     /// Slant range between TX and RX.
     pub slant_range: Distance,
+    /// Link frequency.
+    pub frequency: Frequency,
     /// Free-space path loss.
     pub fspl: Decibel,
-    /// Off-boresight angle at the transmitter.
-    pub tx_angle: Angle,
-    /// Off-boresight angle at the receiver.
-    pub rx_angle: Angle,
     /// EIRP of the transmitter.
     pub eirp: Decibel,
     /// Receiver G/T.
     pub gt: Decibel,
-    /// Carrier-to-noise density ratio.
-    pub c_n0: Decibel,
-    /// Es/N0 (energy per symbol to noise spectral density).
-    pub es_n0: Decibel,
-    /// Eb/N0 (energy per information bit to noise spectral density).
-    pub eb_n0: Decibel,
-    /// Carrier-to-noise ratio.
-    pub c_n: Decibel,
-    /// Link margin.
-    pub margin: Decibel,
     /// Environmental losses.
     pub losses: EnvironmentalLosses,
-    /// Received carrier power.
-    pub carrier_rx_power: Decibel,
-    /// Symbol rate.
-    pub symbol_rate: Frequency,
-    /// Channel bandwidth.
+    /// Received carrier power. `None` for lumped-`Gt` receivers.
+    pub carrier_rx_power: Option<Decibel>,
+    /// Noise power in the channel bandwidth. `None` for lumped-`Gt` receivers.
+    pub noise_power: Option<Decibel>,
+    /// Channel noise bandwidth.
     pub bandwidth: Frequency,
-    /// Link frequency.
-    pub frequency: Frequency,
-    /// Noise power.
-    pub noise_power: Decibel,
-    /// Interference statistics (if applicable).
-    pub interference: Option<InterferenceStats>,
+    /// Carrier-to-noise density ratio (C/N₀).
+    pub c_n0: Decibel,
+    /// Carrier-to-noise ratio (C/N).
+    pub c_n: Decibel,
+    /// Off-boresight angle at the transmitter (0 for lumped `Eirp`).
+    pub tx_angle: Angle,
+    /// Off-boresight angle at the receiver (0 for lumped `Gt`).
+    pub rx_angle: Angle,
 }
 
 impl LinkStats {
-    /// Computes a full link budget.
+    /// Computes a modulation-agnostic link budget.
+    ///
+    /// `bandwidth` is the noise bandwidth used to compute `noise_power` and `C/N` from
+    /// `C/N₀`. It is independent of any modulation scheme.
     pub fn calculate(
         tx_system: &CommunicationSystem,
         rx_system: &CommunicationSystem,
-        channel: &Channel,
         range: Distance,
+        bandwidth: Frequency,
+        losses: EnvironmentalLosses,
         tx_angle: Angle,
         rx_angle: Angle,
-        losses: EnvironmentalLosses,
-    ) -> Self {
+    ) -> Result<Self, LinkBudgetError> {
         let env_loss = losses.total();
 
-        let c_n0 = tx_system
-            .carrier_to_noise_density(rx_system, env_loss, range, tx_angle, rx_angle)
-            .expect("link budget calculation: tx/rx must be configured");
-        let carrier_rx_power = tx_system
-            .carrier_power(rx_system, env_loss, range, tx_angle, rx_angle)
-            .expect("link budget calculation: tx/rx must be configured")
-            .expect("component-tier link budget produces carrier_rx_power");
+        let c_n0 =
+            tx_system.carrier_to_noise_density(rx_system, env_loss, range, tx_angle, rx_angle)?;
+        let carrier_rx_power =
+            tx_system.carrier_power(rx_system, env_loss, range, tx_angle, rx_angle)?;
+        let noise_power = rx_system.noise_power(bandwidth.to_hertz())?;
 
         let tx = tx_system
             .transmitter
             .as_ref()
-            .expect("TX system must have a transmitter");
-        let receiver = rx_system
-            .receiver
-            .as_ref()
-            .expect("RX system must have a receiver");
-
+            .ok_or(LinkBudgetError::MissingTransmitter)?;
         let frequency = tx.frequency();
-        let tx_ant = tx_system
-            .antenna
-            .as_ref()
-            .expect("component-tier TX system must have an antenna");
-        let rx_ant = rx_system
-            .antenna
-            .as_ref()
-            .expect("component-tier RX system must have an antenna");
-        let eirp = tx.eirp(tx_ant, tx_angle);
-        let gt = receiver.gain_to_noise_temperature(rx_ant, rx_angle);
         let fspl = free_space_path_loss(range, frequency);
-        let bandwidth = channel.bandwidth();
-        let noise_power = rx_system
-            .noise_power(bandwidth.to_hertz())
-            .expect("link budget calculation: rx must be configured")
-            .expect("component-tier link budget produces noise_power");
-        let es_n0 = channel.es_n0(c_n0);
-        let eb_n0 = channel.eb_n0(c_n0);
-        let c_n = channel.c_n(c_n0);
-        let margin = channel.link_margin(eb_n0);
 
-        Self {
+        let eirp = tx_system.eirp_at(tx_angle)?;
+        let gt = rx_system.gt_at(rx_angle)?;
+
+        let c_n = c_n0 - Decibel::from_linear(bandwidth.to_hertz());
+
+        Ok(Self {
             slant_range: range,
+            frequency,
             fspl,
-            tx_angle,
-            rx_angle,
             eirp,
             gt,
-            c_n0,
-            es_n0,
-            eb_n0,
-            c_n,
-            margin,
             losses,
             carrier_rx_power,
-            symbol_rate: channel.symbol_rate,
-            bandwidth,
-            frequency,
             noise_power,
-            interference: None,
-        }
+            bandwidth,
+            c_n0,
+            c_n,
+            tx_angle,
+            rx_angle,
+        })
     }
+}
 
-    /// Returns a copy of this link budget with interference statistics added.
+/// Link-budget output with modulation/coding figures applied.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ModulatedLinkStats {
+    /// The modulation-agnostic link budget.
+    pub link: LinkStats,
+    /// The channel (modulation, FEC, required Eb/N₀, margin) applied.
+    pub channel: Channel,
+    /// Symbol rate from the channel.
+    pub symbol_rate: Frequency,
+    /// Es/N0 (energy per symbol to noise spectral density).
+    pub es_n0: Decibel,
+    /// Eb/N0 (energy per information bit to noise spectral density).
+    pub eb_n0: Decibel,
+    /// Link margin.
+    pub margin: Decibel,
+    /// Interference statistics (if applicable).
+    pub interference: Option<InterferenceStats>,
+}
+
+impl ModulatedLinkStats {
+    /// Returns interference statistics for the given interferer power.
+    ///
+    /// For lumped-`Gt` links, the underlying noise power is unknown, so interference
+    /// is treated as the dominant noise contribution (noise floor = 0). The resulting
+    /// figures are upper-bound estimates rather than exact values.
     pub fn with_interference(&self, interference_power_w: f64) -> InterferenceStats {
-        let noise_linear = self.noise_power.to_linear();
+        let noise_linear = self.link.noise_power.map(|n| n.to_linear()).unwrap_or(0.0);
+        let carrier = self.link.carrier_rx_power.unwrap_or_else(|| {
+            // Synthesise a carrier power from C/N0 + bandwidth + noise so the
+            // interference arithmetic stays self-consistent. Only used for lumped
+            // links where noise is treated as zero in the absence of T_sys.
+            self.link.c_n0 + Decibel::from_linear(noise_linear.max(1e-30))
+        });
+
         let total_ni = noise_linear + interference_power_w;
-        let c_n0i0 = self.carrier_rx_power - Decibel::from_linear(total_ni)
-            + Decibel::from_linear(self.bandwidth.to_hertz());
-        // Reuse the nominal C/N0 → Eb/N0 offset (which encodes modulation order,
-        // FEC rate, and symbol rate) rather than recomputing through the Channel,
-        // since LinkStats does not store a reference to the Channel.
-        let c_n0_to_eb_n0 = self.eb_n0 - self.c_n0;
+        let c_n0i0 = carrier - Decibel::from_linear(total_ni)
+            + Decibel::from_linear(self.link.bandwidth.to_hertz());
+        let c_n0_to_eb_n0 = self.eb_n0 - self.link.c_n0;
         let eb_n0i0 = c_n0i0 + c_n0_to_eb_n0;
 
-        // margin = eb_n0 - (required_eb_n0 + required_margin)
-        // So the threshold (required_eb_n0 + required_margin) = eb_n0 - margin
         let threshold = self.eb_n0 - self.margin;
         let margin_with_interference = eb_n0i0 - threshold;
 
@@ -257,12 +253,13 @@ mod tests {
         let stats = LinkStats::calculate(
             &tx_sys,
             &rx_sys,
-            &channel,
             Distance::kilometers(1000.0),
-            Angle::radians(0.0),
-            Angle::radians(0.0),
+            channel.bandwidth(),
             EnvironmentalLosses::none(),
-        );
+            Angle::radians(0.0),
+            Angle::radians(0.0),
+        )
+        .unwrap();
 
         // EIRP = 46 + 10 - 1 = 55 dBW
         assert_approx_eq!(stats.eirp.as_f64(), 55.0, atol <= 0.01);
@@ -270,31 +267,10 @@ mod tests {
         assert_approx_eq!(stats.fspl.as_f64(), 181.696, atol <= 0.1);
         // C/N0 ≈ 104.9 dB·Hz
         assert_approx_eq!(stats.c_n0.as_f64(), 104.9, atol <= 0.2);
-        // Es/N0 = C/N0 - 10*log10(5e6) ≈ 104.9 - 66.99 = 37.91
-        assert_approx_eq!(stats.es_n0.as_f64(), 37.91, atol <= 0.2);
-        // Eb/N0 = Es/N0 - 10*log10(2 * 0.5) = Es/N0 - 0 = 37.91
-        assert_approx_eq!(stats.eb_n0.as_f64(), 37.91, atol <= 0.2);
-        // Margin = Eb/N0 - 10 - 3 = 24.91
-        assert_approx_eq!(stats.margin.as_f64(), 24.91, atol <= 0.2);
-    }
-
-    #[test]
-    fn test_link_stats_with_interference() {
-        let (tx_sys, rx_sys, channel) = test_link();
-        let stats = LinkStats::calculate(
-            &tx_sys,
-            &rx_sys,
-            &channel,
-            Distance::kilometers(1000.0),
-            Angle::radians(0.0),
-            Angle::radians(0.0),
-            EnvironmentalLosses::none(),
-        );
-
-        // Adding interference should reduce margin
-        let interference = stats.with_interference(1e-12);
-        assert!(interference.margin_with_interference.as_f64() <= stats.margin.as_f64());
-        assert!(interference.eb_n0i0.as_f64() <= stats.eb_n0.as_f64());
+        // carrier_rx_power should be Some for component-tier
+        assert!(stats.carrier_rx_power.is_some());
+        // noise_power should be Some for component-tier
+        assert!(stats.noise_power.is_some());
     }
 
     #[test]

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -300,4 +300,71 @@ mod tests {
         let factor = frequency_overlap_factor(10e9, 2e9, 10e9, 0.5e9);
         assert_approx_eq!(factor, 1.0, atol <= 1e-10);
     }
+
+    #[test]
+    fn test_channel_apply_produces_modulated_stats() {
+        let (tx_sys, rx_sys, channel) = test_link();
+        let link = LinkStats::calculate(
+            &tx_sys,
+            &rx_sys,
+            Distance::kilometers(1000.0),
+            channel.bandwidth(),
+            EnvironmentalLosses::none(),
+            Angle::radians(0.0),
+            Angle::radians(0.0),
+        )
+        .unwrap();
+        let m = channel.apply(link);
+        // Eb/N0 ≈ 37.91 (from existing test_link fixtures: QPSK, fec=0.5, C/N0≈104.9 dBHz)
+        assert_approx_eq!(m.eb_n0.as_f64(), 37.91, atol <= 0.2);
+        // required_eb_n0 = 10, margin field = 3 → link_margin ≈ 24.91
+        assert_approx_eq!(m.margin.as_f64(), 24.91, atol <= 0.2);
+    }
+
+    #[test]
+    fn test_modulated_with_interference_reduces_margin() {
+        let (tx_sys, rx_sys, channel) = test_link();
+        let link = LinkStats::calculate(
+            &tx_sys,
+            &rx_sys,
+            Distance::kilometers(1000.0),
+            channel.bandwidth(),
+            EnvironmentalLosses::none(),
+            Angle::radians(0.0),
+            Angle::radians(0.0),
+        )
+        .unwrap();
+        let m = channel.apply(link);
+        let interference = m.with_interference(1e-12);
+        assert!(interference.margin_with_interference.as_f64() <= m.margin.as_f64());
+        assert!(interference.eb_n0i0.as_f64() <= m.eb_n0.as_f64());
+    }
+
+    #[test]
+    fn test_lumped_link_stats_carrier_and_noise_are_none() {
+        use crate::receiver::GtReceiver;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 29.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let stats = LinkStats::calculate(
+            &tx,
+            &rx,
+            Distance::kilometers(1000.0),
+            5.0.mhz(),
+            EnvironmentalLosses::none(),
+            Angle::radians(0.0),
+            Angle::radians(0.0),
+        )
+        .unwrap();
+        assert!(stats.carrier_rx_power.is_none());
+        assert!(stats.noise_power.is_none());
+        assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.2);
+    }
 }

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -179,7 +179,7 @@ mod tests {
 
     use crate::antenna::{Antenna, ConstantAntenna};
     use crate::channel::{LinkDirection, Modulation};
-    use crate::receiver::{Receiver, SimpleReceiver};
+    use crate::receiver::{NoiseTempReceiver, Receiver};
     use crate::transmitter::Transmitter;
 
     use super::*;
@@ -198,7 +198,7 @@ mod tests {
                 gain: 30.0.db(),
                 beamwidth: Angle::degrees(3.0),
             }),
-            receiver: Some(Receiver::Simple(SimpleReceiver {
+            receiver: Some(Receiver::NoiseTemperature(NoiseTempReceiver {
                 frequency: 29.0.ghz(),
                 system_noise_temperature: 500.0,
             })),

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -86,7 +86,8 @@ impl LinkStats {
             .expect("link budget calculation: tx/rx must be configured");
         let carrier_rx_power = tx_system
             .carrier_power(rx_system, env_loss, range, tx_angle, rx_angle)
-            .expect("link budget calculation: tx/rx must be configured");
+            .expect("link budget calculation: tx/rx must be configured")
+            .expect("component-tier link budget produces carrier_rx_power");
 
         let tx = tx_system
             .transmitter
@@ -98,13 +99,22 @@ impl LinkStats {
             .expect("RX system must have a receiver");
 
         let frequency = tx.frequency();
-        let eirp = tx.eirp(&tx_system.antenna, tx_angle);
-        let gt = receiver.gain_to_noise_temperature(&rx_system.antenna, rx_angle);
+        let tx_ant = tx_system
+            .antenna
+            .as_ref()
+            .expect("component-tier TX system must have an antenna");
+        let rx_ant = rx_system
+            .antenna
+            .as_ref()
+            .expect("component-tier RX system must have an antenna");
+        let eirp = tx.eirp(tx_ant, tx_angle);
+        let gt = receiver.gain_to_noise_temperature(rx_ant, rx_angle);
         let fspl = free_space_path_loss(range, frequency);
         let bandwidth = channel.bandwidth();
         let noise_power = rx_system
             .noise_power(bandwidth.to_hertz())
-            .expect("link budget calculation: rx must be configured");
+            .expect("link budget calculation: rx must be configured")
+            .expect("component-tier link budget produces noise_power");
         let es_n0 = channel.es_n0(c_n0);
         let eb_n0 = channel.eb_n0(c_n0);
         let c_n = channel.c_n(c_n0);
@@ -186,10 +196,10 @@ mod tests {
 
     fn test_link() -> (CommunicationSystem, CommunicationSystem, Channel) {
         let tx_sys = CommunicationSystem {
-            antenna: Antenna::Constant(ConstantAntenna {
+            antenna: Some(Antenna::Constant(ConstantAntenna {
                 gain: 46.0.db(),
                 beamwidth: Angle::degrees(0.7),
-            }),
+            })),
             receiver: None,
             transmitter: Some(Transmitter::Amplifier(AmplifierTransmitter::new(
                 29.0.ghz(),
@@ -199,10 +209,10 @@ mod tests {
             ))),
         };
         let rx_sys = CommunicationSystem {
-            antenna: Antenna::Constant(ConstantAntenna {
+            antenna: Some(Antenna::Constant(ConstantAntenna {
                 gain: 30.0.db(),
                 beamwidth: Angle::degrees(3.0),
-            }),
+            })),
             receiver: Some(Receiver::NoiseTemperature(NoiseTempReceiver {
                 frequency: 29.0.ghz(),
                 system_noise_temperature: 500.0,

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -81,10 +81,12 @@ impl LinkStats {
     ) -> Self {
         let env_loss = losses.total();
 
-        let c_n0 =
-            tx_system.carrier_to_noise_density(rx_system, env_loss, range, tx_angle, rx_angle);
-        let carrier_rx_power =
-            tx_system.carrier_power(rx_system, env_loss, range, tx_angle, rx_angle);
+        let c_n0 = tx_system
+            .carrier_to_noise_density(rx_system, env_loss, range, tx_angle, rx_angle)
+            .expect("link budget calculation: tx/rx must be configured");
+        let carrier_rx_power = tx_system
+            .carrier_power(rx_system, env_loss, range, tx_angle, rx_angle)
+            .expect("link budget calculation: tx/rx must be configured");
 
         let tx = tx_system
             .transmitter
@@ -100,7 +102,9 @@ impl LinkStats {
         let gt = receiver.gain_to_noise_temperature(&rx_system.antenna, rx_angle);
         let fspl = free_space_path_loss(range, frequency);
         let bandwidth = channel.bandwidth();
-        let noise_power = rx_system.noise_power(bandwidth.to_hertz());
+        let noise_power = rx_system
+            .noise_power(bandwidth.to_hertz())
+            .expect("link budget calculation: rx must be configured");
         let es_n0 = channel.es_n0(c_n0);
         let eb_n0 = channel.eb_n0(c_n0);
         let c_n = channel.c_n(c_n0);

--- a/crates/lox-comms/src/pattern.rs
+++ b/crates/lox-comms/src/pattern.rs
@@ -58,3 +58,55 @@ impl AntennaPattern {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use lox_core::units::{Distance, FrequencyUnits};
+    use lox_test_utils::assert_approx_eq;
+
+    use crate::antenna::AntennaGain;
+
+    use super::*;
+
+    fn test_frequency() -> lox_core::units::Frequency {
+        29.0.ghz()
+    }
+
+    #[test]
+    fn test_pattern_enum_parabolic_dispatch() {
+        let p = AntennaPattern::Parabolic(ParabolicPattern::new(Distance::meters(0.98), 0.45));
+        let f = test_frequency();
+        let gain = p.gain(f, lox_core::units::Angle::radians(0.0));
+        let peak = p.peak_gain(f);
+        assert_approx_eq!(gain.as_f64(), peak.as_f64(), atol <= 1e-10);
+        assert!(p.beamwidth(f).is_some());
+    }
+
+    #[test]
+    fn test_pattern_enum_gaussian_dispatch() {
+        let p = AntennaPattern::Gaussian(GaussianPattern::new(Distance::meters(0.98), 0.45));
+        let f = test_frequency();
+        let gain = p.gain(f, lox_core::units::Angle::radians(0.0));
+        let peak = p.peak_gain(f);
+        assert_approx_eq!(gain.as_f64(), peak.as_f64(), atol <= 1e-10);
+        assert!(p.beamwidth(f).is_some());
+    }
+
+    #[test]
+    fn test_pattern_enum_dipole_dispatch() {
+        let f = test_frequency();
+        let wavelength = f.wavelength().to_meters();
+        let p = AntennaPattern::Dipole(DipolePattern::new(Distance::meters(wavelength / 2.0)));
+        // Broadside of a half-wave dipole — finite gain
+        let gain = p.gain(
+            f,
+            lox_core::units::Angle::radians(std::f64::consts::PI / 2.0),
+        );
+        assert_approx_eq!(gain.as_f64(), 2.15, atol <= 0.01);
+        // Dipole has no well-defined beamwidth
+        assert!(p.beamwidth(f).is_none());
+        let peak = p.peak_gain(f);
+        // Peak gain is at broadside for a half-wave
+        assert!(peak.as_f64() > 2.0);
+    }
+}

--- a/crates/lox-comms/src/pattern.rs
+++ b/crates/lox-comms/src/pattern.rs
@@ -20,6 +20,7 @@ pub use parabolic::ParabolicPattern;
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum AntennaPattern {
     /// Parabolic (uniform illuminated aperture) pattern.
     Parabolic(ParabolicPattern),

--- a/crates/lox-comms/src/receiver.rs
+++ b/crates/lox-comms/src/receiver.rs
@@ -411,4 +411,27 @@ mod tests {
         let g_total = rx.total_gain(&antenna, Angle::radians(0.0));
         assert_approx_eq!(g_total.as_f64(), 28.5, atol <= 1e-10);
     }
+
+    #[test]
+    fn test_gt_receiver_methods() {
+        use crate::antenna::ConstantAntenna;
+
+        let rx = Receiver::Gt(GtReceiver {
+            frequency: 29.0.ghz(),
+            gt: 3.01.db(),
+        });
+        // Sentinel values for the component-tier paths
+        assert_eq!(rx.system_noise_temperature(), 0.0);
+        let antenna = ConstantAntenna {
+            gain: 30.0.db(),
+            beamwidth: Angle::degrees(1.0),
+        };
+        let total = rx.total_gain(&antenna, Angle::radians(0.0));
+        assert_eq!(total.as_f64(), 0.0);
+        // Frequency accessor returns the stored frequency
+        assert_eq!(rx.frequency().to_hertz(), 29e9);
+        // gain_to_noise_temperature returns the stored G/T figure directly
+        let gt = rx.gain_to_noise_temperature(&antenna, Angle::radians(0.0));
+        assert_approx_eq!(gt.as_f64(), 3.01, atol <= 1e-10);
+    }
 }

--- a/crates/lox-comms/src/receiver.rs
+++ b/crates/lox-comms/src/receiver.rs
@@ -199,7 +199,7 @@ mod tests {
     use lox_core::units::{DecibelUnits, FrequencyUnits};
     use lox_test_utils::assert_approx_eq;
 
-    use crate::antenna::SimpleAntenna;
+    use crate::antenna::ConstantAntenna;
 
     use super::*;
 
@@ -270,7 +270,7 @@ mod tests {
     fn test_simple_receiver_gt() {
         // SimpleReceiver with T_sys=500K, antenna gain=30dBi
         // G/T = 30 - 10*log10(500) = 30 - 26.9897 = 3.0103 dB/K
-        let antenna = SimpleAntenna {
+        let antenna = ConstantAntenna {
             gain: 30.0.db(),
             beamwidth: Angle::degrees(1.0),
         };
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_complex_receiver_gt() {
-        let antenna = SimpleAntenna {
+        let antenna = ConstantAntenna {
             gain: 30.0.db(),
             beamwidth: Angle::degrees(1.0),
         };
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_complex_receiver_total_gain() {
-        let antenna = SimpleAntenna {
+        let antenna = ConstantAntenna {
             gain: 30.0.db(),
             beamwidth: Angle::degrees(1.0),
         };

--- a/crates/lox-comms/src/receiver.rs
+++ b/crates/lox-comms/src/receiver.rs
@@ -166,8 +166,10 @@ pub enum Receiver {
 impl Receiver {
     /// Returns the system noise temperature in Kelvin.
     ///
-    /// For lumped `Gt` receivers, returns `0.0` as a sentinel — the link-budget
-    /// path uses [`Receiver::gain_to_noise_temperature`] directly, not this method.
+    /// # Caveat
+    ///
+    /// The returned value is not physically meaningful for [`Receiver::Gt`]; callers
+    /// outside the link-budget path must match on the variant before calling.
     pub fn system_noise_temperature(&self) -> Kelvin {
         match self {
             Receiver::Gt(_) => 0.0,
@@ -176,17 +178,12 @@ impl Receiver {
         }
     }
 
-    /// Returns the total receiver gain in dB.
+    /// Returns the receiver gain in dB before noise referral.
     ///
-    /// For a noise temperature receiver, this is just the antenna gain.
-    /// For a cascade receiver: G_ant − demod_loss − impl_loss.
+    /// # Caveat
     ///
-    /// For lumped `Gt` receivers, returns `0 dB` as a sentinel — the link-budget
-    /// path uses [`Receiver::gain_to_noise_temperature`] directly, not this method.
-    ///
-    /// Chain gain is excluded because `system_noise_temperature` uses the Friis
-    /// formula, which refers noise to the antenna terminals. Including chain
-    /// gain here would double-count it in the G/T ratio.
+    /// The returned value is not physically meaningful for [`Receiver::Gt`]; callers
+    /// outside the link-budget path must match on the variant before calling.
     pub fn total_gain(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
         match self {
             Receiver::Gt(_) => Decibel::new(0.0),

--- a/crates/lox-comms/src/receiver.rs
+++ b/crates/lox-comms/src/receiver.rs
@@ -139,12 +139,24 @@ impl CascadeReceiver {
     }
 }
 
+/// Lumped receiver specified by a single G/T figure.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GtReceiver {
+    /// Receive frequency.
+    pub frequency: Frequency,
+    /// Gain-to-noise-temperature ratio in dB/K.
+    pub gt: Decibel,
+}
+
 /// A receiver, either characterised by a known T_sys or by an N-stage Friis cascade.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 #[non_exhaustive]
 pub enum Receiver {
+    /// Lumped receiver with aggregate G/T.
+    Gt(GtReceiver),
     /// Receiver with a known system noise temperature.
     NoiseTemperature(NoiseTempReceiver),
     /// Receiver with an N-stage cascade noise model.
@@ -153,8 +165,12 @@ pub enum Receiver {
 
 impl Receiver {
     /// Returns the system noise temperature in Kelvin.
+    ///
+    /// For lumped `Gt` receivers, returns `0.0` as a sentinel — the link-budget
+    /// path uses [`Receiver::gain_to_noise_temperature`] directly, not this method.
     pub fn system_noise_temperature(&self) -> Kelvin {
         match self {
+            Receiver::Gt(_) => 0.0,
             Receiver::NoiseTemperature(r) => r.system_noise_temperature,
             Receiver::Cascade(r) => r.system_noise_temperature(),
         }
@@ -165,11 +181,15 @@ impl Receiver {
     /// For a noise temperature receiver, this is just the antenna gain.
     /// For a cascade receiver: G_ant − demod_loss − impl_loss.
     ///
+    /// For lumped `Gt` receivers, returns `0 dB` as a sentinel — the link-budget
+    /// path uses [`Receiver::gain_to_noise_temperature`] directly, not this method.
+    ///
     /// Chain gain is excluded because `system_noise_temperature` uses the Friis
     /// formula, which refers noise to the antenna terminals. Including chain
     /// gain here would double-count it in the G/T ratio.
     pub fn total_gain(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
         match self {
+            Receiver::Gt(_) => Decibel::new(0.0),
             Receiver::NoiseTemperature(r) => antenna.gain(r.frequency, angle),
             Receiver::Cascade(r) => {
                 antenna.gain(r.frequency, angle) - r.demodulator_loss - r.implementation_loss
@@ -181,14 +201,20 @@ impl Receiver {
     ///
     /// G/T = G_total − 10·log₁₀(T_sys)
     pub fn gain_to_noise_temperature(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
-        let g_total = self.total_gain(antenna, angle);
-        let t_sys = self.system_noise_temperature();
-        g_total - Decibel::from_linear(t_sys)
+        match self {
+            Receiver::Gt(r) => r.gt,
+            Receiver::NoiseTemperature(_) | Receiver::Cascade(_) => {
+                let g_total = self.total_gain(antenna, angle);
+                let t_sys = self.system_noise_temperature();
+                g_total - Decibel::from_linear(t_sys)
+            }
+        }
     }
 
     /// Returns the receive frequency.
     pub fn frequency(&self) -> Frequency {
         match self {
+            Receiver::Gt(r) => r.frequency,
             Receiver::NoiseTemperature(r) => r.frequency,
             Receiver::Cascade(r) => r.frequency,
         }

--- a/crates/lox-comms/src/receiver.rs
+++ b/crates/lox-comms/src/receiver.rs
@@ -16,10 +16,10 @@ pub fn noise_figure_to_temperature(nf: Decibel) -> Kelvin {
     ROOM_TEMPERATURE * (nf.to_linear() - 1.0)
 }
 
-/// A simple receiver with a known system noise temperature.
+/// A receiver with a known system noise temperature.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SimpleReceiver {
+pub struct NoiseTempReceiver {
     /// Receive frequency.
     pub frequency: Frequency,
     /// System noise temperature in Kelvin.
@@ -44,7 +44,7 @@ pub struct NoiseStage {
 /// T_sys = T_ant + T_1 + T_2/G_1 + T_3/(G_1·G_2) + ...
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ComplexReceiver {
+pub struct CascadeReceiver {
     /// Receive frequency.
     pub frequency: Frequency,
     /// Antenna noise temperature in Kelvin.
@@ -57,7 +57,7 @@ pub struct ComplexReceiver {
     pub implementation_loss: Decibel,
 }
 
-impl ComplexReceiver {
+impl CascadeReceiver {
     /// Creates a two-stage receiver model: lossy feed line at room temperature → receiver.
     ///
     /// The feed line is modelled as a passive attenuator at 290 K, contributing
@@ -139,38 +139,39 @@ impl ComplexReceiver {
     }
 }
 
-/// A receiver, either simple (known T_sys) or complex (N-stage Friis cascade).
+/// A receiver, either characterised by a known T_sys or by an N-stage Friis cascade.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum Receiver {
     /// Receiver with a known system noise temperature.
-    Simple(SimpleReceiver),
+    NoiseTemperature(NoiseTempReceiver),
     /// Receiver with an N-stage cascade noise model.
-    Complex(ComplexReceiver),
+    Cascade(CascadeReceiver),
 }
 
 impl Receiver {
     /// Returns the system noise temperature in Kelvin.
     pub fn system_noise_temperature(&self) -> Kelvin {
         match self {
-            Receiver::Simple(r) => r.system_noise_temperature,
-            Receiver::Complex(r) => r.system_noise_temperature(),
+            Receiver::NoiseTemperature(r) => r.system_noise_temperature,
+            Receiver::Cascade(r) => r.system_noise_temperature(),
         }
     }
 
     /// Returns the total receiver gain in dB.
     ///
-    /// For a simple receiver, this is just the antenna gain.
-    /// For a complex receiver: G_ant − demod_loss − impl_loss.
+    /// For a noise temperature receiver, this is just the antenna gain.
+    /// For a cascade receiver: G_ant − demod_loss − impl_loss.
     ///
     /// Chain gain is excluded because `system_noise_temperature` uses the Friis
     /// formula, which refers noise to the antenna terminals. Including chain
     /// gain here would double-count it in the G/T ratio.
     pub fn total_gain(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
         match self {
-            Receiver::Simple(r) => antenna.gain(r.frequency, angle),
-            Receiver::Complex(r) => {
+            Receiver::NoiseTemperature(r) => antenna.gain(r.frequency, angle),
+            Receiver::Cascade(r) => {
                 antenna.gain(r.frequency, angle) - r.demodulator_loss - r.implementation_loss
             }
         }
@@ -188,8 +189,8 @@ impl Receiver {
     /// Returns the receive frequency.
     pub fn frequency(&self) -> Frequency {
         match self {
-            Receiver::Simple(r) => r.frequency,
-            Receiver::Complex(r) => r.frequency,
+            Receiver::NoiseTemperature(r) => r.frequency,
+            Receiver::Cascade(r) => r.frequency,
         }
     }
 }
@@ -215,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_from_feed_loss_and_noise_figure() {
-        // Reproduces old ComplexReceiver test:
+        // Reproduces old CascadeReceiver test:
         // NF=5dB, loss=3dB, T_ant=265K
         // Feed stage: gain=-3dB, T_feed = 290*(10^(3/10)-1) = 290*0.9953 = 288.63
         // Rx stage: gain=20dB (LNA), T_rx = 290*(10^(5/10)-1) = 627.06
@@ -226,7 +227,7 @@ mod tests {
         //
         // The Friis model gives a different reference point. Let's verify the
         // old test value is reproduced by the G/T being equivalent.
-        let rx = ComplexReceiver::from_feed_loss_and_noise_figure(
+        let rx = CascadeReceiver::from_feed_loss_and_noise_figure(
             29.0.ghz(),
             265.0,
             3.0.db(),
@@ -254,7 +255,7 @@ mod tests {
         // Gateway link: T_ant=290K, LNA(G=20dB, T=175K), Rx(NF=2dB)
         // T_rx = 290*(10^(2/10)-1) = 169.619 K
         // T_sys = 290 + 175 + 169.619/100 = 466.696 K
-        let rx = ComplexReceiver::from_lna_and_noise_figure(
+        let rx = CascadeReceiver::from_lna_and_noise_figure(
             26.5.ghz(),
             290.0,
             20.0.db(),
@@ -267,14 +268,14 @@ mod tests {
     }
 
     #[test]
-    fn test_simple_receiver_gt() {
-        // SimpleReceiver with T_sys=500K, antenna gain=30dBi
+    fn test_noise_temp_receiver_gt() {
+        // NoiseTempReceiver with T_sys=500K, antenna gain=30dBi
         // G/T = 30 - 10*log10(500) = 30 - 26.9897 = 3.0103 dB/K
         let antenna = ConstantAntenna {
             gain: 30.0.db(),
             beamwidth: Angle::degrees(1.0),
         };
-        let rx = Receiver::Simple(SimpleReceiver {
+        let rx = Receiver::NoiseTemperature(NoiseTempReceiver {
             frequency: 29.0.ghz(),
             system_noise_temperature: 500.0,
         });
@@ -283,9 +284,9 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_receiver_three_stage() {
+    fn test_cascade_receiver_three_stage() {
         // T_ant=100K, stages: LNA(G=20dB,T=50K), Filter(G=-3dB,T=290K), Rx(G=30dB,T=500K)
-        let rx = ComplexReceiver {
+        let rx = CascadeReceiver {
             frequency: 8.0.ghz(),
             antenna_noise_temperature: 100.0,
             stages: vec![
@@ -312,8 +313,8 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_receiver_chain_gain() {
-        let rx = ComplexReceiver {
+    fn test_cascade_receiver_chain_gain() {
+        let rx = CascadeReceiver {
             frequency: 8.0.ghz(),
             antenna_noise_temperature: 100.0,
             stages: vec![
@@ -338,12 +339,12 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_receiver_gt() {
+    fn test_cascade_receiver_gt() {
         let antenna = ConstantAntenna {
             gain: 30.0.db(),
             beamwidth: Angle::degrees(1.0),
         };
-        let rx = Receiver::Complex(ComplexReceiver::from_lna_and_noise_figure(
+        let rx = Receiver::Cascade(CascadeReceiver::from_lna_and_noise_figure(
             29.0.ghz(),
             150.0,
             30.0.db(),
@@ -360,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_receiver_total_gain() {
+    fn test_cascade_receiver_total_gain() {
         let antenna = ConstantAntenna {
             gain: 30.0.db(),
             beamwidth: Angle::degrees(1.0),
@@ -368,7 +369,7 @@ mod tests {
         // Two stages: LNA(20dB) + Rx(10dB), demod=1dB, impl=0.5dB
         // Chain gain is excluded (Friis noise is input-referred).
         // total_gain = 30 (ant) - 1 - 0.5 = 28.5 dB
-        let rx = Receiver::Complex(ComplexReceiver {
+        let rx = Receiver::Cascade(CascadeReceiver {
             frequency: 29.0.ghz(),
             antenna_noise_temperature: 265.0,
             stages: vec![

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -50,7 +50,7 @@ impl CommunicationSystem {
 
         let eirp = tx.eirp(&self.antenna, tx_angle);
         let gt = receiver.gain_to_noise_temperature(&rx.antenna, rx_angle);
-        let fspl = free_space_path_loss(range, tx.frequency);
+        let fspl = free_space_path_loss(range, tx.frequency());
         let k_db = Decibel::from_linear(BOLTZMANN_CONSTANT);
 
         Ok(eirp + gt - fspl - losses - k_db)
@@ -79,7 +79,7 @@ impl CommunicationSystem {
             .ok_or(LinkBudgetError::MissingReceiver)?;
 
         let eirp = tx.eirp(&self.antenna, tx_angle);
-        let fspl = free_space_path_loss(range, tx.frequency);
+        let fspl = free_space_path_loss(range, tx.frequency());
         let g_rx = receiver.total_gain(&rx.antenna, rx_angle);
 
         Ok(eirp - fspl - losses + g_rx)
@@ -103,7 +103,7 @@ impl CommunicationSystem {
 
     /// Returns the transmit frequency, if this system has a transmitter.
     pub fn tx_frequency(&self) -> Option<Frequency> {
-        self.transmitter.as_ref().map(|tx| tx.frequency)
+        self.transmitter.as_ref().map(|tx| tx.frequency())
     }
 
     /// Returns the receive frequency, if this system has a receiver.
@@ -119,6 +119,7 @@ mod tests {
 
     use crate::antenna::ConstantAntenna;
     use crate::receiver::NoiseTempReceiver;
+    use crate::transmitter::AmplifierTransmitter;
 
     use super::*;
 
@@ -129,7 +130,12 @@ mod tests {
                 beamwidth: Angle::degrees(0.7),
             }),
             receiver: None,
-            transmitter: Some(Transmitter::new(29.0.ghz(), 10.0, 1.0.db(), 0.0.db())),
+            transmitter: Some(Transmitter::Amplifier(AmplifierTransmitter::new(
+                29.0.ghz(),
+                10.0,
+                1.0.db(),
+                0.0.db(),
+            ))),
         }
     }
 

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -160,6 +160,28 @@ impl CommunicationSystem {
         Ok(Some(Decibel::from_linear(p_noise_w)))
     }
 
+    /// Returns the EIRP at the given off-boresight angle.
+    ///
+    /// For lumped `Eirp` transmitters, returns the stored figure; the angle is ignored.
+    pub fn eirp_at(&self, angle: Angle) -> Result<Decibel, LinkBudgetError> {
+        let tx = self
+            .transmitter
+            .as_ref()
+            .ok_or(LinkBudgetError::MissingTransmitter)?;
+        tx_eirp(tx, &self.antenna, angle)
+    }
+
+    /// Returns the G/T at the given off-boresight angle.
+    ///
+    /// For lumped `Gt` receivers, returns the stored figure; the angle is ignored.
+    pub fn gt_at(&self, angle: Angle) -> Result<Decibel, LinkBudgetError> {
+        let rx = self
+            .receiver
+            .as_ref()
+            .ok_or(LinkBudgetError::MissingReceiver)?;
+        rx_gt(rx, &self.antenna, angle)
+    }
+
     /// Returns the transmit frequency, if this system has a transmitter.
     pub fn tx_frequency(&self) -> Option<Frequency> {
         self.transmitter.as_ref().map(|tx| tx.frequency())

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -117,14 +117,14 @@ mod tests {
     use lox_core::units::{DecibelUnits, FrequencyUnits};
     use lox_test_utils::assert_approx_eq;
 
-    use crate::antenna::SimpleAntenna;
+    use crate::antenna::ConstantAntenna;
     use crate::receiver::SimpleReceiver;
 
     use super::*;
 
     fn tx_system() -> CommunicationSystem {
         CommunicationSystem {
-            antenna: Antenna::Simple(SimpleAntenna {
+            antenna: Antenna::Constant(ConstantAntenna {
                 gain: 46.0.db(),
                 beamwidth: Angle::degrees(0.7),
             }),
@@ -135,7 +135,7 @@ mod tests {
 
     fn rx_system() -> CommunicationSystem {
         CommunicationSystem {
-            antenna: Antenna::Simple(SimpleAntenna {
+            antenna: Antenna::Constant(ConstantAntenna {
                 gain: 30.0.db(),
                 beamwidth: Angle::degrees(3.0),
             }),

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -93,6 +93,15 @@ impl CommunicationSystem {
             .as_ref()
             .ok_or(LinkBudgetError::MissingReceiver)?;
 
+        let tx_freq = tx.frequency();
+        let rx_freq = receiver.frequency();
+        if tx_freq != rx_freq {
+            return Err(LinkBudgetError::FrequencyMismatch {
+                tx: tx_freq,
+                rx: rx_freq,
+            });
+        }
+
         let eirp = tx_eirp(tx, &self.antenna, tx_angle)?;
         let gt = rx_gt(receiver, &rx.antenna, rx_angle)?;
         let fspl = free_space_path_loss(range, tx.frequency());
@@ -125,6 +134,15 @@ impl CommunicationSystem {
             .receiver
             .as_ref()
             .ok_or(LinkBudgetError::MissingReceiver)?;
+
+        let tx_freq = tx.frequency();
+        let rx_freq = receiver.frequency();
+        if tx_freq != rx_freq {
+            return Err(LinkBudgetError::FrequencyMismatch {
+                tx: tx_freq,
+                rx: rx_freq,
+            });
+        }
 
         if matches!(receiver, Receiver::Gt(_)) {
             return Ok(None);
@@ -469,5 +487,30 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(err, LinkBudgetError::MissingAntenna);
+    }
+
+    #[test]
+    fn test_frequency_mismatch_is_error() {
+        use crate::receiver::GtReceiver;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 30.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let err = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert!(matches!(err, LinkBudgetError::FrequencyMismatch { .. }));
     }
 }

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -13,12 +13,12 @@ use crate::receiver::Receiver;
 use crate::transmitter::Transmitter;
 use crate::utils::free_space_path_loss;
 
-/// A communication system combining an antenna with optional transmitter and receiver.
+/// A communication system combining an optional antenna with optional transmitter and receiver.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommunicationSystem {
-    /// The antenna.
-    pub antenna: Antenna,
+    /// The antenna (required for component-tier TX/RX; must be absent for lumped `Eirp`/`Gt`).
+    pub antenna: Option<Antenna>,
     /// The receiver (if this system can receive).
     pub receiver: Option<Receiver>,
     /// The transmitter (if this system can transmit).
@@ -26,6 +26,43 @@ pub struct CommunicationSystem {
 }
 
 impl CommunicationSystem {
+    /// Creates a system whose transmitter is described by an aggregate EIRP figure.
+    pub fn eirp_only(tx: crate::transmitter::EirpTransmitter) -> Self {
+        Self {
+            antenna: None,
+            receiver: None,
+            transmitter: Some(Transmitter::Eirp(tx)),
+        }
+    }
+
+    /// Creates a system whose receiver is described by an aggregate G/T figure.
+    pub fn gt_only(rx: crate::receiver::GtReceiver) -> Self {
+        Self {
+            antenna: None,
+            receiver: Some(Receiver::Gt(rx)),
+            transmitter: None,
+        }
+    }
+
+    /// Creates a system from an antenna plus a component-tier amplifier transmitter.
+    pub fn amplifier_with(antenna: Antenna, tx: crate::transmitter::AmplifierTransmitter) -> Self {
+        Self {
+            antenna: Some(antenna),
+            receiver: None,
+            transmitter: Some(Transmitter::Amplifier(tx)),
+        }
+    }
+
+    /// Creates a system from an antenna plus a component-tier receiver
+    /// (either `NoiseTemperature` or `Cascade`).
+    pub fn receiver_with(antenna: Antenna, rx: Receiver) -> Self {
+        Self {
+            antenna: Some(antenna),
+            receiver: Some(rx),
+            transmitter: None,
+        }
+    }
+
     /// Computes the carrier-to-noise density ratio (C/N₀) in dB·Hz.
     ///
     /// C/N₀ = EIRP + G/T − FSPL − losses − 10·log₁₀(k_B)
@@ -48,8 +85,8 @@ impl CommunicationSystem {
             .as_ref()
             .ok_or(LinkBudgetError::MissingReceiver)?;
 
-        let eirp = tx.eirp(&self.antenna, tx_angle);
-        let gt = receiver.gain_to_noise_temperature(&rx.antenna, rx_angle);
+        let eirp = tx_eirp(tx, &self.antenna, tx_angle)?;
+        let gt = rx_gt(receiver, &rx.antenna, rx_angle)?;
         let fspl = free_space_path_loss(range, tx.frequency());
         let k_db = Decibel::from_linear(BOLTZMANN_CONSTANT);
 
@@ -60,6 +97,9 @@ impl CommunicationSystem {
     ///
     /// P_rx = EIRP − FSPL − losses + G_rx_total
     ///
+    /// Returns `Ok(None)` for lumped `Gt` receivers — the absolute receive gain
+    /// is not recoverable from a G/T figure.
+    ///
     /// Returns an error if `self` has no transmitter or `rx` has no receiver.
     pub fn carrier_power(
         &self,
@@ -68,7 +108,7 @@ impl CommunicationSystem {
         range: Distance,
         tx_angle: Angle,
         rx_angle: Angle,
-    ) -> Result<Decibel, LinkBudgetError> {
+    ) -> Result<Option<Decibel>, LinkBudgetError> {
         let tx = self
             .transmitter
             .as_ref()
@@ -78,27 +118,38 @@ impl CommunicationSystem {
             .as_ref()
             .ok_or(LinkBudgetError::MissingReceiver)?;
 
-        let eirp = tx.eirp(&self.antenna, tx_angle);
-        let fspl = free_space_path_loss(range, tx.frequency());
-        let g_rx = receiver.total_gain(&rx.antenna, rx_angle);
+        if matches!(receiver, Receiver::Gt(_)) {
+            return Ok(None);
+        }
 
-        Ok(eirp - fspl - losses + g_rx)
+        let antenna = rx.antenna.as_ref().ok_or(LinkBudgetError::MissingAntenna)?;
+        let eirp = tx_eirp(tx, &self.antenna, tx_angle)?;
+        let fspl = free_space_path_loss(range, tx.frequency());
+        let g_rx = receiver.total_gain(antenna, rx_angle);
+        Ok(Some(eirp - fspl - losses + g_rx))
     }
 
     /// Computes the noise power in dBW for a given bandwidth.
     ///
     /// P_noise = 10·log₁₀(T_sys · k_B · BW)
     ///
+    /// Returns `Ok(None)` for lumped `Gt` receivers — the system noise temperature
+    /// is not exposed separately by a G/T figure.
+    ///
     /// Returns an error if `self` has no receiver.
-    pub fn noise_power(&self, bandwidth_hz: f64) -> Result<Decibel, LinkBudgetError> {
+    pub fn noise_power(&self, bandwidth_hz: f64) -> Result<Option<Decibel>, LinkBudgetError> {
         let receiver = self
             .receiver
             .as_ref()
             .ok_or(LinkBudgetError::MissingReceiver)?;
 
+        if matches!(receiver, Receiver::Gt(_)) {
+            return Ok(None);
+        }
+
         let t_sys = receiver.system_noise_temperature();
         let p_noise_w = t_sys * BOLTZMANN_CONSTANT * bandwidth_hz;
-        Ok(Decibel::from_linear(p_noise_w))
+        Ok(Some(Decibel::from_linear(p_noise_w)))
     }
 
     /// Returns the transmit frequency, if this system has a transmitter.
@@ -109,6 +160,44 @@ impl CommunicationSystem {
     /// Returns the receive frequency, if this system has a receiver.
     pub fn rx_frequency(&self) -> Option<Frequency> {
         self.receiver.as_ref().map(|rx| rx.frequency())
+    }
+}
+
+fn tx_eirp(
+    tx: &Transmitter,
+    antenna: &Option<Antenna>,
+    angle: Angle,
+) -> Result<Decibel, LinkBudgetError> {
+    match tx {
+        Transmitter::Eirp(t) => {
+            if antenna.is_some() {
+                return Err(LinkBudgetError::UnexpectedAntenna);
+            }
+            Ok(t.eirp)
+        }
+        Transmitter::Amplifier(t) => {
+            let ant = antenna.as_ref().ok_or(LinkBudgetError::MissingAntenna)?;
+            Ok(t.eirp(ant, angle))
+        }
+    }
+}
+
+fn rx_gt(
+    rx: &Receiver,
+    antenna: &Option<Antenna>,
+    angle: Angle,
+) -> Result<Decibel, LinkBudgetError> {
+    match rx {
+        Receiver::Gt(r) => {
+            if antenna.is_some() {
+                return Err(LinkBudgetError::UnexpectedAntenna);
+            }
+            Ok(r.gt)
+        }
+        Receiver::NoiseTemperature(_) | Receiver::Cascade(_) => {
+            let ant = antenna.as_ref().ok_or(LinkBudgetError::MissingAntenna)?;
+            Ok(rx.gain_to_noise_temperature(ant, angle))
+        }
     }
 }
 
@@ -125,10 +214,10 @@ mod tests {
 
     fn tx_system() -> CommunicationSystem {
         CommunicationSystem {
-            antenna: Antenna::Constant(ConstantAntenna {
+            antenna: Some(Antenna::Constant(ConstantAntenna {
                 gain: 46.0.db(),
                 beamwidth: Angle::degrees(0.7),
-            }),
+            })),
             receiver: None,
             transmitter: Some(Transmitter::Amplifier(AmplifierTransmitter::new(
                 29.0.ghz(),
@@ -141,10 +230,10 @@ mod tests {
 
     fn rx_system() -> CommunicationSystem {
         CommunicationSystem {
-            antenna: Antenna::Constant(ConstantAntenna {
+            antenna: Some(Antenna::Constant(ConstantAntenna {
                 gain: 30.0.db(),
                 beamwidth: Angle::degrees(3.0),
-            }),
+            })),
             receiver: Some(Receiver::NoiseTemperature(NoiseTempReceiver {
                 frequency: 29.0.ghz(),
                 system_noise_temperature: 500.0,
@@ -189,7 +278,8 @@ mod tests {
                 Angle::radians(0.0),
                 Angle::radians(0.0),
             )
-            .unwrap();
+            .unwrap()
+            .expect("component receiver produces carrier_power");
         assert_approx_eq!(p_rx.as_f64(), -96.696, atol <= 0.1);
     }
 
@@ -199,7 +289,10 @@ mod tests {
         //         = 10*log10(500 * 1.380649e-23 * 1e6)
         //         = -141.61 dBW
         let rx = rx_system();
-        let p_noise = rx.noise_power(1e6).unwrap();
+        let p_noise = rx
+            .noise_power(1e6)
+            .unwrap()
+            .expect("component receiver produces noise_power");
         assert_approx_eq!(p_noise.as_f64(), -141.61, atol <= 0.01);
     }
 
@@ -228,11 +321,96 @@ mod tests {
                 Angle::radians(0.0),
                 Angle::radians(0.0),
             )
-            .unwrap();
-        let p_noise = rx.noise_power(bw).unwrap();
+            .unwrap()
+            .expect("component receiver produces carrier_power");
+        let p_noise = rx
+            .noise_power(bw)
+            .unwrap()
+            .expect("component receiver produces noise_power");
 
         // C/N0 = P_rx - P_noise + 10*log10(BW) (converting from C/N to C/N0)
         let c_n0_from_power = p_rx - p_noise + Decibel::from_linear(bw);
         assert_approx_eq!(c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 0.01);
+    }
+
+    #[test]
+    fn test_eirp_gt_c_n0_lumped() {
+        use crate::receiver::GtReceiver;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 29.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let c_n0 = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap();
+        // EIRP=55, G/T=3.01, FSPL≈181.696, losses=0, k_dB≈-228.599
+        // C/N0 ≈ 55 + 3.01 - 181.696 + 228.599 = 104.913
+        assert_approx_eq!(c_n0.as_f64(), 104.913, atol <= 0.2);
+    }
+
+    #[test]
+    fn test_lumped_carrier_power_is_none() {
+        use crate::receiver::GtReceiver;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 29.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let p = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap();
+        assert!(p.is_none());
+    }
+
+    #[test]
+    fn test_unexpected_antenna_is_error() {
+        use crate::antenna::ConstantAntenna;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem {
+            antenna: Some(Antenna::Constant(ConstantAntenna {
+                gain: 46.0.db(),
+                beamwidth: Angle::degrees(0.7),
+            })),
+            receiver: None,
+            transmitter: Some(Transmitter::Eirp(EirpTransmitter {
+                frequency: 29.0.ghz(),
+                eirp: 55.0.db(),
+            })),
+        };
+        let rx = rx_system();
+        let err = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::UnexpectedAntenna);
     }
 }

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -513,4 +513,80 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, LinkBudgetError::FrequencyMismatch { .. }));
     }
+
+    #[test]
+    fn test_missing_transmitter_is_error() {
+        let tx = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let rx = rx_system();
+        let err = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingTransmitter);
+    }
+
+    #[test]
+    fn test_missing_receiver_is_error() {
+        let tx = tx_system();
+        let rx = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let err = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingReceiver);
+    }
+
+    #[test]
+    fn test_noise_power_missing_receiver_is_error() {
+        let sys = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let err = sys.noise_power(1e6).unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingReceiver);
+    }
+
+    #[test]
+    fn test_frequency_mismatch_carrier_power_is_error() {
+        use crate::receiver::GtReceiver;
+        use crate::transmitter::EirpTransmitter;
+
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 30.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let err = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert!(matches!(err, LinkBudgetError::FrequencyMismatch { .. }));
+    }
 }

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -55,7 +55,15 @@ impl CommunicationSystem {
 
     /// Creates a system from an antenna plus a component-tier receiver
     /// (either `NoiseTemperature` or `Cascade`).
+    ///
+    /// # Panics (debug builds only)
+    ///
+    /// Panics if `rx` is [`Receiver::Gt`]; use [`Self::gt_only`] for lumped G/T receivers.
     pub fn receiver_with(antenna: Antenna, rx: Receiver) -> Self {
+        debug_assert!(
+            !matches!(rx, Receiver::Gt(_)),
+            "receiver_with: use gt_only for lumped G/T receivers"
+        );
         Self {
             antenna: Some(antenna),
             receiver: Some(rx),
@@ -357,7 +365,7 @@ mod tests {
             .unwrap();
         // EIRP=55, G/T=3.01, FSPL≈181.696, losses=0, k_dB≈-228.599
         // C/N0 ≈ 55 + 3.01 - 181.696 + 228.599 = 104.913
-        assert_approx_eq!(c_n0.as_f64(), 104.913, atol <= 0.2);
+        assert_approx_eq!(c_n0.as_f64(), 104.913, atol <= 0.1);
     }
 
     #[test]
@@ -412,5 +420,32 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(err, LinkBudgetError::UnexpectedAntenna);
+    }
+
+    #[test]
+    fn test_missing_antenna_is_error() {
+        use crate::transmitter::AmplifierTransmitter;
+
+        let tx = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: Some(Transmitter::Amplifier(AmplifierTransmitter::new(
+                29.0.ghz(),
+                10.0,
+                1.0.db(),
+                0.0.db(),
+            ))),
+        };
+        let rx = rx_system();
+        let err = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingAntenna);
     }
 }

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -589,4 +589,194 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, LinkBudgetError::FrequencyMismatch { .. }));
     }
+
+    #[test]
+    fn test_amplifier_with_constructor() {
+        let antenna = Antenna::Constant(ConstantAntenna {
+            gain: 46.0.db(),
+            beamwidth: Angle::degrees(0.7),
+        });
+        let tx = AmplifierTransmitter::new(29.0.ghz(), 10.0, 1.0.db(), 0.0.db());
+        let sys = CommunicationSystem::amplifier_with(antenna, tx);
+        assert!(sys.antenna.is_some());
+        assert!(sys.transmitter.is_some());
+        assert!(sys.receiver.is_none());
+    }
+
+    #[test]
+    fn test_receiver_with_constructor() {
+        let antenna = Antenna::Constant(ConstantAntenna {
+            gain: 30.0.db(),
+            beamwidth: Angle::degrees(3.0),
+        });
+        let rx = Receiver::NoiseTemperature(NoiseTempReceiver {
+            frequency: 29.0.ghz(),
+            system_noise_temperature: 500.0,
+        });
+        let sys = CommunicationSystem::receiver_with(antenna, rx);
+        assert!(sys.antenna.is_some());
+        assert!(sys.receiver.is_some());
+        assert!(sys.transmitter.is_none());
+    }
+
+    #[test]
+    fn test_carrier_power_missing_transmitter() {
+        let tx = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let rx = rx_system();
+        let err = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingTransmitter);
+    }
+
+    #[test]
+    fn test_carrier_power_missing_receiver() {
+        let tx = tx_system();
+        let rx = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let err = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingReceiver);
+    }
+
+    #[test]
+    fn test_carrier_power_missing_antenna_on_rx() {
+        // Component-tier receiver (NoiseTemperature) with no antenna should fail.
+        let tx = tx_system();
+        let rx = CommunicationSystem {
+            antenna: None,
+            receiver: Some(Receiver::NoiseTemperature(NoiseTempReceiver {
+                frequency: 29.0.ghz(),
+                system_noise_temperature: 500.0,
+            })),
+            transmitter: None,
+        };
+        let err = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingAntenna);
+    }
+
+    #[test]
+    fn test_eirp_at_missing_transmitter() {
+        let sys = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let err = sys.eirp_at(Angle::radians(0.0)).unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingTransmitter);
+    }
+
+    #[test]
+    fn test_eirp_at_lumped_returns_stored() {
+        use crate::transmitter::EirpTransmitter;
+
+        let sys = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let e = sys.eirp_at(Angle::radians(0.0)).unwrap();
+        assert_approx_eq!(e.as_f64(), 55.0, atol <= 1e-10);
+        // Angle is ignored for the lumped Eirp variant
+        let e_off = sys.eirp_at(Angle::radians(1.0)).unwrap();
+        assert_approx_eq!(e_off.as_f64(), 55.0, atol <= 1e-10);
+    }
+
+    #[test]
+    fn test_gt_at_missing_receiver() {
+        let sys = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        let err = sys.gt_at(Angle::radians(0.0)).unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingReceiver);
+    }
+
+    #[test]
+    fn test_gt_at_lumped_returns_stored() {
+        use crate::receiver::GtReceiver;
+
+        let sys = CommunicationSystem::gt_only(GtReceiver {
+            frequency: 29.0.ghz(),
+            gt: 3.01.db(),
+        });
+        let g = sys.gt_at(Angle::radians(0.0)).unwrap();
+        assert_approx_eq!(g.as_f64(), 3.01, atol <= 1e-10);
+    }
+
+    #[test]
+    fn test_tx_rx_frequency_accessors() {
+        let tx = tx_system();
+        let rx = rx_system();
+        let empty = CommunicationSystem {
+            antenna: None,
+            receiver: None,
+            transmitter: None,
+        };
+        assert_eq!(tx.tx_frequency().unwrap().to_hertz(), 29e9);
+        assert!(tx.rx_frequency().is_none());
+        assert_eq!(rx.rx_frequency().unwrap().to_hertz(), 29e9);
+        assert!(rx.tx_frequency().is_none());
+        assert!(empty.tx_frequency().is_none());
+        assert!(empty.rx_frequency().is_none());
+    }
+
+    #[test]
+    fn test_rx_gt_missing_antenna_for_component_receiver() {
+        use crate::transmitter::EirpTransmitter;
+
+        // Component-tier receiver (NoiseTemperature) with no antenna against
+        // a lumped TX. The carrier_to_noise_density path goes through rx_gt
+        // and should report MissingAntenna.
+        let tx = CommunicationSystem::eirp_only(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        let rx = CommunicationSystem {
+            antenna: None,
+            receiver: Some(Receiver::NoiseTemperature(NoiseTempReceiver {
+                frequency: 29.0.ghz(),
+                system_noise_temperature: 500.0,
+            })),
+            transmitter: None,
+        };
+        let err = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap_err();
+        assert_eq!(err, LinkBudgetError::MissingAntenna);
+    }
 }

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -7,6 +7,7 @@
 use lox_core::units::{Angle, Decibel, Distance, Frequency};
 
 use crate::BOLTZMANN_CONSTANT;
+use crate::LinkBudgetError;
 use crate::antenna::Antenna;
 use crate::receiver::Receiver;
 use crate::transmitter::Transmitter;
@@ -29,7 +30,7 @@ impl CommunicationSystem {
     ///
     /// C/N₀ = EIRP + G/T − FSPL − losses − 10·log₁₀(k_B)
     ///
-    /// `self` is the transmitting system, `rx` is the receiving system.
+    /// Returns an error if `self` has no transmitter or `rx` has no receiver.
     pub fn carrier_to_noise_density(
         &self,
         rx: &CommunicationSystem,
@@ -37,27 +38,29 @@ impl CommunicationSystem {
         range: Distance,
         tx_angle: Angle,
         rx_angle: Angle,
-    ) -> Decibel {
+    ) -> Result<Decibel, LinkBudgetError> {
         let tx = self
             .transmitter
             .as_ref()
-            .expect("transmitting system must have a transmitter");
+            .ok_or(LinkBudgetError::MissingTransmitter)?;
         let receiver = rx
             .receiver
             .as_ref()
-            .expect("receiving system must have a receiver");
+            .ok_or(LinkBudgetError::MissingReceiver)?;
 
         let eirp = tx.eirp(&self.antenna, tx_angle);
         let gt = receiver.gain_to_noise_temperature(&rx.antenna, rx_angle);
         let fspl = free_space_path_loss(range, tx.frequency);
         let k_db = Decibel::from_linear(BOLTZMANN_CONSTANT);
 
-        eirp + gt - fspl - losses - k_db
+        Ok(eirp + gt - fspl - losses - k_db)
     }
 
     /// Computes the received carrier power in dBW.
     ///
     /// P_rx = EIRP − FSPL − losses + G_rx_total
+    ///
+    /// Returns an error if `self` has no transmitter or `rx` has no receiver.
     pub fn carrier_power(
         &self,
         rx: &CommunicationSystem,
@@ -65,32 +68,37 @@ impl CommunicationSystem {
         range: Distance,
         tx_angle: Angle,
         rx_angle: Angle,
-    ) -> Decibel {
+    ) -> Result<Decibel, LinkBudgetError> {
         let tx = self
             .transmitter
             .as_ref()
-            .expect("transmitting system must have a transmitter");
+            .ok_or(LinkBudgetError::MissingTransmitter)?;
         let receiver = rx
             .receiver
             .as_ref()
-            .expect("receiving system must have a receiver");
+            .ok_or(LinkBudgetError::MissingReceiver)?;
 
         let eirp = tx.eirp(&self.antenna, tx_angle);
         let fspl = free_space_path_loss(range, tx.frequency);
         let g_rx = receiver.total_gain(&rx.antenna, rx_angle);
 
-        eirp - fspl - losses + g_rx
+        Ok(eirp - fspl - losses + g_rx)
     }
 
     /// Computes the noise power in dBW for a given bandwidth.
     ///
     /// P_noise = 10·log₁₀(T_sys · k_B · BW)
-    pub fn noise_power(&self, bandwidth_hz: f64) -> Decibel {
-        let receiver = self.receiver.as_ref().expect("system must have a receiver");
+    ///
+    /// Returns an error if `self` has no receiver.
+    pub fn noise_power(&self, bandwidth_hz: f64) -> Result<Decibel, LinkBudgetError> {
+        let receiver = self
+            .receiver
+            .as_ref()
+            .ok_or(LinkBudgetError::MissingReceiver)?;
 
         let t_sys = receiver.system_noise_temperature();
         let p_noise_w = t_sys * BOLTZMANN_CONSTANT * bandwidth_hz;
-        Decibel::from_linear(p_noise_w)
+        Ok(Decibel::from_linear(p_noise_w))
     }
 
     /// Returns the transmit frequency, if this system has a transmitter.
@@ -148,13 +156,15 @@ mod tests {
         // C/N0 = 55 + 3.01 - 181.696 - 0 - (-228.599) = 104.913 dB·Hz
         let tx = tx_system();
         let rx = rx_system();
-        let c_n0 = tx.carrier_to_noise_density(
-            &rx,
-            0.0.db(),
-            Distance::kilometers(1000.0),
-            Angle::radians(0.0),
-            Angle::radians(0.0),
-        );
+        let c_n0 = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap();
         // Verify within reasonable tolerance (some rounding in intermediate values)
         assert_approx_eq!(c_n0.as_f64(), 104.913, atol <= 0.1);
     }
@@ -165,13 +175,15 @@ mod tests {
         // = 55 - 181.696 - 0 + 30 = -96.696 dBW
         let tx = tx_system();
         let rx = rx_system();
-        let p_rx = tx.carrier_power(
-            &rx,
-            0.0.db(),
-            Distance::kilometers(1000.0),
-            Angle::radians(0.0),
-            Angle::radians(0.0),
-        );
+        let p_rx = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                Distance::kilometers(1000.0),
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap();
         assert_approx_eq!(p_rx.as_f64(), -96.696, atol <= 0.1);
     }
 
@@ -181,7 +193,7 @@ mod tests {
         //         = 10*log10(500 * 1.380649e-23 * 1e6)
         //         = -141.61 dBW
         let rx = rx_system();
-        let p_noise = rx.noise_power(1e6);
+        let p_noise = rx.noise_power(1e6).unwrap();
         assert_approx_eq!(p_noise.as_f64(), -141.61, atol <= 0.01);
     }
 
@@ -193,21 +205,25 @@ mod tests {
         let range = Distance::kilometers(1000.0);
         let bw = 1e6;
 
-        let c_n0 = tx.carrier_to_noise_density(
-            &rx,
-            0.0.db(),
-            range,
-            Angle::radians(0.0),
-            Angle::radians(0.0),
-        );
-        let p_rx = tx.carrier_power(
-            &rx,
-            0.0.db(),
-            range,
-            Angle::radians(0.0),
-            Angle::radians(0.0),
-        );
-        let p_noise = rx.noise_power(bw);
+        let c_n0 = tx
+            .carrier_to_noise_density(
+                &rx,
+                0.0.db(),
+                range,
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap();
+        let p_rx = tx
+            .carrier_power(
+                &rx,
+                0.0.db(),
+                range,
+                Angle::radians(0.0),
+                Angle::radians(0.0),
+            )
+            .unwrap();
+        let p_noise = rx.noise_power(bw).unwrap();
 
         // C/N0 = P_rx - P_noise + 10*log10(BW) (converting from C/N to C/N0)
         let c_n0_from_power = p_rx - p_noise + Decibel::from_linear(bw);

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -118,7 +118,7 @@ mod tests {
     use lox_test_utils::assert_approx_eq;
 
     use crate::antenna::ConstantAntenna;
-    use crate::receiver::SimpleReceiver;
+    use crate::receiver::NoiseTempReceiver;
 
     use super::*;
 
@@ -139,7 +139,7 @@ mod tests {
                 gain: 30.0.db(),
                 beamwidth: Angle::degrees(3.0),
             }),
-            receiver: Some(Receiver::Simple(SimpleReceiver {
+            receiver: Some(Receiver::NoiseTemperature(NoiseTempReceiver {
                 frequency: 29.0.ghz(),
                 system_noise_temperature: 500.0,
             })),

--- a/crates/lox-comms/src/system.rs
+++ b/crates/lox-comms/src/system.rs
@@ -177,8 +177,8 @@ mod tests {
 
     #[test]
     fn test_noise_power() {
-        // P_noise = 10*log10(500 * 1.38064852e-23 * 1e6)
-        //         = 10*log10(6.90324e-15)
+        // P_noise = 10*log10(500 * BOLTZMANN_CONSTANT * 1e6)
+        //         = 10*log10(500 * 1.380649e-23 * 1e6)
         //         = -141.61 dBW
         let rx = rx_system();
         let p_noise = rx.noise_power(1e6);

--- a/crates/lox-comms/src/transmitter.rs
+++ b/crates/lox-comms/src/transmitter.rs
@@ -47,12 +47,24 @@ impl AmplifierTransmitter {
     }
 }
 
+/// Lumped transmitter specified by a single EIRP figure.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct EirpTransmitter {
+    /// Transmit frequency.
+    pub frequency: Frequency,
+    /// Effective isotropic radiated power in dBW.
+    pub eirp: Decibel,
+}
+
 /// A transmitter.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 #[non_exhaustive]
 pub enum Transmitter {
+    /// Lumped transmitter with aggregate EIRP.
+    Eirp(EirpTransmitter),
     /// Power-amplifier transmitter (combined with an external antenna).
     Amplifier(AmplifierTransmitter),
 }
@@ -61,13 +73,17 @@ impl Transmitter {
     /// Returns the transmit frequency.
     pub fn frequency(&self) -> Frequency {
         match self {
+            Transmitter::Eirp(t) => t.frequency,
             Transmitter::Amplifier(t) => t.frequency,
         }
     }
 
     /// Returns the EIRP in dBW for the given antenna at the given off-boresight angle.
+    ///
+    /// For the lumped `Eirp` variant, `antenna` and `angle` are ignored.
     pub fn eirp(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
         match self {
+            Transmitter::Eirp(t) => t.eirp,
             Transmitter::Amplifier(t) => t.eirp(antenna, angle),
         }
     }

--- a/crates/lox-comms/src/transmitter.rs
+++ b/crates/lox-comms/src/transmitter.rs
@@ -2,16 +2,17 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-//! Radio transmitter model.
+//! Radio transmitter models.
 
 use lox_core::units::{Angle, Decibel, Frequency};
 
 use crate::antenna::AntennaGain;
 
-/// A radio transmitter.
+/// Transmitter characterised by output power, line loss, and back-off; combined with
+/// an antenna on the [`CommunicationSystem`](crate::system::CommunicationSystem).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Transmitter {
+pub struct AmplifierTransmitter {
     /// Transmit frequency.
     pub frequency: Frequency,
     /// Transmit power in watts.
@@ -22,8 +23,8 @@ pub struct Transmitter {
     pub output_back_off: Decibel,
 }
 
-impl Transmitter {
-    /// Creates a new transmitter with the given parameters.
+impl AmplifierTransmitter {
+    /// Creates a new amplifier transmitter.
     pub fn new(
         frequency: Frequency,
         power_w: f64,
@@ -39,12 +40,36 @@ impl Transmitter {
     }
 
     /// Returns the Effective Isotropic Radiated Power (EIRP) in dBW.
-    ///
-    /// EIRP = G_tx(f, θ) + 10·log₁₀(P_w) − L_line − OBO
     pub fn eirp(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
         antenna.gain(self.frequency, angle) + Decibel::from_linear(self.power_w)
             - self.line_loss
             - self.output_back_off
+    }
+}
+
+/// A transmitter.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[non_exhaustive]
+pub enum Transmitter {
+    /// Power-amplifier transmitter (combined with an external antenna).
+    Amplifier(AmplifierTransmitter),
+}
+
+impl Transmitter {
+    /// Returns the transmit frequency.
+    pub fn frequency(&self) -> Frequency {
+        match self {
+            Transmitter::Amplifier(t) => t.frequency,
+        }
+    }
+
+    /// Returns the EIRP in dBW for the given antenna at the given off-boresight angle.
+    pub fn eirp(&self, antenna: &impl AntennaGain, angle: Angle) -> Decibel {
+        match self {
+            Transmitter::Amplifier(t) => t.eirp(antenna, angle),
+        }
     }
 }
 
@@ -59,27 +84,40 @@ mod tests {
 
     #[test]
     fn test_eirp_simple() {
-        // 10 dBi antenna, 5 W power, 1 dB line loss, 0 dB OBO
-        // EIRP = 10 + 10*log10(5) - 1 - 0 = 10 + 6.9897 - 1 = 15.9897 dBW
         let antenna = ConstantAntenna {
             gain: 10.0.db(),
             beamwidth: Angle::degrees(10.0),
         };
-        let tx = Transmitter::new(29.0.ghz(), 5.0, 1.0.db(), 0.0.db());
+        let tx = AmplifierTransmitter::new(29.0.ghz(), 5.0, 1.0.db(), 0.0.db());
         let eirp = tx.eirp(&antenna, Angle::radians(0.0));
         assert_approx_eq!(eirp.as_f64(), 15.9897, atol <= 0.001);
     }
 
     #[test]
     fn test_eirp_with_obo() {
-        // 20 dBi antenna, 10 W power, 2 dB line loss, 3 dB OBO
-        // EIRP = 20 + 10*log10(10) - 2 - 3 = 20 + 10 - 2 - 3 = 25 dBW
         let antenna = ConstantAntenna {
             gain: 20.0.db(),
             beamwidth: Angle::degrees(5.0),
         };
-        let tx = Transmitter::new(29.0.ghz(), 10.0, 2.0.db(), 3.0.db());
+        let tx = AmplifierTransmitter::new(29.0.ghz(), 10.0, 2.0.db(), 3.0.db());
         let eirp = tx.eirp(&antenna, Angle::radians(0.0));
         assert_approx_eq!(eirp.as_f64(), 25.0, atol <= 1e-10);
+    }
+
+    #[test]
+    fn test_enum_dispatch_amplifier() {
+        let antenna = ConstantAntenna {
+            gain: 10.0.db(),
+            beamwidth: Angle::degrees(10.0),
+        };
+        let tx = Transmitter::Amplifier(AmplifierTransmitter::new(
+            29.0.ghz(),
+            5.0,
+            1.0.db(),
+            0.0.db(),
+        ));
+        let eirp = tx.eirp(&antenna, Angle::radians(0.0));
+        assert_approx_eq!(eirp.as_f64(), 15.9897, atol <= 0.001);
+        assert_eq!(tx.frequency().to_hertz(), 29e9);
     }
 }

--- a/crates/lox-comms/src/transmitter.rs
+++ b/crates/lox-comms/src/transmitter.rs
@@ -136,4 +136,23 @@ mod tests {
         assert_approx_eq!(eirp.as_f64(), 15.9897, atol <= 0.001);
         assert_eq!(tx.frequency().to_hertz(), 29e9);
     }
+
+    #[test]
+    fn test_enum_dispatch_eirp_ignores_antenna_and_angle() {
+        let antenna = ConstantAntenna {
+            gain: 1000.0.db(), // Deliberately absurd value
+            beamwidth: Angle::degrees(10.0),
+        };
+        let tx = Transmitter::Eirp(EirpTransmitter {
+            frequency: 29.0.ghz(),
+            eirp: 55.0.db(),
+        });
+        // For Eirp, antenna gain and angle are ignored — the stored figure is returned verbatim.
+        let eirp = tx.eirp(&antenna, Angle::radians(0.0));
+        assert_approx_eq!(eirp.as_f64(), 55.0, atol <= 1e-10);
+        // Same at any off-boresight angle
+        let eirp_off = tx.eirp(&antenna, Angle::radians(1.0));
+        assert_approx_eq!(eirp_off.as_f64(), 55.0, atol <= 1e-10);
+        assert_eq!(tx.frequency().to_hertz(), 29e9);
+    }
 }

--- a/crates/lox-comms/src/transmitter.rs
+++ b/crates/lox-comms/src/transmitter.rs
@@ -53,7 +53,7 @@ mod tests {
     use lox_core::units::{DecibelUnits, FrequencyUnits};
     use lox_test_utils::assert_approx_eq;
 
-    use crate::antenna::SimpleAntenna;
+    use crate::antenna::ConstantAntenna;
 
     use super::*;
 
@@ -61,7 +61,7 @@ mod tests {
     fn test_eirp_simple() {
         // 10 dBi antenna, 5 W power, 1 dB line loss, 0 dB OBO
         // EIRP = 10 + 10*log10(5) - 1 - 0 = 10 + 6.9897 - 1 = 15.9897 dBW
-        let antenna = SimpleAntenna {
+        let antenna = ConstantAntenna {
             gain: 10.0.db(),
             beamwidth: Angle::degrees(10.0),
         };
@@ -74,7 +74,7 @@ mod tests {
     fn test_eirp_with_obo() {
         // 20 dBi antenna, 10 W power, 2 dB line loss, 3 dB OBO
         // EIRP = 20 + 10*log10(10) - 2 - 3 = 20 + 10 - 2 - 3 = 25 dBW
-        let antenna = SimpleAntenna {
+        let antenna = ConstantAntenna {
             gain: 20.0.db(),
             beamwidth: Angle::degrees(5.0),
         };

--- a/crates/lox-space/docs/comms.md
+++ b/crates/lox-space/docs/comms.md
@@ -29,6 +29,61 @@ RF link budget analysis for space communication systems.
 | `GaussianPattern` | Gaussian roll-off approximation |
 | `DipolePattern` | Short and general dipole radiation patterns |
 
+## Lumped EIRP and G/T
+
+For early-phase mission studies — where manufacturer datasheets typically
+publish only aggregate figures — you can build a link budget directly from
+an `EirpTransmitter` and a `GtReceiver`, without configuring an antenna or
+amplifier separately. Use `CommunicationSystem.eirp_only` and
+`CommunicationSystem.gt_only`:
+
+```python
+import lox_space as lox
+
+tx = lox.CommunicationSystem.eirp_only(
+    lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+)
+rx = lox.CommunicationSystem.gt_only(
+    lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+)
+link = lox.LinkStats.calculate(
+    tx,
+    rx,
+    1000.0 * lox.km,
+    5.0 * lox.MHz,
+    0.0 * lox.rad,
+    0.0 * lox.rad,
+    lox.EnvironmentalLosses.none(),
+)
+print(f"C/N0 = {link.c_n0.as_float():.2f} dB·Hz")
+```
+
+For lumped links, `link.carrier_rx_power` and `link.noise_power` are `None` —
+the absolute carrier and noise power are not recoverable from EIRP and G/T
+alone. The carrier-to-noise density ratio (`c_n0`) and carrier-to-noise ratio
+(`c_n`) remain available.
+
+To compute modulation-aware figures (`Es/N0`, `Eb/N0`, link margin), apply a
+`Channel`:
+
+```python
+channel = lox.Channel(
+    link_type="downlink",
+    symbol_rate=5 * lox.MHz,
+    required_eb_n0=10.0 * lox.dB,
+    margin=3.0 * lox.dB,
+    modulation=lox.Modulation("QPSK"),
+    roll_off=0.35,
+    fec=0.5,
+)
+modulated = channel.apply(link)
+print(f"Margin = {modulated.margin.as_float():.2f} dB")
+```
+
+Use the component tier (configure antennas, amplifiers, receiver noise) when
+you need the full breakdown — for example for noise-budget allocation or
+detailed component trade studies.
+
 ## Quick Example
 
 ```python
@@ -39,13 +94,13 @@ frequency = 29 * lox.GHz
 
 # Transmitter: satellite with parabolic antenna
 tx_pattern = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-tx_antenna = lox.ComplexAntenna(pattern=tx_pattern, boresight=[0.0, 0.0, 1.0])
-tx = lox.Transmitter(frequency=frequency, power=10 * lox.W, line_loss=1.0 * lox.dB)
+tx_antenna = lox.PatternedAntenna(pattern=tx_pattern, boresight=[0.0, 0.0, 1.0])
+tx = lox.AmplifierTransmitter(frequency=frequency, power=10 * lox.W, line_loss=1.0 * lox.dB)
 tx_system = lox.CommunicationSystem(antenna=tx_antenna, transmitter=tx)
 
 # Receiver: ground station with known system noise temperature
-rx_antenna = lox.SimpleAntenna(gain=40.0 * lox.dB, beamwidth=0.5 * lox.deg)
-rx = lox.SimpleReceiver(frequency=frequency, system_noise_temperature=200 * lox.K)
+rx_antenna = lox.ConstantAntenna(gain=40.0 * lox.dB, beamwidth=0.5 * lox.deg)
+rx = lox.NoiseTempReceiver(frequency=frequency, system_noise_temperature=200 * lox.K)
 rx_system = lox.CommunicationSystem(antenna=rx_antenna, receiver=rx)
 
 # Define a QPSK channel at 5 Msps
@@ -60,21 +115,22 @@ channel = lox.Channel(
 )
 
 # Compute a full link budget at 1000 km slant range
-stats = lox.LinkStats.calculate(
+link = lox.LinkStats.calculate(
     tx_system=tx_system,
     rx_system=rx_system,
-    channel=channel,
     range=1000 * lox.km,
+    bandwidth=channel.bandwidth(),
     tx_angle=0.0 * lox.deg,
     rx_angle=0.0 * lox.deg,
 )
+modulated = channel.apply(link)
 
-print(f"EIRP:        {float(stats.eirp):.1f} dBW")
-print(f"FSPL:        {float(stats.fspl):.1f} dB")
-print(f"C/N0:        {float(stats.c_n0):.1f} dB·Hz")
-print(f"Es/N0:       {float(stats.es_n0):.1f} dB")
-print(f"Eb/N0:       {float(stats.eb_n0):.1f} dB")
-print(f"Link margin: {float(stats.margin):.1f} dB")
+print(f"EIRP:        {float(link.eirp):.1f} dBW")
+print(f"FSPL:        {float(link.fspl):.1f} dB")
+print(f"C/N0:        {float(link.c_n0):.1f} dB·Hz")
+print(f"Es/N0:       {float(modulated.es_n0):.1f} dB")
+print(f"Eb/N0:       {float(modulated.eb_n0):.1f} dB")
+print(f"Link margin: {float(modulated.margin):.1f} dB")
 ```
 
 ### Working with Decibels
@@ -117,11 +173,11 @@ losses = lox.EnvironmentalLosses(
 print(f"Total: {float(losses.total()):.1f} dB")
 
 # Pass to LinkStats.calculate via the losses parameter
-stats = lox.LinkStats.calculate(
+link = lox.LinkStats.calculate(
     tx_system=tx_system,
     rx_system=rx_system,
-    channel=channel,
     range=1000 * lox.km,
+    bandwidth=channel.bandwidth(),
     tx_angle=0.0 * lox.deg,
     rx_angle=0.0 * lox.deg,
     losses=losses,
@@ -160,31 +216,43 @@ stats = lox.LinkStats.calculate(
 
 ---
 
-::: lox_space.SimpleAntenna
+::: lox_space.ConstantAntenna
     options:
       show_source: false
 
 ---
 
-::: lox_space.ComplexAntenna
+::: lox_space.PatternedAntenna
     options:
       show_source: false
 
 ---
 
-::: lox_space.Transmitter
+::: lox_space.AmplifierTransmitter
     options:
       show_source: false
 
 ---
 
-::: lox_space.SimpleReceiver
+::: lox_space.EirpTransmitter
     options:
       show_source: false
 
 ---
 
-::: lox_space.ComplexReceiver
+::: lox_space.NoiseTempReceiver
+    options:
+      show_source: false
+
+---
+
+::: lox_space.CascadeReceiver
+    options:
+      show_source: false
+
+---
+
+::: lox_space.GtReceiver
     options:
       show_source: false
 
@@ -215,6 +283,12 @@ stats = lox.LinkStats.calculate(
 ---
 
 ::: lox_space.LinkStats
+    options:
+      show_source: false
+
+---
+
+::: lox_space.ModulatedLinkStats
     options:
       show_source: false
 

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1236,34 +1236,34 @@ impl PyCommunicationSystem {
 
 // --- Link Stats ---
 
-/// Complete link budget statistics.
+/// Modulation-agnostic link budget statistics.
 #[pyclass(name = "LinkStats", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyLinkStats(pub LinkStats);
 
 #[pymethods]
 impl PyLinkStats {
-    /// Computes a full link budget.
+    /// Computes a modulation-agnostic link budget.
     ///
     /// Args:
     ///     tx_system: The transmitting CommunicationSystem.
     ///     rx_system: The receiving CommunicationSystem.
-    ///     channel: The Channel.
     ///     range: Slant range as Distance.
+    ///     bandwidth: Noise bandwidth as Frequency.
     ///     tx_angle: Off-boresight angle at transmitter as Angle.
     ///     rx_angle: Off-boresight angle at receiver as Angle.
     ///     losses: EnvironmentalLosses (optional, defaults to none).
     #[staticmethod]
-    #[pyo3(signature = (tx_system, rx_system, channel, range, tx_angle, rx_angle, losses=None))]
+    #[pyo3(signature = (tx_system, rx_system, range, bandwidth, tx_angle, rx_angle, losses=None))]
     fn calculate(
         tx_system: &PyCommunicationSystem,
         rx_system: &PyCommunicationSystem,
-        channel: &PyChannel,
         range: PyDistance,
+        bandwidth: PyFrequency,
         tx_angle: PyAngle,
         rx_angle: PyAngle,
         losses: Option<&PyEnvironmentalLosses>,
-    ) -> Self {
+    ) -> PyResult<Self> {
         let env_losses = losses
             .map(|l| EnvironmentalLosses {
                 rain: l.0.rain,
@@ -1275,15 +1275,17 @@ impl PyLinkStats {
             })
             .unwrap_or_else(EnvironmentalLosses::none);
 
-        Self(LinkStats::calculate(
+        LinkStats::calculate(
             &tx_system.0,
             &rx_system.0,
-            &channel.0,
             range.0,
+            bandwidth.0,
+            env_losses,
             tx_angle.0,
             rx_angle.0,
-            env_losses,
-        ))
+        )
+        .map(Self)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     /// Slant range.
@@ -1316,49 +1318,25 @@ impl PyLinkStats {
         PyDecibel(self.0.c_n0)
     }
 
-    /// Es/N0 in dB.
-    #[getter]
-    fn es_n0(&self) -> PyDecibel {
-        PyDecibel(self.0.es_n0)
-    }
-
-    /// Eb/N0 in dB.
-    #[getter]
-    fn eb_n0(&self) -> PyDecibel {
-        PyDecibel(self.0.eb_n0)
-    }
-
     /// C/N in dB.
     #[getter]
     fn c_n(&self) -> PyDecibel {
         PyDecibel(self.0.c_n)
     }
 
-    /// Link margin in dB.
+    /// Received carrier power in dBW. ``None`` for lumped G/T receivers.
     #[getter]
-    fn margin(&self) -> PyDecibel {
-        PyDecibel(self.0.margin)
+    fn carrier_rx_power(&self) -> Option<PyDecibel> {
+        self.0.carrier_rx_power.map(PyDecibel)
     }
 
-    /// Received carrier power in dBW.
+    /// Noise power in dBW. ``None`` for lumped G/T receivers.
     #[getter]
-    fn carrier_rx_power(&self) -> PyDecibel {
-        PyDecibel(self.0.carrier_rx_power)
+    fn noise_power(&self) -> Option<PyDecibel> {
+        self.0.noise_power.map(PyDecibel)
     }
 
-    /// Noise power in dBW.
-    #[getter]
-    fn noise_power(&self) -> PyDecibel {
-        PyDecibel(self.0.noise_power)
-    }
-
-    /// Symbol rate.
-    #[getter]
-    fn symbol_rate(&self) -> PyFrequency {
-        PyFrequency(self.0.symbol_rate)
-    }
-
-    /// Channel bandwidth.
+    /// Channel noise bandwidth.
     #[getter]
     fn bandwidth(&self) -> PyFrequency {
         PyFrequency(self.0.bandwidth)
@@ -1370,13 +1348,25 @@ impl PyLinkStats {
         PyFrequency(self.0.frequency)
     }
 
+    /// Off-boresight angle at the transmitter.
+    #[getter]
+    fn tx_angle(&self) -> PyAngle {
+        PyAngle(self.0.tx_angle)
+    }
+
+    /// Off-boresight angle at the receiver.
+    #[getter]
+    fn rx_angle(&self) -> PyAngle {
+        PyAngle(self.0.rx_angle)
+    }
+
     fn __repr__(&self) -> String {
         format!(
-            "LinkStats(c_n0={:.2} dB·Hz, es_n0={:.2} dB, eb_n0={:.2} dB, margin={:.2} dB)",
+            "LinkStats(c_n0={:.2} dB·Hz, c_n={:.2} dB, eirp={:.2} dBW, gt={:.2} dB/K)",
             self.0.c_n0.as_f64(),
-            self.0.es_n0.as_f64(),
-            self.0.eb_n0.as_f64(),
-            self.0.margin.as_f64(),
+            self.0.c_n.as_f64(),
+            self.0.eirp.as_f64(),
+            self.0.gt.as_f64(),
         )
     }
 }

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -604,14 +604,30 @@ fn build_receiver(obj: &Bound<'_, PyAny>) -> PyResult<Receiver> {
     }
 }
 
-fn build_transmitter_from_amplifier(tx: &PyAmplifierTransmitter) -> Transmitter {
-    match &tx.0 {
-        Transmitter::Amplifier(a) => Transmitter::Amplifier(AmplifierTransmitter::new(
-            a.frequency,
-            a.power_w,
-            a.line_loss,
-            a.output_back_off,
-        )),
+fn build_transmitter_any(obj: &Bound<'_, PyAny>) -> PyResult<Transmitter> {
+    if let Ok(eirp) = obj.extract::<PyRef<'_, PyEirpTransmitter>>() {
+        return Ok(Transmitter::Eirp(eirp.0.clone()));
+    }
+    if let Ok(amp) = obj.extract::<PyRef<'_, PyAmplifierTransmitter>>() {
+        return Ok(amp.0.clone());
+    }
+    Err(PyValueError::new_err(
+        "expected EirpTransmitter or AmplifierTransmitter",
+    ))
+}
+
+fn build_receiver_any(obj: &Bound<'_, PyAny>) -> PyResult<Receiver> {
+    build_receiver(obj)
+}
+
+fn transmitter_to_py<'py>(py: Python<'py>, tx: &Transmitter) -> Bound<'py, PyAny> {
+    match tx {
+        Transmitter::Eirp(t) => Bound::new(py, PyEirpTransmitter(t.clone()))
+            .unwrap()
+            .into_any(),
+        Transmitter::Amplifier(_) => Bound::new(py, PyAmplifierTransmitter(tx.clone()))
+            .unwrap()
+            .into_any(),
         _ => unreachable!("unknown transmitter variant"),
     }
 }
@@ -1203,25 +1219,53 @@ pub struct PyCommunicationSystem(pub CommunicationSystem);
 #[pymethods]
 impl PyCommunicationSystem {
     #[new]
-    #[pyo3(signature = (antenna, receiver=None, transmitter=None))]
+    #[pyo3(signature = (antenna=None, receiver=None, transmitter=None))]
     fn new(
-        antenna: &Bound<'_, PyAny>,
+        antenna: Option<&Bound<'_, PyAny>>,
         receiver: Option<&Bound<'_, PyAny>>,
-        transmitter: Option<&PyAmplifierTransmitter>,
+        transmitter: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
-        if let Some(rx_obj) = receiver
-            && rx_obj.extract::<PyRef<'_, PyGtReceiver>>().is_ok()
+        let ant = antenna.map(build_antenna).transpose()?;
+        let rx = receiver.map(build_receiver_any).transpose()?;
+        let tx = transmitter.map(build_transmitter_any).transpose()?;
+
+        if let Some(Transmitter::Eirp(_)) = &tx
+            && ant.is_some()
         {
             return Err(PyValueError::new_err(
-                "GtReceiver is not accepted by the regular constructor; \
-                     use CommunicationSystem.gt_only(rx) instead",
+                "EirpTransmitter must not be paired with an antenna; \
+                     build the system via CommunicationSystem(transmitter=...) \
+                     with antenna=None, or use CommunicationSystem.eirp_only(...)",
             ));
         }
-        let ant = build_antenna(antenna)?;
-        let rx = receiver.map(build_receiver).transpose()?;
-        let tx = transmitter.map(build_transmitter_from_amplifier);
+        if let Some(Transmitter::Amplifier(_)) = &tx
+            && ant.is_none()
+        {
+            return Err(PyValueError::new_err(
+                "AmplifierTransmitter requires an antenna; provide one as the \
+                     antenna= argument or use CommunicationSystem.amplifier_with(...)",
+            ));
+        }
+        if let Some(Receiver::Gt(_)) = &rx
+            && ant.is_some()
+        {
+            return Err(PyValueError::new_err(
+                "GtReceiver must not be paired with an antenna; \
+                     build the system via CommunicationSystem(receiver=...) \
+                     with antenna=None, or use CommunicationSystem.gt_only(...)",
+            ));
+        }
+        if let Some(Receiver::NoiseTemperature(_)) | Some(Receiver::Cascade(_)) = &rx
+            && ant.is_none()
+        {
+            return Err(PyValueError::new_err(
+                "component-tier receiver requires an antenna; provide one as the \
+                     antenna= argument",
+            ));
+        }
+
         Ok(Self(CommunicationSystem {
-            antenna: Some(ant),
+            antenna: ant,
             receiver: rx,
             transmitter: tx,
         }))
@@ -1293,40 +1337,23 @@ impl PyCommunicationSystem {
     fn __getnewargs__<'py>(
         &self,
         py: Python<'py>,
-    ) -> PyResult<(
-        Bound<'py, PyAny>,
+    ) -> (
         Option<Bound<'py, PyAny>>,
-        Option<PyAmplifierTransmitter>,
-    )> {
-        let antenna = match self.0.antenna.as_ref() {
-            Some(a) => antenna_to_py(py, a),
-            None => {
-                return Err(PyValueError::new_err(
-                    "pickling of lumped CommunicationSystem (Eirp/Gt) is not yet supported",
-                ));
-            }
-        };
+        Option<Bound<'py, PyAny>>,
+        Option<Bound<'py, PyAny>>,
+    ) {
+        let antenna = self.0.antenna.as_ref().map(|a| antenna_to_py(py, a));
         let receiver = self.0.receiver.as_ref().map(|r| receiver_to_py(py, r));
         let transmitter = self
             .0
             .transmitter
             .as_ref()
-            .map(|t| match t {
-                Transmitter::Amplifier(a) => Ok(PyAmplifierTransmitter(Transmitter::Amplifier(
-                    AmplifierTransmitter::new(
-                        a.frequency,
-                        a.power_w,
-                        a.line_loss,
-                        a.output_back_off,
-                    ),
-                ))),
-                Transmitter::Eirp(_) => Err(PyValueError::new_err(
-                    "pickling of lumped CommunicationSystem (Eirp/Gt) is not yet supported",
-                )),
-                _ => unreachable!("unknown transmitter variant"),
-            })
-            .transpose()?;
-        Ok((antenna, receiver, transmitter))
+            .map(|t| transmitter_to_py(py, t));
+        (antenna, receiver, transmitter)
+    }
+
+    fn __eq__(&self, other: &PyCommunicationSystem) -> bool {
+        self.__repr__() == other.__repr__()
     }
 
     fn __repr__(&self) -> String {

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -44,6 +44,7 @@ fn modulation_name(m: Modulation) -> &'static str {
         Modulation::Qam64 => "64QAM",
         Modulation::Qam128 => "128QAM",
         Modulation::Qam256 => "256QAM",
+        _ => unreachable!("unknown modulation variant"),
     }
 }
 
@@ -430,6 +431,7 @@ impl PyComplexAntenna {
             AntennaPattern::Dipole(p) => {
                 format!("DipolePattern(length={})", PyDistance(p.length).__repr__())
             }
+            &_ => unreachable!("unknown antenna variant"),
         };
         let b = self.0.boresight;
         format!(
@@ -478,6 +480,7 @@ fn pattern_to_py<'py>(py: Python<'py>, pattern: &AntennaPattern) -> Bound<'py, P
         AntennaPattern::Dipole(p) => Bound::new(py, PyDipolePattern(DipolePattern::new(p.length)))
             .unwrap()
             .into_any(),
+        _ => unreachable!("unknown antenna variant"),
     }
 }
 
@@ -503,6 +506,7 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
                     AntennaPattern::Gaussian(GaussianPattern::new(p.diameter, p.efficiency))
                 }
                 AntennaPattern::Dipole(p) => AntennaPattern::Dipole(DipolePattern::new(p.length)),
+                _ => unreachable!("unknown antenna variant"),
             };
             Bound::new(
                 py,
@@ -551,6 +555,7 @@ fn build_antenna(obj: &Bound<'_, PyAny>) -> PyResult<Antenna> {
                 AntennaPattern::Gaussian(GaussianPattern::new(p.diameter, p.efficiency))
             }
             AntennaPattern::Dipole(p) => AntennaPattern::Dipole(DipolePattern::new(p.length)),
+            _ => unreachable!("unknown antenna variant"),
         };
         Ok(Antenna::Patterned(PatternedAntenna {
             pattern,
@@ -1011,6 +1016,7 @@ impl PyChannel {
             LinkDirection::Uplink => "uplink",
             LinkDirection::Downlink => "downlink",
             LinkDirection::Crosslink => "crosslink",
+            _ => unreachable!("unknown link direction variant"),
         };
         let modulation = Bound::new(py, PyModulation(self.0.modulation))
             .unwrap()
@@ -1176,6 +1182,7 @@ impl PyCommunicationSystem {
                     AntennaPattern::Dipole(p) => {
                         format!("DipolePattern(length={})", PyDistance(p.length).__repr__())
                     }
+                    _ => unreachable!("unknown antenna variant"),
                 };
                 let b = a.boresight;
                 format!(

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -16,7 +16,7 @@ use lox_itur::EnvironmentalLosses;
 use crate::itur::python::PyEnvironmentalLosses;
 use lox_comms::pattern::{AntennaPattern, DipolePattern, GaussianPattern, ParabolicPattern};
 use lox_comms::pfd;
-use lox_comms::receiver::{ComplexReceiver, NoiseStage, Receiver, SimpleReceiver};
+use lox_comms::receiver::{CascadeReceiver, NoiseStage, NoiseTempReceiver, Receiver};
 use lox_comms::system::CommunicationSystem;
 use lox_comms::transmitter::Transmitter;
 use lox_comms::utils::{free_space_path_loss, slant_range as comms_slant_range};
@@ -520,18 +520,19 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
 
 fn receiver_to_py<'py>(py: Python<'py>, receiver: &Receiver) -> Bound<'py, PyAny> {
     match receiver {
-        Receiver::Simple(r) => Bound::new(
+        Receiver::NoiseTemperature(r) => Bound::new(
             py,
-            PySimpleReceiver(SimpleReceiver {
+            PySimpleReceiver(NoiseTempReceiver {
                 frequency: r.frequency,
                 system_noise_temperature: r.system_noise_temperature,
             }),
         )
         .unwrap()
         .into_any(),
-        Receiver::Complex(r) => Bound::new(py, PyComplexReceiver(r.clone()))
+        Receiver::Cascade(r) => Bound::new(py, PyComplexReceiver(r.clone()))
             .unwrap()
             .into_any(),
+        _ => unreachable!("unknown receiver variant"),
     }
 }
 
@@ -564,15 +565,15 @@ fn build_antenna(obj: &Bound<'_, PyAny>) -> PyResult<Antenna> {
 
 fn build_receiver(obj: &Bound<'_, PyAny>) -> PyResult<Receiver> {
     if let Ok(r) = obj.extract::<PyRef<'_, PySimpleReceiver>>() {
-        Ok(Receiver::Simple(SimpleReceiver {
+        Ok(Receiver::NoiseTemperature(NoiseTempReceiver {
             frequency: r.0.frequency,
             system_noise_temperature: r.0.system_noise_temperature,
         }))
     } else if let Ok(r) = obj.extract::<PyRef<'_, PyComplexReceiver>>() {
-        Ok(Receiver::Complex(r.0.clone()))
+        Ok(Receiver::Cascade(r.0.clone()))
     } else {
         Err(PyValueError::new_err(
-            "expected a SimpleReceiver or ComplexReceiver",
+            "expected SimpleReceiver or ComplexReceiver",
         ))
     }
 }
@@ -650,13 +651,13 @@ impl PyTransmitter {
 ///     system_noise_temperature: System noise temperature.
 #[pyclass(name = "SimpleReceiver", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
-pub struct PySimpleReceiver(pub SimpleReceiver);
+pub struct PySimpleReceiver(pub NoiseTempReceiver);
 
 #[pymethods]
 impl PySimpleReceiver {
     #[new]
     fn new(frequency: PyFrequency, system_noise_temperature: PyTemperature) -> Self {
-        Self(SimpleReceiver {
+        Self(NoiseTempReceiver {
             frequency: frequency.0,
             system_noise_temperature: f64::from(system_noise_temperature.0),
         })
@@ -732,7 +733,7 @@ impl PyNoiseStage {
 ///     implementation_loss: Other implementation losses as Decibel (default Decibel(0)).
 #[pyclass(name = "ComplexReceiver", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
-pub struct PyComplexReceiver(pub ComplexReceiver);
+pub struct PyComplexReceiver(pub CascadeReceiver);
 
 #[pymethods]
 impl PyComplexReceiver {
@@ -745,7 +746,7 @@ impl PyComplexReceiver {
         demodulator_loss: Option<PyDecibel>,
         implementation_loss: Option<PyDecibel>,
     ) -> Self {
-        Self(ComplexReceiver {
+        Self(CascadeReceiver {
             frequency: frequency.0,
             antenna_noise_temperature: f64::from(antenna_noise_temperature.0),
             stages: stages.into_iter().map(|s| s.0).collect(),
@@ -767,7 +768,7 @@ impl PyComplexReceiver {
         demodulator_loss: Option<PyDecibel>,
         implementation_loss: Option<PyDecibel>,
     ) -> Self {
-        Self(ComplexReceiver::from_feed_loss_and_noise_figure(
+        Self(CascadeReceiver::from_feed_loss_and_noise_figure(
             frequency.0,
             f64::from(antenna_noise_temperature.0),
             feed_loss.0,
@@ -791,7 +792,7 @@ impl PyComplexReceiver {
         demodulator_loss: Option<PyDecibel>,
         implementation_loss: Option<PyDecibel>,
     ) -> Self {
-        Self(ComplexReceiver::from_lna_and_noise_figure(
+        Self(CascadeReceiver::from_lna_and_noise_figure(
             frequency.0,
             f64::from(antenna_noise_temperature.0),
             lna_gain.0,
@@ -1167,14 +1168,15 @@ impl PyCommunicationSystem {
             _ => unreachable!("unknown antenna variant"),
         };
         let rx_repr = match &self.0.receiver {
-            Some(Receiver::Simple(r)) => format!(
+            Some(Receiver::NoiseTemperature(r)) => format!(
                 ", receiver=SimpleReceiver(frequency={}, system_noise_temperature={})",
                 PyFrequency(r.frequency).__repr__(),
                 PyTemperature::new(r.system_noise_temperature).__repr__(),
             ),
-            Some(Receiver::Complex(r)) => {
+            Some(Receiver::Cascade(r)) => {
                 format!(", receiver={}", PyComplexReceiver(r.clone()).__repr__())
             }
+            Some(_) => unreachable!("unknown receiver variant"),
             None => String::new(),
         };
         let tx_repr = match &self.0.transmitter {

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -18,9 +18,9 @@ use lox_itur::EnvironmentalLosses;
 use crate::itur::python::PyEnvironmentalLosses;
 use lox_comms::pattern::{AntennaPattern, DipolePattern, GaussianPattern, ParabolicPattern};
 use lox_comms::pfd;
-use lox_comms::receiver::{CascadeReceiver, NoiseStage, NoiseTempReceiver, Receiver};
+use lox_comms::receiver::{CascadeReceiver, GtReceiver, NoiseStage, NoiseTempReceiver, Receiver};
 use lox_comms::system::CommunicationSystem;
-use lox_comms::transmitter::{AmplifierTransmitter, Transmitter};
+use lox_comms::transmitter::{AmplifierTransmitter, EirpTransmitter, Transmitter};
 use lox_comms::utils::{free_space_path_loss, slant_range as comms_slant_range};
 use lox_core::units::Decibel;
 
@@ -338,15 +338,15 @@ impl PyDipolePattern {
 /// Args:
 ///     gain: Peak gain as Decibel.
 ///     beamwidth: Half-power beamwidth as Angle.
-#[pyclass(name = "SimpleAntenna", module = "lox_space", frozen, from_py_object)]
+#[pyclass(name = "ConstantAntenna", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
-pub struct PySimpleAntenna {
+pub struct PyConstantAntenna {
     /// The wrapped [`ConstantAntenna`] value.
     pub inner: ConstantAntenna,
 }
 
 #[pymethods]
-impl PySimpleAntenna {
+impl PyConstantAntenna {
     #[new]
     fn new(gain: PyDecibel, beamwidth: PyAngle) -> Self {
         Self {
@@ -357,7 +357,7 @@ impl PySimpleAntenna {
         }
     }
 
-    fn __eq__(&self, other: &PySimpleAntenna) -> bool {
+    fn __eq__(&self, other: &PyConstantAntenna) -> bool {
         self.inner.gain.as_f64() == other.inner.gain.as_f64()
             && f64::from(self.inner.beamwidth) == f64::from(other.inner.beamwidth)
     }
@@ -368,7 +368,7 @@ impl PySimpleAntenna {
 
     fn __repr__(&self) -> String {
         format!(
-            "SimpleAntenna(gain={}, beamwidth={})",
+            "ConstantAntenna(gain={}, beamwidth={})",
             PyDecibel(self.inner.gain).__repr__(),
             PyAngle(self.inner.beamwidth).__repr__(),
         )
@@ -380,12 +380,17 @@ impl PySimpleAntenna {
 /// Args:
 ///     pattern: An antenna pattern (ParabolicPattern, GaussianPattern, or DipolePattern).
 ///     boresight: Boresight direction as [x, y, z].
-#[pyclass(name = "ComplexAntenna", module = "lox_space", frozen, from_py_object)]
+#[pyclass(
+    name = "PatternedAntenna",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
 #[derive(Debug, Clone)]
-pub struct PyComplexAntenna(pub PatternedAntenna);
+pub struct PyPatternedAntenna(pub PatternedAntenna);
 
 #[pymethods]
-impl PyComplexAntenna {
+impl PyPatternedAntenna {
     #[new]
     fn new(pattern: &Bound<'_, PyAny>, boresight: [f64; 3]) -> PyResult<Self> {
         let pattern = extract_antenna_pattern(pattern)?;
@@ -437,7 +442,7 @@ impl PyComplexAntenna {
         };
         let b = self.0.boresight;
         format!(
-            "ComplexAntenna(pattern={pattern_repr}, boresight=[{}, {}, {}])",
+            "PatternedAntenna(pattern={pattern_repr}, boresight=[{}, {}, {}])",
             repr_f64(b.x),
             repr_f64(b.y),
             repr_f64(b.z),
@@ -490,7 +495,7 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
     match antenna {
         Antenna::Constant(a) => Bound::new(
             py,
-            PySimpleAntenna {
+            PyConstantAntenna {
                 inner: ConstantAntenna {
                     gain: a.gain,
                     beamwidth: a.beamwidth,
@@ -512,7 +517,7 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
             };
             Bound::new(
                 py,
-                PyComplexAntenna(PatternedAntenna {
+                PyPatternedAntenna(PatternedAntenna {
                     pattern,
                     boresight: a.boresight,
                 }),
@@ -528,27 +533,36 @@ fn receiver_to_py<'py>(py: Python<'py>, receiver: &Receiver) -> Bound<'py, PyAny
     match receiver {
         Receiver::NoiseTemperature(r) => Bound::new(
             py,
-            PySimpleReceiver(NoiseTempReceiver {
+            PyNoiseTempReceiver(NoiseTempReceiver {
                 frequency: r.frequency,
                 system_noise_temperature: r.system_noise_temperature,
             }),
         )
         .unwrap()
         .into_any(),
-        Receiver::Cascade(r) => Bound::new(py, PyComplexReceiver(r.clone()))
+        Receiver::Cascade(r) => Bound::new(py, PyCascadeReceiver(r.clone()))
             .unwrap()
             .into_any(),
+        Receiver::Gt(r) => Bound::new(
+            py,
+            PyGtReceiver(GtReceiver {
+                frequency: r.frequency,
+                gt: r.gt,
+            }),
+        )
+        .unwrap()
+        .into_any(),
         _ => unreachable!("unknown receiver variant"),
     }
 }
 
 fn build_antenna(obj: &Bound<'_, PyAny>) -> PyResult<Antenna> {
-    if let Ok(a) = obj.extract::<PyRef<'_, PySimpleAntenna>>() {
+    if let Ok(a) = obj.extract::<PyRef<'_, PyConstantAntenna>>() {
         Ok(Antenna::Constant(ConstantAntenna {
             gain: a.inner.gain,
             beamwidth: a.inner.beamwidth,
         }))
-    } else if let Ok(a) = obj.extract::<PyRef<'_, PyComplexAntenna>>() {
+    } else if let Ok(a) = obj.extract::<PyRef<'_, PyPatternedAntenna>>() {
         let pattern = match &a.0.pattern {
             AntennaPattern::Parabolic(p) => {
                 AntennaPattern::Parabolic(ParabolicPattern::new(p.diameter, p.efficiency))
@@ -565,27 +579,32 @@ fn build_antenna(obj: &Bound<'_, PyAny>) -> PyResult<Antenna> {
         }))
     } else {
         Err(PyValueError::new_err(
-            "expected a SimpleAntenna or ComplexAntenna",
+            "expected a ConstantAntenna or PatternedAntenna",
         ))
     }
 }
 
 fn build_receiver(obj: &Bound<'_, PyAny>) -> PyResult<Receiver> {
-    if let Ok(r) = obj.extract::<PyRef<'_, PySimpleReceiver>>() {
+    if let Ok(r) = obj.extract::<PyRef<'_, PyNoiseTempReceiver>>() {
         Ok(Receiver::NoiseTemperature(NoiseTempReceiver {
             frequency: r.0.frequency,
             system_noise_temperature: r.0.system_noise_temperature,
         }))
-    } else if let Ok(r) = obj.extract::<PyRef<'_, PyComplexReceiver>>() {
+    } else if let Ok(r) = obj.extract::<PyRef<'_, PyCascadeReceiver>>() {
         Ok(Receiver::Cascade(r.0.clone()))
+    } else if let Ok(r) = obj.extract::<PyRef<'_, PyGtReceiver>>() {
+        Ok(Receiver::Gt(GtReceiver {
+            frequency: r.0.frequency,
+            gt: r.0.gt,
+        }))
     } else {
         Err(PyValueError::new_err(
-            "expected SimpleReceiver or ComplexReceiver",
+            "expected NoiseTempReceiver, CascadeReceiver, or GtReceiver",
         ))
     }
 }
 
-fn build_transmitter(tx: &PyTransmitter) -> Transmitter {
+fn build_transmitter_from_amplifier(tx: &PyAmplifierTransmitter) -> Transmitter {
     match &tx.0 {
         Transmitter::Amplifier(a) => Transmitter::Amplifier(AmplifierTransmitter::new(
             a.frequency,
@@ -597,21 +616,26 @@ fn build_transmitter(tx: &PyTransmitter) -> Transmitter {
     }
 }
 
-// --- Transmitter ---
+// --- AmplifierTransmitter ---
 
-/// A radio transmitter.
+/// A radio transmitter with an RF power amplifier.
 ///
 /// Args:
 ///     frequency: Transmit frequency.
 ///     power: Transmit power.
 ///     line_loss: Feed/line loss as Decibel.
 ///     output_back_off: Output back-off as Decibel (default Decibel(0)).
-#[pyclass(name = "Transmitter", module = "lox_space", frozen, from_py_object)]
+#[pyclass(
+    name = "AmplifierTransmitter",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
 #[derive(Debug, Clone)]
-pub struct PyTransmitter(pub Transmitter);
+pub struct PyAmplifierTransmitter(pub Transmitter);
 
 #[pymethods]
-impl PyTransmitter {
+impl PyAmplifierTransmitter {
     #[new]
     #[pyo3(signature = (frequency, power, line_loss, output_back_off=None))]
     fn new(
@@ -634,7 +658,7 @@ impl PyTransmitter {
         Ok(PyDecibel(self.0.eirp(&ant, angle.0)))
     }
 
-    fn __eq__(&self, other: &PyTransmitter) -> bool {
+    fn __eq__(&self, other: &PyAmplifierTransmitter) -> bool {
         let freq_eq = f64::from(self.0.frequency()) == f64::from(other.0.frequency());
         match (&self.0, &other.0) {
             (Transmitter::Amplifier(a), Transmitter::Amplifier(b)) => {
@@ -662,7 +686,7 @@ impl PyTransmitter {
     fn __repr__(&self) -> String {
         match &self.0 {
             Transmitter::Amplifier(tx) => format!(
-                "Transmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
+                "AmplifierTransmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
                 PyFrequency(tx.frequency).__repr__(),
                 PyPower::new(tx.power_w).__repr__(),
                 PyDecibel(tx.line_loss).__repr__(),
@@ -673,19 +697,112 @@ impl PyTransmitter {
     }
 }
 
+// --- EirpTransmitter ---
+
+/// A lumped transmitter defined by a frequency and aggregate EIRP.
+///
+/// Args:
+///     frequency: Transmit frequency.
+///     eirp: Effective isotropic radiated power in dBW.
+#[pyclass(name = "EirpTransmitter", module = "lox_space", frozen, from_py_object)]
+#[derive(Debug, Clone)]
+pub struct PyEirpTransmitter(pub EirpTransmitter);
+
+#[pymethods]
+impl PyEirpTransmitter {
+    #[new]
+    fn new(frequency: PyFrequency, eirp: PyDecibel) -> Self {
+        Self(EirpTransmitter {
+            frequency: frequency.0,
+            eirp: eirp.0,
+        })
+    }
+
+    #[getter]
+    fn frequency(&self) -> PyFrequency {
+        PyFrequency(self.0.frequency)
+    }
+
+    #[getter]
+    fn eirp(&self) -> PyDecibel {
+        PyDecibel(self.0.eirp)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "EirpTransmitter(frequency={}, eirp={})",
+            repr_f64(self.0.frequency.to_hertz()),
+            repr_f64(self.0.eirp.as_f64())
+        )
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0.frequency == other.0.frequency && self.0.eirp == other.0.eirp
+    }
+}
+
+// --- GtReceiver ---
+
+/// A lumped receiver defined by a frequency and aggregate G/T.
+///
+/// Args:
+///     frequency: Receive frequency.
+///     gt: Gain-to-noise-temperature ratio in dB/K.
+#[pyclass(name = "GtReceiver", module = "lox_space", frozen, from_py_object)]
+#[derive(Debug, Clone)]
+pub struct PyGtReceiver(pub GtReceiver);
+
+#[pymethods]
+impl PyGtReceiver {
+    #[new]
+    fn new(frequency: PyFrequency, gt: PyDecibel) -> Self {
+        Self(GtReceiver {
+            frequency: frequency.0,
+            gt: gt.0,
+        })
+    }
+
+    #[getter]
+    fn frequency(&self) -> PyFrequency {
+        PyFrequency(self.0.frequency)
+    }
+
+    #[getter]
+    fn gt(&self) -> PyDecibel {
+        PyDecibel(self.0.gt)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "GtReceiver(frequency={}, gt={})",
+            repr_f64(self.0.frequency.to_hertz()),
+            repr_f64(self.0.gt.as_f64())
+        )
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0.frequency == other.0.frequency && self.0.gt == other.0.gt
+    }
+}
+
 // --- Receivers ---
 
-/// A simple receiver with a known system noise temperature.
+/// A receiver with a known system noise temperature.
 ///
 /// Args:
 ///     frequency: Receive frequency.
 ///     system_noise_temperature: System noise temperature.
-#[pyclass(name = "SimpleReceiver", module = "lox_space", frozen, from_py_object)]
+#[pyclass(
+    name = "NoiseTempReceiver",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
 #[derive(Debug, Clone)]
-pub struct PySimpleReceiver(pub NoiseTempReceiver);
+pub struct PyNoiseTempReceiver(pub NoiseTempReceiver);
 
 #[pymethods]
-impl PySimpleReceiver {
+impl PyNoiseTempReceiver {
     #[new]
     fn new(frequency: PyFrequency, system_noise_temperature: PyTemperature) -> Self {
         Self(NoiseTempReceiver {
@@ -694,7 +811,7 @@ impl PySimpleReceiver {
         })
     }
 
-    fn __eq__(&self, other: &PySimpleReceiver) -> bool {
+    fn __eq__(&self, other: &PyNoiseTempReceiver) -> bool {
         f64::from(self.0.frequency) == f64::from(other.0.frequency)
             && self.0.system_noise_temperature == other.0.system_noise_temperature
     }
@@ -708,7 +825,7 @@ impl PySimpleReceiver {
 
     fn __repr__(&self) -> String {
         format!(
-            "SimpleReceiver(frequency={}, system_noise_temperature={})",
+            "NoiseTempReceiver(frequency={}, system_noise_temperature={})",
             PyFrequency(self.0.frequency).__repr__(),
             PyTemperature::new(self.0.system_noise_temperature).__repr__(),
         )
@@ -752,7 +869,7 @@ impl PyNoiseStage {
     }
 }
 
-// --- Complex Receiver ---
+// --- Cascade Receiver ---
 
 /// An N-stage cascade receiver using the Friis noise formula.
 ///
@@ -762,12 +879,12 @@ impl PyNoiseStage {
 ///     stages: List of NoiseStage (ordered: LNA first, then downstream).
 ///     demodulator_loss: Demodulator loss as Decibel (default Decibel(0)).
 ///     implementation_loss: Other implementation losses as Decibel (default Decibel(0)).
-#[pyclass(name = "ComplexReceiver", module = "lox_space", frozen, from_py_object)]
+#[pyclass(name = "CascadeReceiver", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
-pub struct PyComplexReceiver(pub CascadeReceiver);
+pub struct PyCascadeReceiver(pub CascadeReceiver);
 
 #[pymethods]
-impl PyComplexReceiver {
+impl PyCascadeReceiver {
     #[new]
     #[pyo3(signature = (frequency, antenna_noise_temperature, stages, demodulator_loss=None, implementation_loss=None))]
     fn new(
@@ -844,7 +961,7 @@ impl PyComplexReceiver {
         PyDecibel(self.0.chain_gain())
     }
 
-    fn __eq__(&self, other: &PyComplexReceiver) -> bool {
+    fn __eq__(&self, other: &PyCascadeReceiver) -> bool {
         f64::from(self.0.frequency) == f64::from(other.0.frequency)
             && self.0.antenna_noise_temperature == other.0.antenna_noise_temperature
             && self.0.stages.len() == other.0.stages.len()
@@ -896,7 +1013,7 @@ impl PyComplexReceiver {
             })
             .collect();
         format!(
-            "ComplexReceiver(frequency={}, antenna_noise_temperature={}, stages=[{}], demodulator_loss={}, implementation_loss={})",
+            "CascadeReceiver(frequency={}, antenna_noise_temperature={}, stages=[{}], demodulator_loss={}, implementation_loss={})",
             PyFrequency(self.0.frequency).__repr__(),
             PyTemperature::new(self.0.antenna_noise_temperature).__repr__(),
             stages_repr.join(", "),
@@ -1063,9 +1180,9 @@ impl PyChannel {
 /// A communication system combining an antenna with optional transmitter and receiver.
 ///
 /// Args:
-///     antenna: A SimpleAntenna or ComplexAntenna.
-///     receiver: A SimpleReceiver or ComplexReceiver (optional).
-///     transmitter: A Transmitter (optional).
+///     antenna: A ConstantAntenna or PatternedAntenna.
+///     receiver: A NoiseTempReceiver, CascadeReceiver, or GtReceiver (optional).
+///     transmitter: An AmplifierTransmitter or EirpTransmitter (optional).
 #[pyclass(
     name = "CommunicationSystem",
     module = "lox_space",
@@ -1082,16 +1199,28 @@ impl PyCommunicationSystem {
     fn new(
         antenna: &Bound<'_, PyAny>,
         receiver: Option<&Bound<'_, PyAny>>,
-        transmitter: Option<&PyTransmitter>,
+        transmitter: Option<&PyAmplifierTransmitter>,
     ) -> PyResult<Self> {
         let ant = build_antenna(antenna)?;
         let rx = receiver.map(build_receiver).transpose()?;
-        let tx = transmitter.map(build_transmitter);
+        let tx = transmitter.map(build_transmitter_from_amplifier);
         Ok(Self(CommunicationSystem {
             antenna: Some(ant),
             receiver: rx,
             transmitter: tx,
         }))
+    }
+
+    /// Creates a lumped transmit-only system from a known EIRP.
+    #[classmethod]
+    fn eirp_only(_cls: &Bound<'_, pyo3::types::PyType>, tx: PyEirpTransmitter) -> Self {
+        Self(CommunicationSystem::eirp_only(tx.0))
+    }
+
+    /// Creates a lumped receive-only system from a known G/T.
+    #[classmethod]
+    fn gt_only(_cls: &Bound<'_, pyo3::types::PyType>, rx: PyGtReceiver) -> Self {
+        Self(CommunicationSystem::gt_only(rx.0))
     }
 
     /// Computes the carrier-to-noise density ratio (C/N0).
@@ -1148,37 +1277,46 @@ impl PyCommunicationSystem {
     fn __getnewargs__<'py>(
         &self,
         py: Python<'py>,
-    ) -> (
+    ) -> PyResult<(
         Bound<'py, PyAny>,
         Option<Bound<'py, PyAny>>,
-        Option<PyTransmitter>,
-    ) {
-        let antenna = self
-            .0
-            .antenna
-            .as_ref()
-            .map(|a| antenna_to_py(py, a))
-            .expect("component-tier CommunicationSystem must have an antenna");
+        Option<PyAmplifierTransmitter>,
+    )> {
+        let antenna = match self.0.antenna.as_ref() {
+            Some(a) => antenna_to_py(py, a),
+            None => {
+                return Err(PyValueError::new_err(
+                    "pickling of lumped CommunicationSystem (Eirp/Gt) is not yet supported",
+                ));
+            }
+        };
         let receiver = self.0.receiver.as_ref().map(|r| receiver_to_py(py, r));
-        let transmitter = self.0.transmitter.as_ref().map(|t| {
-            PyTransmitter(match t {
-                Transmitter::Amplifier(a) => Transmitter::Amplifier(AmplifierTransmitter::new(
-                    a.frequency,
-                    a.power_w,
-                    a.line_loss,
-                    a.output_back_off,
+        let transmitter = self
+            .0
+            .transmitter
+            .as_ref()
+            .map(|t| match t {
+                Transmitter::Amplifier(a) => Ok(PyAmplifierTransmitter(Transmitter::Amplifier(
+                    AmplifierTransmitter::new(
+                        a.frequency,
+                        a.power_w,
+                        a.line_loss,
+                        a.output_back_off,
+                    ),
+                ))),
+                Transmitter::Eirp(_) => Err(PyValueError::new_err(
+                    "pickling of lumped CommunicationSystem (Eirp/Gt) is not yet supported",
                 )),
-                Transmitter::Eirp(_) => unreachable!("Eirp transmitter not yet exposed in Python"),
                 _ => unreachable!("unknown transmitter variant"),
             })
-        });
-        (antenna, receiver, transmitter)
+            .transpose()?;
+        Ok((antenna, receiver, transmitter))
     }
 
     fn __repr__(&self) -> String {
         let antenna_repr = match self.0.antenna.as_ref() {
             Some(Antenna::Constant(a)) => format!(
-                "SimpleAntenna(gain={}, beamwidth={})",
+                "ConstantAntenna(gain={}, beamwidth={})",
                 PyDecibel(a.gain).__repr__(),
                 PyAngle(a.beamwidth).__repr__(),
             ),
@@ -1201,7 +1339,7 @@ impl PyCommunicationSystem {
                 };
                 let b = a.boresight;
                 format!(
-                    "ComplexAntenna(pattern={pattern_repr}, boresight=[{}, {}, {}])",
+                    "PatternedAntenna(pattern={pattern_repr}, boresight=[{}, {}, {}])",
                     repr_f64(b.x),
                     repr_f64(b.y),
                     repr_f64(b.z),
@@ -1212,27 +1350,35 @@ impl PyCommunicationSystem {
         };
         let rx_repr = match &self.0.receiver {
             Some(Receiver::NoiseTemperature(r)) => format!(
-                ", receiver=SimpleReceiver(frequency={}, system_noise_temperature={})",
+                ", receiver=NoiseTempReceiver(frequency={}, system_noise_temperature={})",
                 PyFrequency(r.frequency).__repr__(),
                 PyTemperature::new(r.system_noise_temperature).__repr__(),
             ),
             Some(Receiver::Cascade(r)) => {
-                format!(", receiver={}", PyComplexReceiver(r.clone()).__repr__())
+                format!(", receiver={}", PyCascadeReceiver(r.clone()).__repr__())
             }
-            Some(Receiver::Gt(_)) => unreachable!("Gt receiver not yet exposed in Python"),
+            Some(Receiver::Gt(r)) => format!(
+                ", receiver=GtReceiver(frequency={}, gt={})",
+                repr_f64(r.frequency.to_hertz()),
+                repr_f64(r.gt.as_f64()),
+            ),
             Some(_) => unreachable!("unknown receiver variant"),
             None => String::new(),
         };
         let tx_repr = match &self.0.transmitter {
             Some(t) => match t {
                 Transmitter::Amplifier(a) => format!(
-                    ", transmitter=Transmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
+                    ", transmitter=AmplifierTransmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
                     PyFrequency(a.frequency).__repr__(),
                     PyPower::new(a.power_w).__repr__(),
                     PyDecibel(a.line_loss).__repr__(),
                     PyDecibel(a.output_back_off).__repr__(),
                 ),
-                Transmitter::Eirp(_) => unreachable!("Eirp transmitter not yet exposed in Python"),
+                Transmitter::Eirp(e) => format!(
+                    ", transmitter=EirpTransmitter(frequency={}, eirp={})",
+                    repr_f64(e.frequency.to_hertz()),
+                    repr_f64(e.eirp.as_f64()),
+                ),
                 _ => unreachable!("unknown transmitter variant"),
             },
             None => String::new(),

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1201,6 +1201,14 @@ impl PyCommunicationSystem {
         receiver: Option<&Bound<'_, PyAny>>,
         transmitter: Option<&PyAmplifierTransmitter>,
     ) -> PyResult<Self> {
+        if let Some(rx_obj) = receiver {
+            if rx_obj.extract::<PyRef<'_, PyGtReceiver>>().is_ok() {
+                return Err(PyValueError::new_err(
+                    "GtReceiver is not accepted by the regular constructor; \
+                     use CommunicationSystem.gt_only(rx) instead",
+                ));
+            }
+        }
         let ant = build_antenna(antenna)?;
         let rx = receiver.map(build_receiver).transpose()?;
         let tx = transmitter.map(build_transmitter_from_amplifier);

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -18,7 +18,7 @@ use lox_comms::pattern::{AntennaPattern, DipolePattern, GaussianPattern, Parabol
 use lox_comms::pfd;
 use lox_comms::receiver::{CascadeReceiver, NoiseStage, NoiseTempReceiver, Receiver};
 use lox_comms::system::CommunicationSystem;
-use lox_comms::transmitter::Transmitter;
+use lox_comms::transmitter::{AmplifierTransmitter, Transmitter};
 use lox_comms::utils::{free_space_path_loss, slant_range as comms_slant_range};
 use lox_core::units::Decibel;
 
@@ -578,6 +578,18 @@ fn build_receiver(obj: &Bound<'_, PyAny>) -> PyResult<Receiver> {
     }
 }
 
+fn build_transmitter(tx: &PyTransmitter) -> Transmitter {
+    match &tx.0 {
+        Transmitter::Amplifier(a) => Transmitter::Amplifier(AmplifierTransmitter::new(
+            a.frequency,
+            a.power_w,
+            a.line_loss,
+            a.output_back_off,
+        )),
+        _ => unreachable!("unknown transmitter variant"),
+    }
+}
+
 // --- Transmitter ---
 
 /// A radio transmitter.
@@ -601,12 +613,12 @@ impl PyTransmitter {
         line_loss: PyDecibel,
         output_back_off: Option<PyDecibel>,
     ) -> Self {
-        Self(Transmitter::new(
+        Self(Transmitter::Amplifier(AmplifierTransmitter::new(
             frequency.0,
             f64::from(power.0),
             line_loss.0,
             output_back_off.map_or(Decibel::new(0.0), |d| d.0),
-        ))
+        )))
     }
 
     /// Returns the EIRP in dBW for the given antenna and off-boresight angle.
@@ -616,29 +628,41 @@ impl PyTransmitter {
     }
 
     fn __eq__(&self, other: &PyTransmitter) -> bool {
-        f64::from(self.0.frequency) == f64::from(other.0.frequency)
-            && self.0.power_w == other.0.power_w
-            && self.0.line_loss.as_f64() == other.0.line_loss.as_f64()
-            && self.0.output_back_off.as_f64() == other.0.output_back_off.as_f64()
+        let freq_eq = f64::from(self.0.frequency()) == f64::from(other.0.frequency());
+        match (&self.0, &other.0) {
+            (Transmitter::Amplifier(a), Transmitter::Amplifier(b)) => {
+                freq_eq
+                    && a.power_w == b.power_w
+                    && a.line_loss.as_f64() == b.line_loss.as_f64()
+                    && a.output_back_off.as_f64() == b.output_back_off.as_f64()
+            }
+            _ => unreachable!("unknown transmitter variant"),
+        }
     }
 
     fn __getnewargs__(&self) -> (PyFrequency, PyPower, PyDecibel, Option<PyDecibel>) {
-        (
-            PyFrequency(self.0.frequency),
-            PyPower::new(self.0.power_w),
-            PyDecibel(self.0.line_loss),
-            Some(PyDecibel(self.0.output_back_off)),
-        )
+        match &self.0 {
+            Transmitter::Amplifier(tx) => (
+                PyFrequency(tx.frequency),
+                PyPower::new(tx.power_w),
+                PyDecibel(tx.line_loss),
+                Some(PyDecibel(tx.output_back_off)),
+            ),
+            _ => unreachable!("unknown transmitter variant"),
+        }
     }
 
     fn __repr__(&self) -> String {
-        format!(
-            "Transmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
-            PyFrequency(self.0.frequency).__repr__(),
-            PyPower::new(self.0.power_w).__repr__(),
-            PyDecibel(self.0.line_loss).__repr__(),
-            PyDecibel(self.0.output_back_off).__repr__(),
-        )
+        match &self.0 {
+            Transmitter::Amplifier(tx) => format!(
+                "Transmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
+                PyFrequency(tx.frequency).__repr__(),
+                PyPower::new(tx.power_w).__repr__(),
+                PyDecibel(tx.line_loss).__repr__(),
+                PyDecibel(tx.output_back_off).__repr__(),
+            ),
+            _ => unreachable!("unknown transmitter variant"),
+        }
     }
 }
 
@@ -1049,14 +1073,7 @@ impl PyCommunicationSystem {
     ) -> PyResult<Self> {
         let ant = build_antenna(antenna)?;
         let rx = receiver.map(build_receiver).transpose()?;
-        let tx = transmitter.map(|t| {
-            Transmitter::new(
-                t.0.frequency,
-                t.0.power_w,
-                t.0.line_loss,
-                t.0.output_back_off,
-            )
-        });
+        let tx = transmitter.map(build_transmitter);
         Ok(Self(CommunicationSystem {
             antenna: ant,
             receiver: rx,
@@ -1124,12 +1141,15 @@ impl PyCommunicationSystem {
         let antenna = antenna_to_py(py, &self.0.antenna);
         let receiver = self.0.receiver.as_ref().map(|r| receiver_to_py(py, r));
         let transmitter = self.0.transmitter.as_ref().map(|t| {
-            PyTransmitter(Transmitter::new(
-                t.frequency,
-                t.power_w,
-                t.line_loss,
-                t.output_back_off,
-            ))
+            PyTransmitter(match t {
+                Transmitter::Amplifier(a) => Transmitter::Amplifier(AmplifierTransmitter::new(
+                    a.frequency,
+                    a.power_w,
+                    a.line_loss,
+                    a.output_back_off,
+                )),
+                _ => unreachable!("unknown transmitter variant"),
+            })
         });
         (antenna, receiver, transmitter)
     }
@@ -1180,13 +1200,16 @@ impl PyCommunicationSystem {
             None => String::new(),
         };
         let tx_repr = match &self.0.transmitter {
-            Some(t) => format!(
-                ", transmitter=Transmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
-                PyFrequency(t.frequency).__repr__(),
-                PyPower::new(t.power_w).__repr__(),
-                PyDecibel(t.line_loss).__repr__(),
-                PyDecibel(t.output_back_off).__repr__(),
-            ),
+            Some(t) => match t {
+                Transmitter::Amplifier(a) => format!(
+                    ", transmitter=Transmitter(frequency={}, power={}, line_loss={}, output_back_off={})",
+                    PyFrequency(a.frequency).__repr__(),
+                    PyPower::new(a.power_w).__repr__(),
+                    PyDecibel(a.line_loss).__repr__(),
+                    PyDecibel(a.output_back_off).__repr__(),
+                ),
+                _ => unreachable!("unknown transmitter variant"),
+            },
             None => String::new(),
         };
         format!("CommunicationSystem(antenna={antenna_repr}{rx_repr}{tx_repr})")

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -10,7 +10,9 @@ use pyo3::prelude::*;
 
 use lox_comms::antenna::{Antenna, AntennaGain, ConstantAntenna, PatternedAntenna};
 use lox_comms::channel::{Channel, LinkDirection, Modulation};
-use lox_comms::link_budget::{LinkStats, frequency_overlap_factor};
+use lox_comms::link_budget::{
+    InterferenceStats, LinkStats, ModulatedLinkStats, frequency_overlap_factor,
+};
 use lox_itur::EnvironmentalLosses;
 
 use crate::itur::python::PyEnvironmentalLosses;
@@ -998,6 +1000,11 @@ impl PyChannel {
         self.0.processing_gain().map(PyDecibel)
     }
 
+    /// Layers modulation/FEC figures onto a modulation-agnostic link budget.
+    fn apply(&self, link: PyLinkStats) -> PyModulatedLinkStats {
+        PyModulatedLinkStats(self.0.apply(link.0))
+    }
+
     #[allow(clippy::type_complexity)]
     fn __getnewargs__<'py>(
         &self,
@@ -1367,6 +1374,133 @@ impl PyLinkStats {
             self.0.c_n.as_f64(),
             self.0.eirp.as_f64(),
             self.0.gt.as_f64(),
+        )
+    }
+}
+
+// --- Interference Stats ---
+
+/// Interference statistics for a link with a given interferer power.
+#[pyclass(
+    name = "InterferenceStats",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
+#[derive(Debug, Clone)]
+pub struct PyInterferenceStats(pub InterferenceStats);
+
+#[pymethods]
+impl PyInterferenceStats {
+    /// Interference power in watts.
+    #[getter]
+    fn interference_power_w(&self) -> f64 {
+        self.0.interference_power_w
+    }
+
+    /// Carrier-to-noise-plus-interference density ratio in dB·Hz.
+    #[getter]
+    fn c_n0i0(&self) -> PyDecibel {
+        PyDecibel(self.0.c_n0i0)
+    }
+
+    /// Eb/(N0+I0) in dB.
+    #[getter]
+    fn eb_n0i0(&self) -> PyDecibel {
+        PyDecibel(self.0.eb_n0i0)
+    }
+
+    /// Link margin with interference in dB.
+    #[getter]
+    fn margin_with_interference(&self) -> PyDecibel {
+        PyDecibel(self.0.margin_with_interference)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "InterferenceStats(interference_power_w={}, c_n0i0={:.2} dB·Hz, eb_n0i0={:.2} dB, margin_with_interference={:.2} dB)",
+            repr_f64(self.0.interference_power_w),
+            self.0.c_n0i0.as_f64(),
+            self.0.eb_n0i0.as_f64(),
+            self.0.margin_with_interference.as_f64(),
+        )
+    }
+}
+
+// --- Modulated Link Stats ---
+
+/// Link-budget output with modulation/coding figures applied.
+#[pyclass(
+    name = "ModulatedLinkStats",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
+#[derive(Debug, Clone)]
+pub struct PyModulatedLinkStats(pub ModulatedLinkStats);
+
+#[pymethods]
+impl PyModulatedLinkStats {
+    /// The underlying modulation-agnostic link budget.
+    #[getter]
+    fn link(&self) -> PyLinkStats {
+        PyLinkStats(self.0.link.clone())
+    }
+
+    /// The channel (modulation, FEC, required Eb/N0, margin) applied.
+    #[getter]
+    fn channel(&self) -> PyChannel {
+        PyChannel(self.0.channel.clone())
+    }
+
+    /// Symbol rate from the channel.
+    #[getter]
+    fn symbol_rate(&self) -> PyFrequency {
+        PyFrequency(self.0.symbol_rate)
+    }
+
+    /// Es/N0 (energy per symbol to noise spectral density) in dB.
+    #[getter]
+    fn es_n0(&self) -> PyDecibel {
+        PyDecibel(self.0.es_n0)
+    }
+
+    /// Eb/N0 (energy per information bit to noise spectral density) in dB.
+    #[getter]
+    fn eb_n0(&self) -> PyDecibel {
+        PyDecibel(self.0.eb_n0)
+    }
+
+    /// Link margin in dB.
+    #[getter]
+    fn margin(&self) -> PyDecibel {
+        PyDecibel(self.0.margin)
+    }
+
+    /// Interference statistics (if computed).
+    #[getter]
+    fn interference(&self) -> Option<PyInterferenceStats> {
+        self.0
+            .interference
+            .as_ref()
+            .map(|i| PyInterferenceStats(i.clone()))
+    }
+
+    /// Computes interference statistics for a given interferer power.
+    fn with_interference(&self, interference_power_w: f64) -> PyInterferenceStats {
+        PyInterferenceStats(self.0.with_interference(interference_power_w))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ModulatedLinkStats(eb_n0={:.2} dB, margin={:.2} dB, interference={})",
+            self.0.eb_n0.as_f64(),
+            self.0.margin.as_f64(),
+            if self.0.interference.is_some() {
+                "present"
+            } else {
+                "None"
+            },
         )
     }
 }

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -736,6 +736,10 @@ impl PyEirpTransmitter {
         )
     }
 
+    fn __getnewargs__(&self) -> (PyFrequency, PyDecibel) {
+        (PyFrequency(self.0.frequency), PyDecibel(self.0.eirp))
+    }
+
     fn __eq__(&self, other: &Self) -> bool {
         self.0.frequency == other.0.frequency && self.0.eirp == other.0.eirp
     }
@@ -778,6 +782,10 @@ impl PyGtReceiver {
             repr_f64(self.0.frequency.to_hertz()),
             repr_f64(self.0.gt.as_f64())
         )
+    }
+
+    fn __getnewargs__(&self) -> (PyFrequency, PyDecibel) {
+        (PyFrequency(self.0.frequency), PyDecibel(self.0.gt))
     }
 
     fn __eq__(&self, other: &Self) -> bool {
@@ -1201,13 +1209,13 @@ impl PyCommunicationSystem {
         receiver: Option<&Bound<'_, PyAny>>,
         transmitter: Option<&PyAmplifierTransmitter>,
     ) -> PyResult<Self> {
-        if let Some(rx_obj) = receiver {
-            if rx_obj.extract::<PyRef<'_, PyGtReceiver>>().is_ok() {
-                return Err(PyValueError::new_err(
-                    "GtReceiver is not accepted by the regular constructor; \
+        if let Some(rx_obj) = receiver
+            && rx_obj.extract::<PyRef<'_, PyGtReceiver>>().is_ok()
+        {
+            return Err(PyValueError::new_err(
+                "GtReceiver is not accepted by the regular constructor; \
                      use CommunicationSystem.gt_only(rx) instead",
-                ));
-            }
+            ));
         }
         let ant = build_antenna(antenna)?;
         let rx = receiver.map(build_receiver).transpose()?;
@@ -1641,8 +1649,11 @@ impl PyModulatedLinkStats {
     }
 
     /// Computes interference statistics for a given interferer power.
-    fn with_interference(&self, interference_power_w: f64) -> PyInterferenceStats {
-        PyInterferenceStats(self.0.with_interference(interference_power_w))
+    fn with_interference(&self, interference_power_w: f64) -> PyResult<PyInterferenceStats> {
+        self.0
+            .with_interference(interference_power_w)
+            .map(PyInterferenceStats)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     fn __repr__(&self) -> String {

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -8,7 +8,7 @@ use lox_core::glam::DVec3;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use lox_comms::antenna::{Antenna, AntennaGain, ComplexAntenna, SimpleAntenna};
+use lox_comms::antenna::{Antenna, AntennaGain, ConstantAntenna, PatternedAntenna};
 use lox_comms::channel::{Channel, LinkDirection, Modulation};
 use lox_comms::link_budget::{LinkStats, frequency_overlap_factor};
 use lox_itur::EnvironmentalLosses;
@@ -338,8 +338,8 @@ impl PyDipolePattern {
 #[pyclass(name = "SimpleAntenna", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PySimpleAntenna {
-    /// The wrapped [`SimpleAntenna`] value.
-    pub inner: SimpleAntenna,
+    /// The wrapped [`ConstantAntenna`] value.
+    pub inner: ConstantAntenna,
 }
 
 #[pymethods]
@@ -347,7 +347,7 @@ impl PySimpleAntenna {
     #[new]
     fn new(gain: PyDecibel, beamwidth: PyAngle) -> Self {
         Self {
-            inner: SimpleAntenna {
+            inner: ConstantAntenna {
                 gain: gain.0,
                 beamwidth: beamwidth.0,
             },
@@ -379,14 +379,14 @@ impl PySimpleAntenna {
 ///     boresight: Boresight direction as [x, y, z].
 #[pyclass(name = "ComplexAntenna", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
-pub struct PyComplexAntenna(pub ComplexAntenna);
+pub struct PyComplexAntenna(pub PatternedAntenna);
 
 #[pymethods]
 impl PyComplexAntenna {
     #[new]
     fn new(pattern: &Bound<'_, PyAny>, boresight: [f64; 3]) -> PyResult<Self> {
         let pattern = extract_antenna_pattern(pattern)?;
-        Ok(Self(ComplexAntenna {
+        Ok(Self(PatternedAntenna {
             pattern,
             boresight: DVec3::from_array(boresight),
         }))
@@ -483,10 +483,10 @@ fn pattern_to_py<'py>(py: Python<'py>, pattern: &AntennaPattern) -> Bound<'py, P
 
 fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
     match antenna {
-        Antenna::Simple(a) => Bound::new(
+        Antenna::Constant(a) => Bound::new(
             py,
             PySimpleAntenna {
-                inner: SimpleAntenna {
+                inner: ConstantAntenna {
                     gain: a.gain,
                     beamwidth: a.beamwidth,
                 },
@@ -494,7 +494,7 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
         )
         .unwrap()
         .into_any(),
-        Antenna::Complex(a) => {
+        Antenna::Patterned(a) => {
             let pattern = match &a.pattern {
                 AntennaPattern::Parabolic(p) => {
                     AntennaPattern::Parabolic(ParabolicPattern::new(p.diameter, p.efficiency))
@@ -506,7 +506,7 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
             };
             Bound::new(
                 py,
-                PyComplexAntenna(ComplexAntenna {
+                PyComplexAntenna(PatternedAntenna {
                     pattern,
                     boresight: a.boresight,
                 }),
@@ -514,6 +514,7 @@ fn antenna_to_py<'py>(py: Python<'py>, antenna: &Antenna) -> Bound<'py, PyAny> {
             .unwrap()
             .into_any()
         }
+        _ => unreachable!("unknown antenna variant"),
     }
 }
 
@@ -536,7 +537,7 @@ fn receiver_to_py<'py>(py: Python<'py>, receiver: &Receiver) -> Bound<'py, PyAny
 
 fn build_antenna(obj: &Bound<'_, PyAny>) -> PyResult<Antenna> {
     if let Ok(a) = obj.extract::<PyRef<'_, PySimpleAntenna>>() {
-        Ok(Antenna::Simple(SimpleAntenna {
+        Ok(Antenna::Constant(ConstantAntenna {
             gain: a.inner.gain,
             beamwidth: a.inner.beamwidth,
         }))
@@ -550,7 +551,7 @@ fn build_antenna(obj: &Bound<'_, PyAny>) -> PyResult<Antenna> {
             }
             AntennaPattern::Dipole(p) => AntennaPattern::Dipole(DipolePattern::new(p.length)),
         };
-        Ok(Antenna::Complex(ComplexAntenna {
+        Ok(Antenna::Patterned(PatternedAntenna {
             pattern,
             boresight: a.0.boresight,
         }))
@@ -1077,13 +1078,11 @@ impl PyCommunicationSystem {
         range: PyDistance,
         tx_angle: PyAngle,
         rx_angle: PyAngle,
-    ) -> PyDecibel {
-        PyDecibel(self.0.carrier_to_noise_density(
-            &rx_system.0,
-            losses.0,
-            range.0,
-            tx_angle.0,
-            rx_angle.0,
+    ) -> PyResult<PyDecibel> {
+        Ok(PyDecibel(
+            self.0
+                .carrier_to_noise_density(&rx_system.0, losses.0, range.0, tx_angle.0, rx_angle.0)
+                .map_err(|e| PyValueError::new_err(e.to_string()))?,
         ))
     }
 
@@ -1095,16 +1094,21 @@ impl PyCommunicationSystem {
         range: PyDistance,
         tx_angle: PyAngle,
         rx_angle: PyAngle,
-    ) -> PyDecibel {
-        PyDecibel(
+    ) -> PyResult<PyDecibel> {
+        Ok(PyDecibel(
             self.0
-                .carrier_power(&rx_system.0, losses.0, range.0, tx_angle.0, rx_angle.0),
-        )
+                .carrier_power(&rx_system.0, losses.0, range.0, tx_angle.0, rx_angle.0)
+                .map_err(|e| PyValueError::new_err(e.to_string()))?,
+        ))
     }
 
     /// Computes the noise power in dBW for a given bandwidth.
-    fn noise_power(&self, bandwidth: PyFrequency) -> PyDecibel {
-        PyDecibel(self.0.noise_power(f64::from(bandwidth.0)))
+    fn noise_power(&self, bandwidth: PyFrequency) -> PyResult<PyDecibel> {
+        Ok(PyDecibel(
+            self.0
+                .noise_power(f64::from(bandwidth.0))
+                .map_err(|e| PyValueError::new_err(e.to_string()))?,
+        ))
     }
 
     #[allow(clippy::type_complexity)]
@@ -1131,12 +1135,12 @@ impl PyCommunicationSystem {
 
     fn __repr__(&self) -> String {
         let antenna_repr = match &self.0.antenna {
-            Antenna::Simple(a) => format!(
+            Antenna::Constant(a) => format!(
                 "SimpleAntenna(gain={}, beamwidth={})",
                 PyDecibel(a.gain).__repr__(),
                 PyAngle(a.beamwidth).__repr__(),
             ),
-            Antenna::Complex(a) => {
+            Antenna::Patterned(a) => {
                 let pattern_repr = match &a.pattern {
                     AntennaPattern::Parabolic(p) => format!(
                         "ParabolicPattern(diameter={}, efficiency={})",
@@ -1160,6 +1164,7 @@ impl PyCommunicationSystem {
                     repr_f64(b.z),
                 )
             }
+            _ => unreachable!("unknown antenna variant"),
         };
         let rx_repr = match &self.0.receiver {
             Some(Receiver::Simple(r)) => format!(

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1081,7 +1081,7 @@ impl PyCommunicationSystem {
         let rx = receiver.map(build_receiver).transpose()?;
         let tx = transmitter.map(build_transmitter);
         Ok(Self(CommunicationSystem {
-            antenna: ant,
+            antenna: Some(ant),
             receiver: rx,
             transmitter: tx,
         }))
@@ -1111,6 +1111,8 @@ impl PyCommunicationSystem {
     }
 
     /// Computes the received carrier power in dBW.
+    ///
+    /// Returns ``None`` for lumped G/T receivers.
     fn carrier_power(
         &self,
         rx_system: &PyCommunicationSystem,
@@ -1118,21 +1120,21 @@ impl PyCommunicationSystem {
         range: PyDistance,
         tx_angle: PyAngle,
         rx_angle: PyAngle,
-    ) -> PyResult<PyDecibel> {
-        Ok(PyDecibel(
-            self.0
-                .carrier_power(&rx_system.0, losses.0, range.0, tx_angle.0, rx_angle.0)
-                .map_err(|e| PyValueError::new_err(e.to_string()))?,
-        ))
+    ) -> PyResult<Option<PyDecibel>> {
+        self.0
+            .carrier_power(&rx_system.0, losses.0, range.0, tx_angle.0, rx_angle.0)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+            .map(|opt| opt.map(PyDecibel))
     }
 
     /// Computes the noise power in dBW for a given bandwidth.
-    fn noise_power(&self, bandwidth: PyFrequency) -> PyResult<PyDecibel> {
-        Ok(PyDecibel(
-            self.0
-                .noise_power(f64::from(bandwidth.0))
-                .map_err(|e| PyValueError::new_err(e.to_string()))?,
-        ))
+    ///
+    /// Returns ``None`` for lumped G/T receivers.
+    fn noise_power(&self, bandwidth: PyFrequency) -> PyResult<Option<PyDecibel>> {
+        self.0
+            .noise_power(f64::from(bandwidth.0))
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+            .map(|opt| opt.map(PyDecibel))
     }
 
     #[allow(clippy::type_complexity)]
@@ -1144,7 +1146,12 @@ impl PyCommunicationSystem {
         Option<Bound<'py, PyAny>>,
         Option<PyTransmitter>,
     ) {
-        let antenna = antenna_to_py(py, &self.0.antenna);
+        let antenna = self
+            .0
+            .antenna
+            .as_ref()
+            .map(|a| antenna_to_py(py, a))
+            .expect("component-tier CommunicationSystem must have an antenna");
         let receiver = self.0.receiver.as_ref().map(|r| receiver_to_py(py, r));
         let transmitter = self.0.transmitter.as_ref().map(|t| {
             PyTransmitter(match t {
@@ -1154,6 +1161,7 @@ impl PyCommunicationSystem {
                     a.line_loss,
                     a.output_back_off,
                 )),
+                Transmitter::Eirp(_) => unreachable!("Eirp transmitter not yet exposed in Python"),
                 _ => unreachable!("unknown transmitter variant"),
             })
         });
@@ -1161,13 +1169,13 @@ impl PyCommunicationSystem {
     }
 
     fn __repr__(&self) -> String {
-        let antenna_repr = match &self.0.antenna {
-            Antenna::Constant(a) => format!(
+        let antenna_repr = match self.0.antenna.as_ref() {
+            Some(Antenna::Constant(a)) => format!(
                 "SimpleAntenna(gain={}, beamwidth={})",
                 PyDecibel(a.gain).__repr__(),
                 PyAngle(a.beamwidth).__repr__(),
             ),
-            Antenna::Patterned(a) => {
+            Some(Antenna::Patterned(a)) => {
                 let pattern_repr = match &a.pattern {
                     AntennaPattern::Parabolic(p) => format!(
                         "ParabolicPattern(diameter={}, efficiency={})",
@@ -1192,7 +1200,8 @@ impl PyCommunicationSystem {
                     repr_f64(b.z),
                 )
             }
-            _ => unreachable!("unknown antenna variant"),
+            Some(_) => unreachable!("unknown antenna variant"),
+            None => String::from("None"),
         };
         let rx_repr = match &self.0.receiver {
             Some(Receiver::NoiseTemperature(r)) => format!(
@@ -1203,6 +1212,7 @@ impl PyCommunicationSystem {
             Some(Receiver::Cascade(r)) => {
                 format!(", receiver={}", PyComplexReceiver(r.clone()).__repr__())
             }
+            Some(Receiver::Gt(_)) => unreachable!("Gt receiver not yet exposed in Python"),
             Some(_) => unreachable!("unknown receiver variant"),
             None => String::new(),
         };
@@ -1215,6 +1225,7 @@ impl PyCommunicationSystem {
                     PyDecibel(a.line_loss).__repr__(),
                     PyDecibel(a.output_back_off).__repr__(),
                 ),
+                Transmitter::Eirp(_) => unreachable!("Eirp transmitter not yet exposed in Python"),
                 _ => unreachable!("unknown transmitter variant"),
             },
             None => String::new(),

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -13,9 +13,9 @@ use crate::analysis::python::{
 use crate::bodies::python::PyOrigin;
 use crate::comms::python::{
     PyChannel, PyCommunicationSystem, PyComplexAntenna, PyComplexReceiver, PyDecibel,
-    PyDipolePattern, PyGaussianPattern, PyLinkStats, PyModulation, PyNoiseStage,
-    PyParabolicPattern, PySimpleAntenna, PySimpleReceiver, PyTransmitter, freq_overlap, fspl,
-    pfd_mask, power_flux_density, slant_range,
+    PyDipolePattern, PyGaussianPattern, PyInterferenceStats, PyLinkStats, PyModulatedLinkStats,
+    PyModulation, PyNoiseStage, PyParabolicPattern, PySimpleAntenna, PySimpleReceiver,
+    PyTransmitter, freq_overlap, fspl, pfd_mask, power_flux_density, slant_range,
 };
 use crate::constellations::python::{PyConstellation, PyConstellationSatellite};
 use crate::earth::python::ut1::{EopParserError, EopProviderError, PyEopProvider};
@@ -73,6 +73,8 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyEnvironmentalLosses>()?;
     m.add_class::<PyCommunicationSystem>()?;
     m.add_class::<PyLinkStats>()?;
+    m.add_class::<PyInterferenceStats>()?;
+    m.add_class::<PyModulatedLinkStats>()?;
     m.add_function(wrap_pyfunction!(fspl, m)?)?;
     m.add_function(wrap_pyfunction!(freq_overlap, m)?)?;
     m.add_function(wrap_pyfunction!(power_flux_density, m)?)?;

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -12,10 +12,11 @@ use crate::analysis::python::{
 };
 use crate::bodies::python::PyOrigin;
 use crate::comms::python::{
-    PyChannel, PyCommunicationSystem, PyComplexAntenna, PyComplexReceiver, PyDecibel,
-    PyDipolePattern, PyGaussianPattern, PyInterferenceStats, PyLinkStats, PyModulatedLinkStats,
-    PyModulation, PyNoiseStage, PyParabolicPattern, PySimpleAntenna, PySimpleReceiver,
-    PyTransmitter, freq_overlap, fspl, pfd_mask, power_flux_density, slant_range,
+    PyAmplifierTransmitter, PyCascadeReceiver, PyChannel, PyCommunicationSystem, PyConstantAntenna,
+    PyDecibel, PyDipolePattern, PyEirpTransmitter, PyGaussianPattern, PyGtReceiver,
+    PyInterferenceStats, PyLinkStats, PyModulatedLinkStats, PyModulation, PyNoiseStage,
+    PyNoiseTempReceiver, PyParabolicPattern, PyPatternedAntenna, freq_overlap, fspl, pfd_mask,
+    power_flux_density, slant_range,
 };
 use crate::constellations::python::{PyConstellation, PyConstellationSatellite};
 use crate::earth::python::ut1::{EopParserError, EopProviderError, PyEopProvider};
@@ -62,11 +63,13 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyParabolicPattern>()?;
     m.add_class::<PyGaussianPattern>()?;
     m.add_class::<PyDipolePattern>()?;
-    m.add_class::<PySimpleAntenna>()?;
-    m.add_class::<PyComplexAntenna>()?;
-    m.add_class::<PyTransmitter>()?;
-    m.add_class::<PySimpleReceiver>()?;
-    m.add_class::<PyComplexReceiver>()?;
+    m.add_class::<PyConstantAntenna>()?;
+    m.add_class::<PyPatternedAntenna>()?;
+    m.add_class::<PyAmplifierTransmitter>()?;
+    m.add_class::<PyEirpTransmitter>()?;
+    m.add_class::<PyNoiseTempReceiver>()?;
+    m.add_class::<PyCascadeReceiver>()?;
+    m.add_class::<PyGtReceiver>()?;
     m.add_class::<PyNoiseStage>()?;
     m.add_class::<PyChannel>()?;
     m.add_class::<PyItuProvider>()?;

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -1304,3 +1304,39 @@ def test_eirp_gt_lumped_link():
     assert link.carrier_rx_power is None
     assert link.noise_power is None
     assert abs(float(link.c_n0) - 104.913) < 0.2
+
+
+def test_lumped_transmitter_receiver_pickle():
+    tx = lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    rx = lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+
+    assert pickle.loads(pickle.dumps(tx)) == tx
+    assert pickle.loads(pickle.dumps(rx)) == rx
+
+
+def test_lumped_link_interference_requires_absolute_power():
+    tx = lox.CommunicationSystem.eirp_only(
+        lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    )
+    rx = lox.CommunicationSystem.gt_only(
+        lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    )
+    channel = lox.Channel(
+        link_type="downlink",
+        symbol_rate=5.0 * lox.MHz,
+        required_eb_n0=10.0 * lox.dB,
+        margin=3.0 * lox.dB,
+        modulation=lox.Modulation("QPSK"),
+    )
+    link = lox.LinkStats.calculate(
+        tx,
+        rx,
+        1000.0 * lox.km,
+        channel.bandwidth(),
+        0.0 * lox.rad,
+        0.0 * lox.rad,
+    )
+    modulated = channel.apply(link)
+
+    with pytest.raises(ValueError, match="absolute carrier and noise powers"):
+        modulated.with_interference(1e-12)

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -1451,3 +1451,279 @@ def test_modulated_with_interference_component_tier():
     assert float(interference.margin_with_interference) < float(modulated.margin)
     assert float(interference.eb_n0i0) < float(modulated.eb_n0)
     assert interference.interference_power_w == 1e-12
+
+
+# --- CommunicationSystem __new__ validation error paths ---
+
+
+def test_build_transmitter_rejects_non_transmitter():
+    antenna = lox.ConstantAntenna(0.0 * lox.dB, 1.0 * lox.deg)
+    with pytest.raises(ValueError, match="EirpTransmitter or AmplifierTransmitter"):
+        lox.CommunicationSystem(antenna=antenna, transmitter="not a transmitter")
+
+
+def test_amplifier_without_antenna_rejected():
+    tx = lox.AmplifierTransmitter(29.0 * lox.GHz, 10.0 * lox.W, 1.0 * lox.dB)
+    with pytest.raises(ValueError, match="AmplifierTransmitter requires an antenna"):
+        lox.CommunicationSystem(transmitter=tx)
+
+
+def test_gt_receiver_with_antenna_rejected():
+    antenna = lox.ConstantAntenna(30.0 * lox.dB, 3.0 * lox.deg)
+    rx = lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    with pytest.raises(ValueError, match="GtReceiver must not be paired"):
+        lox.CommunicationSystem(antenna=antenna, receiver=rx)
+
+
+def test_component_receiver_without_antenna_rejected():
+    rx = lox.NoiseTempReceiver(29.0 * lox.GHz, 500.0 * lox.K)
+    with pytest.raises(ValueError, match="component-tier receiver requires"):
+        lox.CommunicationSystem(receiver=rx)
+
+
+def test_cascade_receiver_without_antenna_rejected():
+    rx = lox.CascadeReceiver(
+        frequency=29 * lox.GHz,
+        antenna_noise_temperature=100.0 * lox.K,
+        stages=[lox.NoiseStage(gain=20.0 * lox.dB, noise_temperature=50.0 * lox.K)],
+    )
+    with pytest.raises(ValueError, match="component-tier receiver requires"):
+        lox.CommunicationSystem(receiver=rx)
+
+
+# --- EirpTransmitter getters and repr ---
+
+
+def test_eirp_transmitter_getters():
+    tx = lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    assert tx.frequency.to_hertz() == pytest.approx(29e9, abs=1.0)
+    assert float(tx.eirp) == pytest.approx(55.0, abs=1e-10)
+
+
+def test_eirp_transmitter_repr():
+    tx = lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    r = repr(tx)
+    assert "EirpTransmitter" in r
+    assert "55.0" in r
+
+
+def test_eirp_transmitter_eq():
+    a = lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    b = lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    c = lox.EirpTransmitter(29.0 * lox.GHz, 50.0 * lox.dB)
+    assert a == b
+    assert not (a == c)
+
+
+# --- GtReceiver getters and repr ---
+
+
+def test_gt_receiver_getters():
+    rx = lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    assert rx.frequency.to_hertz() == pytest.approx(29e9, abs=1.0)
+    assert float(rx.gt) == pytest.approx(3.01, abs=1e-10)
+
+
+def test_gt_receiver_repr():
+    rx = lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    r = repr(rx)
+    assert "GtReceiver" in r
+    assert "3.01" in r
+
+
+def test_gt_receiver_eq():
+    a = lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    b = lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    c = lox.GtReceiver(29.0 * lox.GHz, 5.0 * lox.dB)
+    assert a == b
+    assert not (a == c)
+
+
+# --- NoiseTempReceiver repr ---
+
+
+def test_simple_receiver_repr():
+    rx = lox.NoiseTempReceiver(frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K)
+    r = repr(rx)
+    assert "NoiseTempReceiver" in r
+    assert "500" in r
+
+
+# --- CommunicationSystem __eq__ ---
+
+
+def test_communication_system_eq():
+    ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    tx = lox.AmplifierTransmitter(frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB)
+    a = lox.CommunicationSystem(antenna=ant, transmitter=tx)
+    b = lox.CommunicationSystem(antenna=ant, transmitter=tx)
+    c = lox.CommunicationSystem(antenna=ant)
+    assert a == b
+    assert not (a == c)
+
+
+# --- Channel DSSS pickle ---
+
+
+def test_channel_dsss_pickle():
+    ch = lox.Channel(
+        link_type="downlink",
+        symbol_rate=10 * lox.kHz,
+        required_eb_n0=10.0 * lox.dB,
+        margin=3.0 * lox.dB,
+        modulation=lox.Modulation("BPSK"),
+        chip_rate=4 * lox.MHz,
+    )
+    restored = pickle.loads(pickle.dumps(ch))
+    assert restored.spreading_factor() == pytest.approx(ch.spreading_factor(), rel=1e-10)
+    assert float(restored.processing_gain()) == pytest.approx(float(ch.processing_gain()), abs=1e-10)
+
+
+# --- LinkStats tx_angle and rx_angle getters ---
+
+
+def test_link_stats_angle_getters():
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB)
+    tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
+
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K)
+    rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
+
+    stats = lox.LinkStats.calculate(
+        tx_sys, rx_sys, 1000.0 * lox.km, 5.0 * lox.MHz, 2.0 * lox.deg, 1.0 * lox.deg
+    )
+    assert stats.tx_angle.to_degrees() == pytest.approx(2.0, abs=1e-10)
+    assert stats.rx_angle.to_degrees() == pytest.approx(1.0, abs=1e-10)
+
+
+# --- ModulatedLinkStats link, channel, interference getters ---
+
+
+def test_modulated_link_stats_link_and_channel_getters():
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB)
+    tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
+
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K)
+    rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
+
+    ch = lox.Channel(
+        link_type="downlink",
+        symbol_rate=5 * lox.MHz,
+        required_eb_n0=10.0 * lox.dB,
+        margin=3.0 * lox.dB,
+        modulation=lox.Modulation("QPSK"),
+    )
+    stats = lox.LinkStats.calculate(
+        tx_sys, rx_sys, 1000.0 * lox.km, ch.bandwidth(), 0.0 * lox.deg, 0.0 * lox.deg
+    )
+    modulated = ch.apply(stats)
+
+    # link getter returns the underlying PyLinkStats
+    assert modulated.link.c_n0 == stats.c_n0
+    # channel getter returns the PyChannel
+    assert "QPSK" in repr(modulated.channel)
+    # interference getter is None when no interference was applied
+    assert modulated.interference is None
+
+
+# --- InterferenceStats c_n0i0 and repr ---
+
+
+def test_interference_stats_c_n0i0_and_repr():
+    tx_antenna = lox.ConstantAntenna(46.0 * lox.dB, 0.7 * lox.deg)
+    tx_transmitter = lox.AmplifierTransmitter(
+        frequency=29.0 * lox.GHz, power=10.0 * lox.W, line_loss=1.0 * lox.dB,
+    )
+    tx = lox.CommunicationSystem(antenna=tx_antenna, transmitter=tx_transmitter)
+
+    rx_antenna = lox.ConstantAntenna(30.0 * lox.dB, 3.0 * lox.deg)
+    rx_receiver = lox.NoiseTempReceiver(29.0 * lox.GHz, 500.0 * lox.K)
+    rx = lox.CommunicationSystem(antenna=rx_antenna, receiver=rx_receiver)
+
+    channel = lox.Channel(
+        link_type="downlink",
+        symbol_rate=5.0 * lox.MHz,
+        required_eb_n0=10.0 * lox.dB,
+        margin=3.0 * lox.dB,
+        modulation=lox.Modulation("QPSK"),
+    )
+    link = lox.LinkStats.calculate(
+        tx, rx, 1000.0 * lox.km, channel.bandwidth(), 0.0 * lox.rad, 0.0 * lox.rad,
+    )
+    modulated = channel.apply(link)
+    interference = modulated.with_interference(1e-12)
+
+    assert math.isfinite(float(interference.c_n0i0))
+    r = repr(interference)
+    assert "InterferenceStats" in r
+    assert "c_n0i0" in r
+
+
+# --- ModulatedLinkStats repr ---
+
+
+def test_modulated_link_stats_repr():
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB)
+    tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
+
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K)
+    rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
+
+    ch = lox.Channel(
+        link_type="downlink",
+        symbol_rate=5 * lox.MHz,
+        required_eb_n0=10.0 * lox.dB,
+        margin=3.0 * lox.dB,
+        modulation=lox.Modulation("QPSK"),
+    )
+    stats = lox.LinkStats.calculate(
+        tx_sys, rx_sys, 1000.0 * lox.km, ch.bandwidth(), 0.0 * lox.deg, 0.0 * lox.deg
+    )
+    modulated = ch.apply(stats)
+    r = repr(modulated)
+    assert "ModulatedLinkStats" in r
+    assert "eb_n0=" in r
+    assert "margin=" in r
+
+
+# --- CommunicationSystem repr with GtReceiver (lumped rx side) ---
+
+
+def test_communication_system_repr_gt_receiver():
+    rx_sys = lox.CommunicationSystem.gt_only(lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB))
+    r = repr(rx_sys)
+    assert "GtReceiver" in r
+    assert "3.01" in r
+
+
+# --- Decibel arithmetic: __mul__ with scalar on left side ---
+
+
+def test_decibel_mul_left():
+    db = lox.Decibel(5.0)
+    result = db * 3.0
+    assert float(result) == pytest.approx(15.0, abs=1e-10)
+
+
+# --- Modulation: all variants pickle to correct name ---
+
+
+def test_modulation_repr_all_variants():
+    expected = {
+        "BPSK": "Modulation('BPSK')",
+        "QPSK": "Modulation('QPSK')",
+        "8PSK": "Modulation('8PSK')",
+        "16QAM": "Modulation('16QAM')",
+        "32QAM": "Modulation('32QAM')",
+        "64QAM": "Modulation('64QAM')",
+        "128QAM": "Modulation('128QAM')",
+        "256QAM": "Modulation('256QAM')",
+    }
+    for name, expected_repr in expected.items():
+        assert repr(lox.Modulation(name)) == expected_repr

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -289,10 +289,10 @@ def test_dipole_repr_roundtrip():
 def test_complex_antenna_dipole_beamwidth_is_none():
     # DipolePattern returns None because the API has no plane-of-measurement
     # parameter; the E-plane HPBW is physically defined but not expressible as
-    # a single value here. ComplexAntenna delegates to the pattern, so it also
+    # a single value here. PatternedAntenna delegates to the pattern, so it also
     # returns None.
     d = lox.DipolePattern(length=0.005 * lox.m)
-    a = lox.ComplexAntenna(pattern=d, boresight=[0.0, 0.0, 1.0])
+    a = lox.PatternedAntenna(pattern=d, boresight=[0.0, 0.0, 1.0])
     assert a.beamwidth(frequency=29e9 * lox.Hz) is None
 
 
@@ -300,31 +300,31 @@ def test_complex_antenna_dipole_beamwidth_is_none():
 
 
 def test_simple_antenna():
-    a = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    a = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
     r = repr(a)
-    assert r.startswith("SimpleAntenna(gain=Decibel(30.0), beamwidth=Angle(")
+    assert r.startswith("ConstantAntenna(gain=Decibel(30.0), beamwidth=Angle(")
 
 
 def test_simple_antenna_eq():
-    a = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    b = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    c = lox.SimpleAntenna(gain=20.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    a = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    b = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    c = lox.ConstantAntenna(gain=20.0 * lox.dB, beamwidth=3.0 * lox.deg)
     assert a == b
     assert not (a == c)
 
 
 def test_simple_antenna_pickle():
-    a = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    a = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
     assert pickle.loads(pickle.dumps(a)) == a
 
 
 def test_simple_antenna_repr_roundtrip():
-    a = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    a = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
     assert (
         eval(
             repr(a),
             {
-                "SimpleAntenna": lox.SimpleAntenna,
+                "ConstantAntenna": lox.ConstantAntenna,
                 "Decibel": lox.Decibel,
                 "Angle": lox.Angle,
             },
@@ -335,21 +335,21 @@ def test_simple_antenna_repr_roundtrip():
 
 def test_complex_antenna():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    a = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
     gain = a.gain(29e9 * lox.Hz, angle=0.0 * lox.deg)
     assert float(gain) == pytest.approx(46.01119, rel=1e-4)
 
 
 def test_complex_antenna_invalid_pattern():
     with pytest.raises(ValueError, match="expected a ParabolicPattern"):
-        lox.ComplexAntenna(pattern="not a pattern", boresight=[0.0, 0.0, 1.0])
+        lox.PatternedAntenna(pattern="not a pattern", boresight=[0.0, 0.0, 1.0])
 
 
 def test_complex_antenna_pickle():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    a = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
     restored = pickle.loads(pickle.dumps(a))
-    # ComplexAntenna doesn't have __eq__, verify via gain
+    # PatternedAntenna doesn't have __eq__, verify via gain
     assert float(restored.gain(29e9 * lox.Hz, 0.0 * lox.deg)) == pytest.approx(
         float(a.gain(29e9 * lox.Hz, 0.0 * lox.deg)), abs=1e-10
     )
@@ -357,9 +357,9 @@ def test_complex_antenna_pickle():
 
 def test_complex_antenna_repr():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    a = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
     r = repr(a)
-    assert r.startswith("ComplexAntenna(pattern=ParabolicPattern(")
+    assert r.startswith("PatternedAntenna(pattern=ParabolicPattern(")
     assert "boresight=[0.0, 0.0, 1.0]" in r
 
 
@@ -369,8 +369,8 @@ def test_complex_antenna_repr():
 def test_transmitter_eirp():
     # 10 dBi antenna, 5 W power, 1 dB line loss, 0 dB OBO
     # EIRP = 10 + 10*log10(5) - 1 = 15.99 dBW
-    a = lox.SimpleAntenna(gain=10.0 * lox.dB, beamwidth=10.0 * lox.deg)
-    tx = lox.Transmitter(
+    a = lox.ConstantAntenna(gain=10.0 * lox.dB, beamwidth=10.0 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=5.0 * lox.W, line_loss=1.0 * lox.dB
     )
     eirp = tx.eirp(a, angle=0.0 * lox.deg)
@@ -378,20 +378,20 @@ def test_transmitter_eirp():
 
 
 def test_transmitter_default_obo():
-    tx = lox.Transmitter(
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=0.0 * lox.dB
     )
     assert repr(tx).endswith("output_back_off=Decibel(0.0))")
 
 
 def test_transmitter_eq():
-    a = lox.Transmitter(
+    a = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
-    b = lox.Transmitter(
+    b = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
-    c = lox.Transmitter(
+    c = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=5.0 * lox.W, line_loss=1.0 * lox.dB
     )
     assert a == b
@@ -399,7 +399,7 @@ def test_transmitter_eq():
 
 
 def test_transmitter_pickle():
-    tx = lox.Transmitter(
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz,
         power=10.0 * lox.W,
         line_loss=1.0 * lox.dB,
@@ -409,7 +409,7 @@ def test_transmitter_pickle():
 
 
 def test_transmitter_repr_roundtrip():
-    tx = lox.Transmitter(
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz,
         power=10.0 * lox.W,
         line_loss=1.0 * lox.dB,
@@ -419,7 +419,7 @@ def test_transmitter_repr_roundtrip():
         eval(
             repr(tx),
             {
-                "Transmitter": lox.Transmitter,
+                "AmplifierTransmitter": lox.AmplifierTransmitter,
                 "Frequency": lox.Frequency,
                 "Power": lox.Power,
                 "Decibel": lox.Decibel,
@@ -435,7 +435,7 @@ def test_transmitter_repr_roundtrip():
 def test_complex_receiver_from_lna_and_noise_figure():
     # Gateway link: T_ant=290K, LNA(G=20dB, T=175K), Rx(NF=2dB)
     # T_sys = 290 + 175 + 169.619/100 = 466.696 K
-    rx = lox.ComplexReceiver.from_lna_and_noise_figure(
+    rx = lox.CascadeReceiver.from_lna_and_noise_figure(
         frequency=26.5 * lox.GHz,
         antenna_noise_temperature=290.0 * lox.K,
         lna_gain=20.0 * lox.dB,
@@ -447,7 +447,7 @@ def test_complex_receiver_from_lna_and_noise_figure():
 
 def test_complex_receiver_from_feed_loss_and_noise_figure():
     # Feed loss=3dB, NF=5dB, T_ant=265K, receiver_gain=20dB
-    rx = lox.ComplexReceiver.from_feed_loss_and_noise_figure(
+    rx = lox.CascadeReceiver.from_feed_loss_and_noise_figure(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=265.0 * lox.K,
         feed_loss=3.0 * lox.dB,
@@ -463,13 +463,13 @@ def test_complex_receiver_from_feed_loss_and_noise_figure():
 
 
 def test_simple_receiver_eq():
-    a = lox.SimpleReceiver(
+    a = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
-    b = lox.SimpleReceiver(
+    b = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
-    c = lox.SimpleReceiver(
+    c = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=600.0 * lox.K
     )
     assert a == b
@@ -477,21 +477,21 @@ def test_simple_receiver_eq():
 
 
 def test_simple_receiver_pickle():
-    rx = lox.SimpleReceiver(
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     assert pickle.loads(pickle.dumps(rx)) == rx
 
 
 def test_simple_receiver_repr_roundtrip():
-    rx = lox.SimpleReceiver(
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     assert (
         eval(
             repr(rx),
             {
-                "SimpleReceiver": lox.SimpleReceiver,
+                "NoiseTempReceiver": lox.NoiseTempReceiver,
                 "Frequency": lox.Frequency,
                 "Temperature": lox.Temperature,
             },
@@ -502,7 +502,7 @@ def test_simple_receiver_repr_roundtrip():
 
 def test_complex_receiver_system_noise_temperature():
     # Direct stage construction
-    rx = lox.ComplexReceiver(
+    rx = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=100.0 * lox.K,
         stages=[
@@ -522,9 +522,9 @@ def test_complex_receiver_eq():
             lox.NoiseStage(gain=20.0 * lox.dB, noise_temperature=50.0 * lox.K),
         ],
     )
-    a = lox.ComplexReceiver(**kwargs)
-    b = lox.ComplexReceiver(**kwargs)
-    c = lox.ComplexReceiver(
+    a = lox.CascadeReceiver(**kwargs)
+    b = lox.CascadeReceiver(**kwargs)
+    c = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=200.0 * lox.K,
         stages=[
@@ -536,7 +536,7 @@ def test_complex_receiver_eq():
 
 
 def test_complex_receiver_pickle():
-    rx = lox.ComplexReceiver(
+    rx = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=100.0 * lox.K,
         stages=[
@@ -550,7 +550,7 @@ def test_complex_receiver_pickle():
 
 
 def test_complex_receiver_repr_roundtrip():
-    rx = lox.ComplexReceiver(
+    rx = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=100.0 * lox.K,
         stages=[
@@ -561,7 +561,7 @@ def test_complex_receiver_repr_roundtrip():
         eval(
             repr(rx),
             {
-                "ComplexReceiver": lox.ComplexReceiver,
+                "CascadeReceiver": lox.CascadeReceiver,
                 "NoiseStage": lox.NoiseStage,
                 "Frequency": lox.Frequency,
                 "Temperature": lox.Temperature,
@@ -721,14 +721,14 @@ def test_freq_overlap_partial():
 
 
 def test_communication_system_c_n0():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
 
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -744,8 +744,8 @@ def test_communication_system_c_n0():
 
 
 def test_communication_system_noise_power():
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -755,8 +755,8 @@ def test_communication_system_noise_power():
 
 
 def test_communication_system_pickle():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
@@ -766,8 +766,8 @@ def test_communication_system_pickle():
 
 
 def test_communication_system_pickle_with_receiver():
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -782,14 +782,14 @@ def test_communication_system_pickle_with_receiver():
 
 
 def test_link_stats_end_to_end():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
 
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -807,11 +807,12 @@ def test_link_stats_end_to_end():
     stats = lox.LinkStats.calculate(
         tx_system=tx_sys,
         rx_system=rx_sys,
-        channel=ch,
         range=1000.0 * lox.km,
+        bandwidth=ch.bandwidth(),
         tx_angle=0.0 * lox.deg,
         rx_angle=0.0 * lox.deg,
     )
+    modulated = ch.apply(stats)
 
     # EIRP = 46 + 10 - 1 = 55 dBW
     assert float(stats.eirp) == pytest.approx(55.0, abs=0.01)
@@ -820,26 +821,26 @@ def test_link_stats_end_to_end():
     # C/N0
     assert float(stats.c_n0) == pytest.approx(104.9, abs=0.2)
     # Es/N0 = C/N0 - 10*log10(5e6)
-    assert float(stats.es_n0) == pytest.approx(37.91, abs=0.2)
+    assert float(modulated.es_n0) == pytest.approx(37.91, abs=0.2)
     # Eb/N0 = Es/N0 - 10*log10(2*0.5) = Es/N0
-    assert float(stats.eb_n0) == pytest.approx(37.91, abs=0.2)
+    assert float(modulated.eb_n0) == pytest.approx(37.91, abs=0.2)
     # Margin = Eb/N0 - 10 - 3
-    assert float(stats.margin) == pytest.approx(24.91, abs=0.2)
+    assert float(modulated.margin) == pytest.approx(24.91, abs=0.2)
     # Properties
     assert stats.slant_range.to_kilometers() == pytest.approx(1000.0, abs=1e-6)
-    assert stats.symbol_rate.to_hertz() == pytest.approx(5e6, abs=1e-6)
+    assert modulated.symbol_rate.to_hertz() == pytest.approx(5e6, abs=1e-6)
     assert stats.frequency.to_hertz() == pytest.approx(29e9, abs=1.0)
 
 
 def test_link_stats_with_losses():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
 
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -857,14 +858,16 @@ def test_link_stats_with_losses():
     losses = lox.EnvironmentalLosses.from_values(rain=2.0 * lox.dB, atmospheric=1.0 * lox.dB)
 
     stats_no_loss = lox.LinkStats.calculate(
-        tx_sys, rx_sys, ch, 1000 * lox.km, 0 * lox.deg, 0 * lox.deg
+        tx_sys, rx_sys, 1000 * lox.km, ch.bandwidth(), 0 * lox.deg, 0 * lox.deg
     )
     stats_loss = lox.LinkStats.calculate(
-        tx_sys, rx_sys, ch, 1000 * lox.km, 0 * lox.deg, 0 * lox.deg, losses
+        tx_sys, rx_sys, 1000 * lox.km, ch.bandwidth(), 0 * lox.deg, 0 * lox.deg, losses
     )
+    modulated_no_loss = ch.apply(stats_no_loss)
+    modulated_loss = ch.apply(stats_loss)
 
     # 3 dB of environmental losses should reduce margin by 3 dB
-    margin_diff = float(stats_no_loss.margin) - float(stats_loss.margin)
+    margin_diff = float(modulated_no_loss.margin) - float(modulated_loss.margin)
     assert margin_diff == pytest.approx(3.0, abs=0.01)
 
 
@@ -978,14 +981,14 @@ def test_channel_repr_with_chip_rate():
 
 
 def test_communication_system_carrier_power():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
 
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -1003,13 +1006,13 @@ def test_communication_system_carrier_power():
 
 def test_communication_system_with_complex_antenna():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    ant = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
-    tx = lox.Transmitter(
+    ant = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     sys = lox.CommunicationSystem(antenna=ant, transmitter=tx)
     r = repr(sys)
-    assert "ComplexAntenna" in r
+    assert "PatternedAntenna" in r
     assert "ParabolicPattern" in r
     # Pickle roundtrip
     restored = pickle.loads(pickle.dumps(sys))
@@ -1017,8 +1020,8 @@ def test_communication_system_with_complex_antenna():
 
 
 def test_communication_system_with_complex_receiver():
-    ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.ComplexReceiver(
+    ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=100.0 * lox.K,
         stages=[
@@ -1027,29 +1030,29 @@ def test_communication_system_with_complex_receiver():
     )
     sys = lox.CommunicationSystem(antenna=ant, receiver=rx)
     r = repr(sys)
-    assert "ComplexReceiver" in r
+    assert "CascadeReceiver" in r
     # Pickle roundtrip
     restored = pickle.loads(pickle.dumps(sys))
     assert repr(restored) == repr(sys)
 
 
 def test_communication_system_invalid_antenna():
-    with pytest.raises(ValueError, match="expected a SimpleAntenna"):
+    with pytest.raises(ValueError, match="expected a ConstantAntenna or PatternedAntenna"):
         lox.CommunicationSystem(antenna="not an antenna")
 
 
 def test_communication_system_invalid_receiver():
-    ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    with pytest.raises(ValueError, match="expected a SimpleReceiver"):
+    ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    with pytest.raises(ValueError, match="expected NoiseTempReceiver, CascadeReceiver, or GtReceiver"):
         lox.CommunicationSystem(antenna=ant, receiver="not a receiver")
 
 
-# --- ComplexAntenna additional patterns ---
+# --- PatternedAntenna additional patterns ---
 
 
 def test_complex_antenna_gaussian_repr():
     p = lox.GaussianPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[1.0, 0.0, 0.0])
+    a = lox.PatternedAntenna(pattern=p, boresight=[1.0, 0.0, 0.0])
     r = repr(a)
     assert "GaussianPattern" in r
     # Pickle roundtrip
@@ -1061,7 +1064,7 @@ def test_complex_antenna_gaussian_repr():
 
 def test_complex_antenna_dipole_repr():
     d = lox.DipolePattern(length=0.005 * lox.m)
-    a = lox.ComplexAntenna(pattern=d, boresight=[0.0, 1.0, 0.0])
+    a = lox.PatternedAntenna(pattern=d, boresight=[0.0, 1.0, 0.0])
     r = repr(a)
     assert "DipolePattern" in r
     # Pickle roundtrip
@@ -1073,7 +1076,7 @@ def test_complex_antenna_dipole_repr():
 
 def test_complex_antenna_beamwidth():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    a = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
     bw = a.beamwidth(frequency=29e9 * lox.Hz)
     assert bw is not None
     assert bw.to_degrees() > 0
@@ -1081,16 +1084,16 @@ def test_complex_antenna_beamwidth():
 
 def test_complex_antenna_peak_gain():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    a = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
     pg = a.peak_gain(frequency=29e9 * lox.Hz)
     assert float(pg) == pytest.approx(46.01119, rel=1e-4)
 
 
-# --- ComplexReceiver additional methods ---
+# --- CascadeReceiver additional methods ---
 
 
 def test_complex_receiver_chain_gain():
-    rx = lox.ComplexReceiver(
+    rx = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=100.0 * lox.K,
         stages=[
@@ -1123,14 +1126,14 @@ def test_noise_stage_pickle():
 
 
 def test_link_stats_all_getters():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
 
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -1146,26 +1149,28 @@ def test_link_stats_all_getters():
     )
 
     stats = lox.LinkStats.calculate(
-        tx_sys, rx_sys, ch, 1000 * lox.km, 0 * lox.deg, 0 * lox.deg
+        tx_sys, rx_sys, 1000 * lox.km, ch.bandwidth(), 0 * lox.deg, 0 * lox.deg
     )
 
     # Test getters not covered in test_link_stats_end_to_end
     assert math.isfinite(float(stats.c_n))
+    assert stats.carrier_rx_power is not None
     assert math.isfinite(float(stats.carrier_rx_power))
+    assert stats.noise_power is not None
     assert math.isfinite(float(stats.noise_power))
     assert stats.bandwidth.to_hertz() == pytest.approx(5e6 * 1.35, rel=1e-6)
     assert math.isfinite(float(stats.gt))
 
 
 def test_link_stats_repr():
-    tx_ant = lox.SimpleAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
-    tx = lox.Transmitter(
+    tx_ant = lox.ConstantAntenna(gain=46.0 * lox.dB, beamwidth=0.7 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     tx_sys = lox.CommunicationSystem(antenna=tx_ant, transmitter=tx)
 
-    rx_ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    rx = lox.SimpleReceiver(
+    rx_ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    rx = lox.NoiseTempReceiver(
         frequency=29e9 * lox.Hz, system_noise_temperature=500.0 * lox.K
     )
     rx_sys = lox.CommunicationSystem(antenna=rx_ant, receiver=rx)
@@ -1179,12 +1184,13 @@ def test_link_stats_repr():
     )
 
     stats = lox.LinkStats.calculate(
-        tx_sys, rx_sys, ch, 1000 * lox.km, 0 * lox.deg, 0 * lox.deg
+        tx_sys, rx_sys, 1000 * lox.km, ch.bandwidth(), 0 * lox.deg, 0 * lox.deg
     )
+    modulated = ch.apply(stats)
     r = repr(stats)
     assert "LinkStats" in r
     assert "c_n0=" in r
-    assert "margin=" in r
+    assert "margin=" in repr(modulated)
 
 
 # --- Free functions ---
@@ -1233,13 +1239,13 @@ def test_pfd_mask():
     assert float(mask) == pytest.approx(-144.0, abs=1e-10)
 
 
-# --- Transmitter with ComplexAntenna ---
+# --- AmplifierTransmitter with PatternedAntenna ---
 
 
 def test_transmitter_eirp_complex_antenna():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
-    a = lox.ComplexAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
-    tx = lox.Transmitter(
+    a = lox.PatternedAntenna(pattern=p, boresight=[0.0, 0.0, 1.0])
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     eirp = tx.eirp(a, angle=0.0 * lox.deg)
@@ -1247,10 +1253,10 @@ def test_transmitter_eirp_complex_antenna():
 
 
 def test_transmitter_eirp_invalid_antenna():
-    tx = lox.Transmitter(
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
-    with pytest.raises(ValueError, match="expected a SimpleAntenna"):
+    with pytest.raises(ValueError, match="expected a ConstantAntenna or PatternedAntenna"):
         tx.eirp("not an antenna", angle=0.0 * lox.deg)
 
 
@@ -1258,20 +1264,43 @@ def test_transmitter_eirp_invalid_antenna():
 
 
 def test_communication_system_repr_minimal():
-    ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
     sys = lox.CommunicationSystem(antenna=ant)
     r = repr(sys)
     assert "CommunicationSystem" in r
-    assert "SimpleAntenna" in r
+    assert "ConstantAntenna" in r
     assert "receiver=" not in r
     assert "transmitter=" not in r
 
 
 def test_communication_system_repr_with_transmitter():
-    ant = lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
-    tx = lox.Transmitter(
+    ant = lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=3.0 * lox.deg)
+    tx = lox.AmplifierTransmitter(
         frequency=29e9 * lox.Hz, power=10.0 * lox.W, line_loss=1.0 * lox.dB
     )
     sys = lox.CommunicationSystem(antenna=ant, transmitter=tx)
     r = repr(sys)
-    assert "transmitter=Transmitter" in r
+    assert "transmitter=AmplifierTransmitter" in r
+
+
+# --- Lumped-tier smoke test ---
+
+
+def test_eirp_gt_lumped_link():
+    tx = lox.CommunicationSystem.eirp_only(
+        lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    )
+    rx = lox.CommunicationSystem.gt_only(
+        lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    )
+    link = lox.LinkStats.calculate(
+        tx,
+        rx,
+        1000.0 * lox.km,
+        5.0 * lox.MHz,
+        0.0 * lox.rad,
+        0.0 * lox.rad,
+    )
+    assert link.carrier_rx_power is None
+    assert link.noise_power is None
+    assert abs(float(link.c_n0) - 104.913) < 0.2

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -1340,3 +1340,114 @@ def test_lumped_link_interference_requires_absolute_power():
 
     with pytest.raises(ValueError, match="absolute carrier and noise powers"):
         modulated.with_interference(1e-12)
+
+
+# --- Error mapping tests ---
+
+
+def test_missing_transmitter_raises_value_error():
+    antenna = lox.ConstantAntenna(0.0 * lox.dB, 1.0 * lox.deg)
+    rx_antenna = lox.ConstantAntenna(0.0 * lox.dB, 1.0 * lox.deg)
+    rx_receiver = lox.NoiseTempReceiver(29.0 * lox.GHz, 500.0 * lox.K)
+    tx = lox.CommunicationSystem(antenna=antenna)
+    rx = lox.CommunicationSystem(antenna=rx_antenna, receiver=rx_receiver)
+    with pytest.raises(ValueError, match="transmitter"):
+        tx.carrier_to_noise_density(
+            rx, 0.0 * lox.dB, 1000.0 * lox.km,
+            0.0 * lox.rad, 0.0 * lox.rad,
+        )
+
+
+def test_missing_receiver_raises_value_error():
+    tx_antenna = lox.ConstantAntenna(0.0 * lox.dB, 1.0 * lox.deg)
+    tx_transmitter = lox.AmplifierTransmitter(
+        frequency=29.0 * lox.GHz, power=10.0 * lox.W, line_loss=0.0 * lox.dB,
+    )
+    tx = lox.CommunicationSystem(antenna=tx_antenna, transmitter=tx_transmitter)
+    rx_antenna = lox.ConstantAntenna(0.0 * lox.dB, 1.0 * lox.deg)
+    rx = lox.CommunicationSystem(antenna=rx_antenna)
+    with pytest.raises(ValueError, match="receiver"):
+        tx.carrier_to_noise_density(
+            rx, 0.0 * lox.dB, 1000.0 * lox.km,
+            0.0 * lox.rad, 0.0 * lox.rad,
+        )
+
+
+def test_frequency_mismatch_raises_value_error():
+    tx = lox.CommunicationSystem.eirp_only(
+        lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    )
+    rx = lox.CommunicationSystem.gt_only(
+        lox.GtReceiver(30.0 * lox.GHz, 3.01 * lox.dB)
+    )
+    with pytest.raises(ValueError, match="frequency"):
+        tx.carrier_to_noise_density(
+            rx, 0.0 * lox.dB, 1000.0 * lox.km,
+            0.0 * lox.rad, 0.0 * lox.rad,
+        )
+
+
+def test_unexpected_antenna_raises_value_error():
+    antenna = lox.ConstantAntenna(46.0 * lox.dB, 0.7 * lox.deg)
+    tx_transmitter = lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    with pytest.raises(ValueError, match="EirpTransmitter must not be paired"):
+        lox.CommunicationSystem(antenna=antenna, transmitter=tx_transmitter)
+
+
+# --- Pickle round-trip tests for lumped CommunicationSystem ---
+
+
+def test_lumped_communication_system_pickle():
+    tx_system = lox.CommunicationSystem.eirp_only(
+        lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    )
+    rx_system = lox.CommunicationSystem.gt_only(
+        lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    )
+    assert pickle.loads(pickle.dumps(tx_system)) == tx_system
+    assert pickle.loads(pickle.dumps(rx_system)) == rx_system
+
+
+def test_lumped_communication_system_via_constructor_pickle():
+    tx_system = lox.CommunicationSystem(
+        transmitter=lox.EirpTransmitter(29.0 * lox.GHz, 55.0 * lox.dB)
+    )
+    rx_system = lox.CommunicationSystem(
+        receiver=lox.GtReceiver(29.0 * lox.GHz, 3.01 * lox.dB)
+    )
+    assert pickle.loads(pickle.dumps(tx_system)) == tx_system
+    assert pickle.loads(pickle.dumps(rx_system)) == rx_system
+
+
+# --- ModulatedLinkStats.with_interference happy path ---
+
+
+def test_modulated_with_interference_component_tier():
+    tx_antenna = lox.ConstantAntenna(46.0 * lox.dB, 0.7 * lox.deg)
+    tx_transmitter = lox.AmplifierTransmitter(
+        frequency=29.0 * lox.GHz, power=10.0 * lox.W, line_loss=1.0 * lox.dB,
+    )
+    tx = lox.CommunicationSystem(antenna=tx_antenna, transmitter=tx_transmitter)
+
+    rx_antenna = lox.ConstantAntenna(30.0 * lox.dB, 3.0 * lox.deg)
+    rx_receiver = lox.NoiseTempReceiver(29.0 * lox.GHz, 500.0 * lox.K)
+    rx = lox.CommunicationSystem(antenna=rx_antenna, receiver=rx_receiver)
+
+    channel = lox.Channel(
+        link_type="downlink",
+        symbol_rate=5.0 * lox.MHz,
+        required_eb_n0=10.0 * lox.dB,
+        margin=3.0 * lox.dB,
+        modulation=lox.Modulation("QPSK"),
+    )
+
+    link = lox.LinkStats.calculate(
+        tx, rx, 1000.0 * lox.km, channel.bandwidth(),
+        0.0 * lox.rad, 0.0 * lox.rad,
+    )
+    modulated = channel.apply(link)
+    interference = modulated.with_interference(1e-12)
+
+    assert float(interference.margin_with_interference) < float(modulated.margin)
+    assert float(interference.eb_n0i0) < float(modulated.eb_n0)
+    assert interference.interference_power_w == 1e-12

--- a/crates/lox-space/tests/test_spacelink_comms.py
+++ b/crates/lox-space/tests/test_spacelink_comms.py
@@ -161,7 +161,7 @@ NF_CASES = [0.1, 1.0, 2.5, 5.0, 8.0, 15.0]
 def test_noise_temperature(noise_figure_db):
     """Noise figure to temperature should agree between lox and spacelink to 0.01 K."""
     # Build a receiver with only the NF stage (LNA has zero noise, unity gain)
-    rx = lox.ComplexReceiver.from_lna_and_noise_figure(
+    rx = lox.CascadeReceiver.from_lna_and_noise_figure(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=0.0 * lox.K,
         lna_gain=0.0 * lox.dB,
@@ -186,7 +186,7 @@ def test_noise_temperature(noise_figure_db):
 def test_system_noise_temperature_degenerate(noise_figure_db):
     """With no antenna temperature and transparent LNA,
     system_noise_temperature() must equal the bare receiver noise temperature."""
-    rx = lox.ComplexReceiver(
+    rx = lox.CascadeReceiver(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=0.0 * lox.K,
         stages=[
@@ -259,8 +259,8 @@ NOISE_POWER_CASES = [
 def test_noise_power(t_sys_k, bandwidth_hz):
     """CommunicationSystem.noise_power() should agree with spacelink to 0.001 dBW."""
     rx_sys = lox.CommunicationSystem(
-        lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=5.0 * lox.deg),
-        receiver=lox.SimpleReceiver(
+        lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=5.0 * lox.deg),
+        receiver=lox.NoiseTempReceiver(
             frequency=10 * lox.GHz,
             system_noise_temperature=t_sys_k * lox.K,
         ),
@@ -274,7 +274,7 @@ def test_noise_power(t_sys_k, bandwidth_hz):
 # ---------------------------------------------------------------------------
 # Test 9: Noise figure round-trip
 #
-# lox: NF → T via ComplexReceiver.from_lna_and_noise_figure
+# lox: NF → T via CascadeReceiver.from_lna_and_noise_figure
 # spacelink: T → NF via temperature_to_noise_figure
 # The round-trip should recover the original NF.
 # ---------------------------------------------------------------------------
@@ -283,7 +283,7 @@ def test_noise_power(t_sys_k, bandwidth_hz):
 @pytest.mark.parametrize("noise_figure_db", NF_CASES)
 def test_noise_figure_round_trip(noise_figure_db):
     """NF → T (lox) → NF (spacelink) should recover the original noise figure."""
-    rx = lox.ComplexReceiver.from_lna_and_noise_figure(
+    rx = lox.CascadeReceiver.from_lna_and_noise_figure(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=0.0 * lox.K,
         lna_gain=0.0 * lox.dB,
@@ -309,8 +309,8 @@ NPD_CASES = [150.0, 290.0, 500.0, 1000.0]
 def test_noise_power_density(t_sys_k):
     """k_B · T should agree between lox and spacelink to 0.001 dB."""
     rx_sys = lox.CommunicationSystem(
-        lox.SimpleAntenna(gain=0.0 * lox.dB, beamwidth=360.0 * lox.deg),
-        receiver=lox.SimpleReceiver(
+        lox.ConstantAntenna(gain=0.0 * lox.dB, beamwidth=360.0 * lox.deg),
+        receiver=lox.NoiseTempReceiver(
             frequency=10 * lox.GHz,
             system_noise_temperature=t_sys_k * lox.K,
         ),
@@ -341,17 +341,17 @@ GT_CASES = [
 @pytest.mark.parametrize("gain_db,t_sys_k", GT_CASES)
 def test_gt_decomposition(gain_db, t_sys_k):
     """G/T computed by lox should decompose correctly via spacelink."""
-    antenna = lox.SimpleAntenna(gain=gain_db * lox.dB, beamwidth=5.0 * lox.deg)
+    antenna = lox.ConstantAntenna(gain=gain_db * lox.dB, beamwidth=5.0 * lox.deg)
     rx_sys = lox.CommunicationSystem(
         antenna,
-        receiver=lox.SimpleReceiver(
+        receiver=lox.NoiseTempReceiver(
             frequency=29 * lox.GHz,
             system_noise_temperature=t_sys_k * lox.K,
         ),
     )
     tx_sys = lox.CommunicationSystem(
-        lox.SimpleAntenna(gain=30.0 * lox.dB, beamwidth=5.0 * lox.deg),
-        transmitter=lox.Transmitter(
+        lox.ConstantAntenna(gain=30.0 * lox.dB, beamwidth=5.0 * lox.deg),
+        transmitter=lox.AmplifierTransmitter(
             frequency=29 * lox.GHz,
             power=10.0 * lox.W,
             line_loss=0.0 * lox.dB,
@@ -366,8 +366,9 @@ def test_gt_decomposition(gain_db, t_sys_k):
         fec=1.0,
     )
     stats = lox.LinkStats.calculate(
-        tx_sys, rx_sys, channel,
+        tx_sys, rx_sys,
         range=1000 * lox.km,
+        bandwidth=channel.bandwidth(),
         tx_angle=0.0 * lox.deg,
         rx_angle=0.0 * lox.deg,
     )
@@ -395,7 +396,7 @@ def test_friis_cascade_feed_loss():
     rx_nf_db = 5.0
     t_ant = 265.0
 
-    rx = lox.ComplexReceiver.from_feed_loss_and_noise_figure(
+    rx = lox.CascadeReceiver.from_feed_loss_and_noise_figure(
         frequency=29 * lox.GHz,
         antenna_noise_temperature=t_ant * lox.K,
         feed_loss=feed_loss_db * lox.dB,
@@ -445,10 +446,10 @@ def test_tdrs_ka_band_return_link():
     tx_line_loss_db = 1.0
 
     tx_pattern = lox.ParabolicPattern(tx_diameter * lox.m, tx_efficiency)
-    tx_antenna = lox.ComplexAntenna(
+    tx_antenna = lox.PatternedAntenna(
         pattern=tx_pattern, boresight=[0.0, 0.0, 1.0]
     )
-    tx = lox.Transmitter(
+    tx = lox.AmplifierTransmitter(
         frequency=freq,
         power=tx_power_w * lox.W,
         line_loss=tx_line_loss_db * lox.dB,
@@ -475,10 +476,10 @@ def test_tdrs_ka_band_return_link():
     rx_nf_db = 3.0
 
     rx_pattern = lox.ParabolicPattern(rx_diameter * lox.m, rx_efficiency)
-    rx_antenna = lox.ComplexAntenna(
+    rx_antenna = lox.PatternedAntenna(
         pattern=rx_pattern, boresight=[0.0, 0.0, 1.0]
     )
-    rx = lox.ComplexReceiver.from_lna_and_noise_figure(
+    rx = lox.CascadeReceiver.from_lna_and_noise_figure(
         frequency=freq,
         antenna_noise_temperature=t_ant * lox.K,
         lna_gain=lna_gain_db * lox.dB,
@@ -523,11 +524,13 @@ def test_tdrs_ka_band_return_link():
     # --- Link budget ---
     range_km = 40000.0
     stats = lox.LinkStats.calculate(
-        tx_sys, rx_sys, channel,
+        tx_sys, rx_sys,
         range=range_km * lox.km,
+        bandwidth=channel.bandwidth(),
         tx_angle=0.0 * lox.deg,
         rx_angle=0.0 * lox.deg,
     )
+    modulated = channel.apply(stats)
 
     # Cross-check FSPL against spacelink
     sl_fspl_db = float(sl_fspl(range_km * u.km, freq_ghz * u.GHz).value)
@@ -542,7 +545,7 @@ def test_tdrs_ka_band_return_link():
             information_rate_hz * u.Hz,
         ).value
     )
-    assert float(stats.eb_n0) == pytest.approx(sl_ebn0, abs=1e-4)
+    assert float(modulated.eb_n0) == pytest.approx(sl_ebn0, abs=1e-4)
 
     # Verify G/T via spacelink gain recovery
     recovered_gain = float(
@@ -555,5 +558,5 @@ def test_tdrs_ka_band_return_link():
     assert recovered_gain == pytest.approx(lox_rx_gain, abs=0.1)
 
     # Sanity checks: the link should close with these parameters
-    assert float(stats.margin) > 0.0, "TDRS Ka-band return link should close"
+    assert float(modulated.margin) > 0.0, "TDRS Ka-band return link should close"
     assert float(stats.c_n0) > 60.0, "C/N0 should be reasonable for Ka-band relay"

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2691,17 +2691,15 @@ class CommunicationSystem:
     """A communication system combining an antenna with optional transmitter and receiver.
 
     Args:
-        antenna: A ConstantAntenna or PatternedAntenna.
-        receiver: A NoiseTempReceiver or CascadeReceiver (optional).
-            Use ``CommunicationSystem.gt_only(rx)`` for lumped G/T receivers.
-        transmitter: An AmplifierTransmitter (optional).
-            Use ``CommunicationSystem.eirp_only(tx)`` for lumped EIRP transmitters.
+        antenna: A ConstantAntenna or PatternedAntenna (optional; omit for lumped systems).
+        receiver: A NoiseTempReceiver, CascadeReceiver, or GtReceiver (optional).
+        transmitter: An AmplifierTransmitter or EirpTransmitter (optional).
     """
     def __new__(
         cls,
-        antenna: ConstantAntenna | PatternedAntenna,
-        receiver: NoiseTempReceiver | CascadeReceiver | None = None,
-        transmitter: AmplifierTransmitter | None = None,
+        antenna: ConstantAntenna | PatternedAntenna | None = None,
+        receiver: NoiseTempReceiver | CascadeReceiver | GtReceiver | None = None,
+        transmitter: AmplifierTransmitter | EirpTransmitter | None = None,
     ) -> Self: ...
     @classmethod
     def eirp_only(cls, tx: EirpTransmitter) -> CommunicationSystem:

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2414,7 +2414,7 @@ class DipolePattern:
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
-class SimpleAntenna:
+class ConstantAntenna:
     """A simple antenna with constant gain and beamwidth.
 
     Args:
@@ -2425,7 +2425,7 @@ class SimpleAntenna:
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
-class ComplexAntenna:
+class PatternedAntenna:
     """An antenna with a physics-based gain pattern and boresight vector.
 
     Args:
@@ -2449,8 +2449,8 @@ class ComplexAntenna:
         ...
     def __repr__(self) -> str: ...
 
-class Transmitter:
-    """A radio transmitter.
+class AmplifierTransmitter:
+    """A radio transmitter with an RF power amplifier.
 
     Args:
         frequency: Transmit frequency.
@@ -2465,14 +2465,29 @@ class Transmitter:
         line_loss: Decibel,
         output_back_off: Decibel | None = None,
     ) -> Self: ...
-    def eirp(self, antenna: SimpleAntenna | ComplexAntenna, angle: Angle) -> Decibel:
+    def eirp(self, antenna: ConstantAntenna | PatternedAntenna, angle: Angle) -> Decibel:
         """Returns the EIRP in dBW for the given antenna and off-boresight angle."""
         ...
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
-class SimpleReceiver:
-    """A simple receiver with a known system noise temperature.
+class EirpTransmitter:
+    """A lumped transmitter defined by a frequency and aggregate EIRP.
+
+    Args:
+        frequency: Transmit frequency.
+        eirp: Effective isotropic radiated power in dBW.
+    """
+    def __new__(cls, frequency: Frequency, eirp: Decibel) -> Self: ...
+    @property
+    def frequency(self) -> Frequency: ...
+    @property
+    def eirp(self) -> Decibel: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
+class NoiseTempReceiver:
+    """A receiver with a known system noise temperature.
 
     Args:
         frequency: Receive frequency.
@@ -2484,6 +2499,21 @@ class SimpleReceiver:
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
+class GtReceiver:
+    """A lumped receiver defined by a frequency and aggregate G/T.
+
+    Args:
+        frequency: Receive frequency.
+        gt: Gain-to-noise-temperature ratio in dB/K.
+    """
+    def __new__(cls, frequency: Frequency, gt: Decibel) -> Self: ...
+    @property
+    def frequency(self) -> Frequency: ...
+    @property
+    def gt(self) -> Decibel: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
 class NoiseStage:
     """A single stage in an RF receiver chain.
 
@@ -2494,7 +2524,7 @@ class NoiseStage:
     def __new__(cls, gain: Decibel, noise_temperature: Temperature) -> Self: ...
     def __repr__(self) -> str: ...
 
-class ComplexReceiver:
+class CascadeReceiver:
     """An N-stage cascade receiver using the Friis noise formula.
 
     Args:
@@ -2521,7 +2551,7 @@ class ComplexReceiver:
         receiver_gain: Decibel,
         demodulator_loss: Decibel | None = None,
         implementation_loss: Decibel | None = None,
-    ) -> ComplexReceiver:
+    ) -> CascadeReceiver:
         """Creates a two-stage model: lossy feed line at room temperature followed by a receiver."""
         ...
     @staticmethod
@@ -2533,7 +2563,7 @@ class ComplexReceiver:
         receiver_noise_figure: Decibel,
         demodulator_loss: Decibel | None = None,
         implementation_loss: Decibel | None = None,
-    ) -> ComplexReceiver:
+    ) -> CascadeReceiver:
         """Creates a two-stage model: LNA followed by a receiver characterised by noise figure."""
         ...
     def system_noise_temperature(self) -> Temperature:
@@ -2594,6 +2624,9 @@ class Channel:
         ...
     def processing_gain(self) -> Decibel | None:
         """Returns the DSSS processing gain in dB, or None for narrowband."""
+        ...
+    def apply(self, link: LinkStats) -> ModulatedLinkStats:
+        """Layers modulation/FEC figures onto a modulation-agnostic link budget."""
         ...
     def __repr__(self) -> str: ...
 
@@ -2658,16 +2691,24 @@ class CommunicationSystem:
     """A communication system combining an antenna with optional transmitter and receiver.
 
     Args:
-        antenna: A SimpleAntenna or ComplexAntenna.
-        receiver: A SimpleReceiver or ComplexReceiver (optional).
-        transmitter: A Transmitter (optional).
+        antenna: A ConstantAntenna or PatternedAntenna.
+        receiver: A NoiseTempReceiver, CascadeReceiver, or GtReceiver (optional).
+        transmitter: An AmplifierTransmitter (optional).
     """
     def __new__(
         cls,
-        antenna: SimpleAntenna | ComplexAntenna,
-        receiver: SimpleReceiver | ComplexReceiver | None = None,
-        transmitter: Transmitter | None = None,
+        antenna: ConstantAntenna | PatternedAntenna,
+        receiver: NoiseTempReceiver | CascadeReceiver | GtReceiver | None = None,
+        transmitter: AmplifierTransmitter | None = None,
     ) -> Self: ...
+    @classmethod
+    def eirp_only(cls, tx: EirpTransmitter) -> CommunicationSystem:
+        """Creates a lumped transmit-only system from a known EIRP."""
+        ...
+    @classmethod
+    def gt_only(cls, rx: GtReceiver) -> CommunicationSystem:
+        """Creates a lumped receive-only system from a known G/T."""
+        ...
     def carrier_to_noise_density(
         self,
         rx_system: CommunicationSystem,
@@ -2693,33 +2734,33 @@ class CommunicationSystem:
         range: Distance,
         tx_angle: Angle,
         rx_angle: Angle,
-    ) -> Decibel:
-        """Computes the received carrier power in dBW."""
+    ) -> Decibel | None:
+        """Computes the received carrier power in dBW. Returns ``None`` for lumped G/T receivers."""
         ...
-    def noise_power(self, bandwidth: Frequency) -> Decibel:
-        """Computes the noise power in dBW for a given bandwidth."""
+    def noise_power(self, bandwidth: Frequency) -> Decibel | None:
+        """Computes the noise power in dBW for a given bandwidth. Returns ``None`` for lumped G/T receivers."""
         ...
     def __repr__(self) -> str: ...
 
 class LinkStats:
-    """Complete link budget statistics."""
+    """Modulation-agnostic link budget statistics."""
     @staticmethod
     def calculate(
         tx_system: CommunicationSystem,
         rx_system: CommunicationSystem,
-        channel: Channel,
         range: Distance,
+        bandwidth: Frequency,
         tx_angle: Angle,
         rx_angle: Angle,
         losses: EnvironmentalLosses | None = None,
     ) -> LinkStats:
-        """Computes a full link budget.
+        """Computes a modulation-agnostic link budget.
 
         Args:
             tx_system: The transmitting CommunicationSystem.
             rx_system: The receiving CommunicationSystem.
-            channel: The Channel.
             range: Slant range as Distance.
+            bandwidth: Noise bandwidth as Frequency.
             tx_angle: Off-boresight angle at transmitter as Angle.
             rx_angle: Off-boresight angle at receiver as Angle.
             losses: EnvironmentalLosses (optional, defaults to none).
@@ -2746,40 +2787,87 @@ class LinkStats:
         """Carrier-to-noise density ratio in dB·Hz."""
         ...
     @property
+    def c_n(self) -> Decibel:
+        """C/N in dB."""
+        ...
+    @property
+    def carrier_rx_power(self) -> Decibel | None:
+        """Received carrier power in dBW. ``None`` for lumped G/T receivers."""
+        ...
+    @property
+    def noise_power(self) -> Decibel | None:
+        """Noise power in dBW. ``None`` for lumped G/T receivers."""
+        ...
+    @property
+    def bandwidth(self) -> Frequency:
+        """Channel noise bandwidth."""
+        ...
+    @property
+    def frequency(self) -> Frequency:
+        """Link frequency."""
+        ...
+    @property
+    def tx_angle(self) -> Angle:
+        """Off-boresight angle at the transmitter."""
+        ...
+    @property
+    def rx_angle(self) -> Angle:
+        """Off-boresight angle at the receiver."""
+        ...
+    def __repr__(self) -> str: ...
+
+class InterferenceStats:
+    """Interference statistics for a link with a given interferer power."""
+    @property
+    def interference_power_w(self) -> float:
+        """Interference power in watts."""
+        ...
+    @property
+    def c_n0i0(self) -> Decibel:
+        """Carrier-to-noise-plus-interference density ratio in dB·Hz."""
+        ...
+    @property
+    def eb_n0i0(self) -> Decibel:
+        """Eb/(N0+I0) in dB."""
+        ...
+    @property
+    def margin_with_interference(self) -> Decibel:
+        """Link margin with interference in dB."""
+        ...
+    def __repr__(self) -> str: ...
+
+class ModulatedLinkStats:
+    """Link-budget output with modulation/coding figures applied."""
+    @property
+    def link(self) -> LinkStats:
+        """The underlying modulation-agnostic link budget."""
+        ...
+    @property
+    def channel(self) -> Channel:
+        """The channel (modulation, FEC, required Eb/N0, margin) applied."""
+        ...
+    @property
+    def symbol_rate(self) -> Frequency:
+        """Symbol rate from the channel."""
+        ...
+    @property
     def es_n0(self) -> Decibel:
-        """Es/N0 in dB."""
+        """Es/N0 (energy per symbol to noise spectral density) in dB."""
         ...
     @property
     def eb_n0(self) -> Decibel:
-        """Eb/N0 in dB."""
-        ...
-    @property
-    def c_n(self) -> Decibel:
-        """C/N in dB."""
+        """Eb/N0 (energy per information bit to noise spectral density) in dB."""
         ...
     @property
     def margin(self) -> Decibel:
         """Link margin in dB."""
         ...
     @property
-    def carrier_rx_power(self) -> Decibel:
-        """Received carrier power in dBW."""
+    def interference(self) -> InterferenceStats | None:
+        """Interference statistics, if computed."""
         ...
-    @property
-    def noise_power(self) -> Decibel:
-        """Noise power in dBW."""
-        ...
-    @property
-    def symbol_rate(self) -> Frequency:
-        """Symbol rate."""
-        ...
-    @property
-    def bandwidth(self) -> Frequency:
-        """Channel bandwidth."""
-        ...
-    @property
-    def frequency(self) -> Frequency:
-        """Link frequency."""
+    def with_interference(self, interference_power_w: float) -> InterferenceStats:
+        """Computes interference statistics for a given interferer power."""
         ...
     def __repr__(self) -> str: ...
 

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2692,13 +2692,15 @@ class CommunicationSystem:
 
     Args:
         antenna: A ConstantAntenna or PatternedAntenna.
-        receiver: A NoiseTempReceiver, CascadeReceiver, or GtReceiver (optional).
+        receiver: A NoiseTempReceiver or CascadeReceiver (optional).
+            Use ``CommunicationSystem.gt_only(rx)`` for lumped G/T receivers.
         transmitter: An AmplifierTransmitter (optional).
+            Use ``CommunicationSystem.eirp_only(tx)`` for lumped EIRP transmitters.
     """
     def __new__(
         cls,
         antenna: ConstantAntenna | PatternedAntenna,
-        receiver: NoiseTempReceiver | CascadeReceiver | GtReceiver | None = None,
+        receiver: NoiseTempReceiver | CascadeReceiver | None = None,
         transmitter: AmplifierTransmitter | None = None,
     ) -> Self: ...
     @classmethod


### PR DESCRIPTION
- **feat(lox-comms): add LinkBudgetError; SI-2019 Boltzmann constant**
- **fix(lox-comms): expand error test coverage; refresh Boltzmann references**
- **refactor(lox-comms): return Result from CommunicationSystem accessors**
- **refactor(lox-comms): rename Antenna Simple/Complex to Constant/Patterned**
- **docs(lox-comms): fix tautological ConstantAntenna doc comment**
- **refactor(lox-comms): rename Receiver Simple/Complex to NoiseTemperature/Cascade**
- **refactor(lox-comms): lift Transmitter into enum over AmplifierTransmitter**
- **refactor(lox-comms): mark AntennaPattern/Modulation/LinkDirection non_exhaustive**
- **feat(lox-comms): add Eirp/Gt lumped variants and Option<Antenna> on CommunicationSystem**
- **fix(lox-comms): tighten Gt sentinel docs, receiver_with guard, lumped test rigor**
- **refactor(lox-comms): split LinkStats; introduce ModulatedLinkStats**
- **feat(lox-comms): add Channel::apply for modulation-aware link stats**
- **feat(lox-space): rename comms wrappers; add Eirp/Gt; ModulatedLinkStats**
- **test(lox-space): update comms tests for renames and ModulatedLinkStats**
- **docs(lox-space): document lumped Eirp/Gt tier and ModulatedLinkStats split**
- **build(lox-comms): move lox-test-utils to dev-dependencies**
- **docs(lox-comms): changelog for link-budget API redesign**
- **fix(lox-comms): wire up FrequencyMismatch error; tighten Python stub union**
- **fix(lox-comms): return Result from with_interference; pickle lumped TX/RX**
