### PR TITLE
he/rain degraded gt

### DIFF
--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -416,10 +416,12 @@ impl LinkStats {
             None => rx.gt_at(carrier, params.rx_pointing)?,
         };
 
-        // Rain→noise coupling: only a downlink receiver sits behind the
-        // absorbing atmosphere. Uplink antennas already look at warm Earth
-        // through their configured clear-sky T_ant; crosslinks see no
-        // atmosphere.
+        // Rain raises the receive noise temperature only on downlinks,
+        // where the antenna looks up through the absorbing atmosphere and
+        // picks up its thermal re-radiation. An uplink receiver is a
+        // spacecraft antenna pointed at Earth: its configured T_ant already
+        // reflects the ~290 K warm-Earth background, which dwarfs any extra
+        // atmospheric emission. A crosslink has no atmosphere in its path.
         let degraded_terms = if params.direction == Some(LinkDirection::Downlink) {
             rx.rx_terms_degraded(carrier, params.rx_pointing, params.losses.absorptive())?
         } else {

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -12,7 +12,7 @@
 
 use lox_core::units::{Decibel, Distance, Frequency, Power, Temperature};
 
-use crate::channel::Channel;
+use crate::channel::{Channel, LinkDirection};
 use crate::error::NonPhysicalError;
 use crate::pointing::Pointing;
 use crate::utils::free_space_path_loss;
@@ -23,6 +23,33 @@ pub use lox_core::comms::PropagationLosses;
 
 /// Boltzmann constant in dB(W/Hz/K).
 const BOLTZMANN_CONSTANT_DB: Decibel = Decibel::new(-228.599_167_173_217_67);
+
+/// Effective mean radiating temperature of the absorbing atmosphere
+/// (ITU-R P.618 §8.2).
+pub const MEDIUM_TEMPERATURE: Temperature = Temperature::kelvin(275.0);
+
+/// Returns the sky-noise temperature seen by an antenna behind an absorbing
+/// atmosphere (ITU-R P.618 §8.2).
+///
+/// An absorptive medium with linear loss `L ≥ 1` attenuates the clear-sky
+/// contribution and re-radiates thermally at the mean medium temperature
+/// `t_m`:
+///
+/// ```text
+/// T_sky = T_clear / L + t_m · (1 − 1/L)
+/// ```
+///
+/// Only absorptive loss terms apply (rain, gaseous, cloud — see
+/// [`PropagationLosses::absorptive`]); scintillation and depolarization do
+/// not heat the antenna.
+pub fn degraded_sky_temperature(
+    t_clear: Temperature,
+    absorptive: Decibel,
+    t_m: Temperature,
+) -> Temperature {
+    let l = absorptive.to_linear();
+    Temperature::kelvin(t_clear.to_kelvin() / l + t_m.to_kelvin() * (1.0 - 1.0 / l))
+}
 
 /// The transmit end of a radio link.
 ///
@@ -114,6 +141,22 @@ pub trait GOverT {
         let _ = (carrier, pointing);
         Ok(None)
     }
+
+    /// Returns the receive terms with the antenna noise temperature degraded
+    /// by the absorptive part of the atmospheric loss (ITU-R P.618 §8.2).
+    ///
+    /// `None` for ends that cannot recompute their noise budget — aggregate
+    /// G/T figures are clear-sky values and stay undegraded. Defaults to
+    /// `None`.
+    fn rx_terms_degraded(
+        &self,
+        carrier: Frequency,
+        pointing: Pointing,
+        absorptive: Decibel,
+    ) -> Result<Option<RxTerms>, LinkBudgetError> {
+        let _ = (carrier, pointing, absorptive);
+        Ok(None)
+    }
 }
 
 /// Interference statistics for a link.
@@ -150,6 +193,7 @@ pub struct LinkParameters {
     losses: PropagationLosses,
     tx_pointing: Pointing,
     rx_pointing: Pointing,
+    direction: Option<LinkDirection>,
 }
 
 /// Serde wire format for [`LinkParameters`]: forces deserialization through
@@ -166,6 +210,8 @@ struct LinkParametersRepr {
     tx_pointing: Pointing,
     #[serde(default)]
     rx_pointing: Pointing,
+    #[serde(default)]
+    direction: Option<LinkDirection>,
 }
 
 #[cfg(feature = "serde")]
@@ -173,11 +219,14 @@ impl TryFrom<LinkParametersRepr> for LinkParameters {
     type Error = NonPhysicalError;
 
     fn try_from(repr: LinkParametersRepr) -> Result<Self, Self::Error> {
-        LinkParameters::builder(repr.carrier, repr.bandwidth, repr.range)
+        let mut builder = LinkParameters::builder(repr.carrier, repr.bandwidth, repr.range)
             .losses(repr.losses)
             .tx_pointing(repr.tx_pointing)
-            .rx_pointing(repr.rx_pointing)
-            .build()
+            .rx_pointing(repr.rx_pointing);
+        if let Some(direction) = repr.direction {
+            builder = builder.direction(direction);
+        }
+        builder.build()
     }
 }
 
@@ -198,6 +247,7 @@ impl LinkParameters {
             losses: PropagationLosses::none(),
             tx_pointing: Pointing::Boresight,
             rx_pointing: Pointing::Boresight,
+            direction: None,
         }
     }
 
@@ -230,6 +280,11 @@ impl LinkParameters {
     pub fn rx_pointing(&self) -> Pointing {
         self.rx_pointing
     }
+
+    /// Returns the link direction, when specified.
+    pub fn direction(&self) -> Option<LinkDirection> {
+        self.direction
+    }
 }
 
 /// Builder for [`LinkParameters`].
@@ -244,6 +299,7 @@ pub struct LinkParametersBuilder {
     losses: PropagationLosses,
     tx_pointing: Pointing,
     rx_pointing: Pointing,
+    direction: Option<LinkDirection>,
 }
 
 impl LinkParametersBuilder {
@@ -262,6 +318,18 @@ impl LinkParametersBuilder {
     /// Sets the pointing at the receive end.
     pub fn rx_pointing(mut self, pointing: Pointing) -> Self {
         self.rx_pointing = pointing;
+        self
+    }
+
+    /// Sets the link direction.
+    ///
+    /// On downlinks the receive antenna sits behind the absorbing
+    /// atmosphere, so the budget recomputes the system noise temperature
+    /// with the rain-degraded sky temperature (ITU-R P.618 §8.2). Uplink
+    /// and crosslink receivers are unaffected, as is an unspecified
+    /// direction.
+    pub fn direction(mut self, direction: LinkDirection) -> Self {
+        self.direction = Some(direction);
         self
     }
 
@@ -284,6 +352,7 @@ impl LinkParametersBuilder {
             losses: self.losses,
             tx_pointing: self.tx_pointing,
             rx_pointing: self.rx_pointing,
+            direction: self.direction,
         })
     }
 }
@@ -300,8 +369,14 @@ pub struct LinkStats {
     pub fspl: Decibel,
     /// EIRP of the transmitter.
     pub eirp: Decibel,
-    /// Receiver G/T.
+    /// Receiver G/T under clear-sky conditions.
     pub gt: Decibel,
+    /// Receiver G/T with the antenna noise temperature degraded by
+    /// absorptive atmospheric loss. `Some` only on downlinks with a receive
+    /// end that exposes degradable terms; this is the value the budget uses.
+    pub gt_degraded: Option<Decibel>,
+    /// Link direction, when specified.
+    pub direction: Option<LinkDirection>,
     /// Environmental losses.
     pub losses: PropagationLosses,
     /// Received carrier power. `None` for receive ends without [`RxTerms`].
@@ -322,7 +397,10 @@ impl LinkStats {
     /// under the given conditions.
     ///
     /// The carrier must lie inside both ends' frequency ranges. Each end
-    /// resolves its own pointing against its antenna.
+    /// resolves its own pointing against its antenna. On downlinks the
+    /// budget uses the rain-degraded G/T when the receive end exposes
+    /// degradable terms (see [`GOverT::rx_terms_degraded`]); aggregate G/T
+    /// figures stay at their clear-sky value.
     pub fn for_link(
         tx: &impl Eirp,
         rx: &impl GOverT,
@@ -337,16 +415,30 @@ impl LinkStats {
             Some(terms) => terms.gt(),
             None => rx.gt_at(carrier, params.rx_pointing)?,
         };
+
+        // Rain→noise coupling: only a downlink receiver sits behind the
+        // absorbing atmosphere. Uplink antennas already look at warm Earth
+        // through their configured clear-sky T_ant; crosslinks see no
+        // atmosphere.
+        let degraded_terms = if params.direction == Some(LinkDirection::Downlink) {
+            rx.rx_terms_degraded(carrier, params.rx_pointing, params.losses.absorptive())?
+        } else {
+            None
+        };
+        let gt_degraded = degraded_terms.as_ref().map(RxTerms::gt);
+        let effective_terms = degraded_terms.or(rx_terms);
+        let effective_gt = gt_degraded.unwrap_or(gt);
+
         let fspl = free_space_path_loss(params.range, carrier);
         let env_loss = params.losses.total();
 
-        let c_n0 = eirp + gt - fspl - env_loss - BOLTZMANN_CONSTANT_DB;
+        let c_n0 = eirp + effective_gt - fspl - env_loss - BOLTZMANN_CONSTANT_DB;
         let c_n = c_n0 - Decibel::from_linear(bandwidth.to_hertz());
 
-        let carrier_rx_power = rx_terms
+        let carrier_rx_power = effective_terms
             .as_ref()
             .map(|terms| eirp - fspl - env_loss + terms.gain());
-        let noise_power = rx_terms.as_ref().map(|terms| {
+        let noise_power = effective_terms.as_ref().map(|terms| {
             Decibel::from_linear(
                 terms.system_noise_temperature().to_kelvin()
                     * BOLTZMANN_CONSTANT
@@ -360,6 +452,8 @@ impl LinkStats {
             fspl,
             eirp,
             gt,
+            gt_degraded,
+            direction: params.direction,
             losses: params.losses.clone(),
             carrier_rx_power,
             noise_power,
@@ -699,6 +793,119 @@ mod tests {
         assert_approx_eq!(params.carrier().to_gigahertz(), 29.0, rtol <= 1e-12);
         assert_approx_eq!(params.bandwidth().to_megahertz(), 5.0, rtol <= 1e-12);
         assert_approx_eq!(params.range().to_meters(), 1e6, rtol <= 1e-12);
+    }
+
+    fn p618_losses() -> PropagationLosses {
+        // absorptive = 2.7 dB (rain + gaseous + cloud), total = 3.0 dB
+        PropagationLosses::builder()
+            .rain(2.0.db())
+            .gaseous(0.5.db())
+            .cloud(0.2.db())
+            .scintillation(0.3.db())
+            .build()
+            .unwrap()
+    }
+
+    fn faded_params(direction: Option<LinkDirection>) -> LinkParameters {
+        let mut builder =
+            LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
+                .losses(p618_losses());
+        if let Some(direction) = direction {
+            builder = builder.direction(direction);
+        }
+        builder.build().unwrap()
+    }
+
+    #[test]
+    fn test_degraded_sky_temperature() {
+        // No absorption: the clear-sky temperature passes through.
+        let t = degraded_sky_temperature(Temperature::kelvin(50.0), 0.0.db(), MEDIUM_TEMPERATURE);
+        assert_approx_eq!(t.to_kelvin(), 50.0, rtol <= 1e-12);
+        // Opaque atmosphere: the antenna sees the medium itself.
+        let t = degraded_sky_temperature(Temperature::kelvin(50.0), 60.0.db(), MEDIUM_TEMPERATURE);
+        assert_approx_eq!(t.to_kelvin(), 275.0, rtol <= 1e-5);
+        // 3 dB of absorption: T = 50/L + 275·(1 − 1/L), L = 10^0.3.
+        let t = degraded_sky_temperature(Temperature::kelvin(50.0), 3.0.db(), MEDIUM_TEMPERATURE);
+        let l = 10.0_f64.powf(0.3);
+        assert_approx_eq!(
+            t.to_kelvin(),
+            50.0 / l + 275.0 * (1.0 - 1.0 / l),
+            rtol <= 1e-12
+        );
+    }
+
+    #[test]
+    fn test_for_link_downlink_degrades_gt() {
+        let clear = LinkStats::for_link(&tx_chain(), &rx_chain(), &faded_params(None)).unwrap();
+        let faded = LinkStats::for_link(
+            &tx_chain(),
+            &rx_chain(),
+            &faded_params(Some(LinkDirection::Downlink)),
+        )
+        .unwrap();
+
+        // T_sys: 500 K clear → 500 + 275·(1 − 1/L_abs) K degraded (T_ant = 0 K).
+        let l_abs = 10.0_f64.powf(0.27);
+        let t_sys_degraded = 500.0 + 275.0 * (1.0 - 1.0 / l_abs);
+        let gt_degraded_exp = 30.0 - 10.0 * t_sys_degraded.log10();
+
+        assert_approx_eq!(faded.gt.as_f64(), clear.gt.as_f64(), atol <= 1e-12);
+        let gt_degraded = faded.gt_degraded.unwrap();
+        assert_approx_eq!(gt_degraded.as_f64(), gt_degraded_exp, atol <= 1e-10);
+        assert!(gt_degraded.as_f64() < faded.gt.as_f64());
+
+        // The budget uses the degraded G/T.
+        assert_approx_eq!(
+            clear.c_n0.as_f64() - faded.c_n0.as_f64(),
+            clear.gt.as_f64() - gt_degraded.as_f64(),
+            atol <= 1e-10
+        );
+
+        // C/N0 consistency holds with the degraded noise power.
+        let c_n0_from_power = faded.carrier_rx_power.unwrap() - faded.noise_power.unwrap()
+            + Decibel::from_linear(faded.bandwidth.to_hertz());
+        assert_approx_eq!(faded.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
+    }
+
+    #[test]
+    fn test_for_link_uplink_and_crosslink_stay_clear_sky() {
+        let clear = LinkStats::for_link(&tx_chain(), &rx_chain(), &faded_params(None)).unwrap();
+        for direction in [LinkDirection::Uplink, LinkDirection::Crosslink] {
+            let stats =
+                LinkStats::for_link(&tx_chain(), &rx_chain(), &faded_params(Some(direction)))
+                    .unwrap();
+            assert!(stats.gt_degraded.is_none());
+            assert_eq!(stats.direction, Some(direction));
+            assert_approx_eq!(stats.c_n0.as_f64(), clear.c_n0.as_f64(), atol <= 1e-12);
+        }
+    }
+
+    #[test]
+    fn test_for_link_lumped_downlink_stays_clear_sky() {
+        // An aggregate G/T figure cannot be degraded — documented caveat.
+        let tx = EirpModel::new(ka_band(), 55.0.db()).unwrap();
+        let rx = GtModel::new(ka_band(), 3.01.db()).unwrap();
+        let clear = LinkStats::for_link(&tx, &rx, &faded_params(None)).unwrap();
+        let faded =
+            LinkStats::for_link(&tx, &rx, &faded_params(Some(LinkDirection::Downlink))).unwrap();
+        assert!(faded.gt_degraded.is_none());
+        assert_approx_eq!(faded.c_n0.as_f64(), clear.c_n0.as_f64(), atol <= 1e-12);
+    }
+
+    #[test]
+    fn test_for_link_downlink_without_absorption_is_a_no_op() {
+        let params = LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
+            .direction(LinkDirection::Downlink)
+            .build()
+            .unwrap();
+        let stats = LinkStats::for_link(&tx_chain(), &rx_chain(), &params).unwrap();
+        // L_abs = 1: degraded equals clear-sky.
+        assert_approx_eq!(
+            stats.gt_degraded.unwrap().as_f64(),
+            stats.gt.as_f64(),
+            atol <= 1e-12
+        );
+        assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.01);
     }
 
     #[test]

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -910,6 +910,45 @@ mod tests {
         assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.01);
     }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_link_parameters_serde_round_trip_and_validation() {
+        let params = LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
+            .losses(p618_losses())
+            .tx_pointing(Pointing::off_boresight(lox_core::units::Angle::degrees(
+                2.0,
+            )))
+            .direction(LinkDirection::Downlink)
+            .build()
+            .unwrap();
+        let json = serde_json::to_string(&params).unwrap();
+        let round_trip: LinkParameters = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip.carrier(), params.carrier());
+        assert_eq!(round_trip.bandwidth(), params.bandwidth());
+        assert_eq!(round_trip.range(), params.range());
+        assert_eq!(round_trip.losses(), params.losses());
+        assert_eq!(round_trip.tx_pointing(), params.tx_pointing());
+        assert_eq!(round_trip.rx_pointing(), params.rx_pointing());
+        assert_eq!(round_trip.direction(), params.direction());
+
+        // Optional fields default: no losses, boresight, no direction.
+        let minimal: LinkParameters =
+            serde_json::from_str(r#"{"carrier":29.0e9,"bandwidth":5.0e6,"range":1.0e6}"#).unwrap();
+        assert_approx_eq!(minimal.losses().total().as_f64(), 0.0, atol <= 1e-15);
+        assert_eq!(minimal.tx_pointing(), Pointing::Boresight);
+        assert_eq!(minimal.rx_pointing(), Pointing::Boresight);
+        assert_eq!(minimal.direction(), None);
+
+        // Non-physical inputs are rejected at deserialization time.
+        for bad in [
+            r#"{"carrier":0.0,"bandwidth":5.0e6,"range":1.0e6}"#,
+            r#"{"carrier":29.0e9,"bandwidth":-5.0e6,"range":1.0e6}"#,
+            r#"{"carrier":29.0e9,"bandwidth":5.0e6,"range":0.0}"#,
+        ] {
+            assert!(serde_json::from_str::<LinkParameters>(bad).is_err());
+        }
+    }
+
     #[test]
     fn test_for_link_applies_propagation_losses() {
         let losses = PropagationLosses::builder()

--- a/crates/lox-comms/src/terminal.rs
+++ b/crates/lox-comms/src/terminal.rs
@@ -547,6 +547,18 @@ impl GOverT for RxTerminal {
             RxTerminal::Lumped(model) => model.rx_terms(carrier, pointing),
         }
     }
+
+    fn rx_terms_degraded(
+        &self,
+        carrier: Frequency,
+        pointing: Pointing,
+        absorptive: Decibel,
+    ) -> Result<Option<RxTerms>, LinkBudgetError> {
+        match self {
+            RxTerminal::Component(chain) => chain.rx_terms_degraded(carrier, pointing, absorptive),
+            RxTerminal::Lumped(model) => model.rx_terms_degraded(carrier, pointing, absorptive),
+        }
+    }
 }
 
 /// Rejects a carrier outside a terminal's frequency range.
@@ -956,6 +968,12 @@ mod tests {
         assert!(rx.band().contains(29.0.ghz()));
         assert!(
             rx.rx_terms(29.0.ghz(), Pointing::Boresight)
+                .unwrap()
+                .is_some()
+        );
+        // The degraded terms delegate through the enum as well.
+        assert!(
+            rx.rx_terms_degraded(29.0.ghz(), Pointing::Boresight, 3.0.db())
                 .unwrap()
                 .is_some()
         );

--- a/crates/lox-comms/src/terminal.rs
+++ b/crates/lox-comms/src/terminal.rs
@@ -21,7 +21,7 @@ use lox_core::units::{Angle, Decibel, Frequency, Temperature};
 
 use crate::antenna::{Antenna, AntennaGain};
 use crate::error::NonPhysicalError;
-use crate::link_budget::{Eirp, GOverT, RxTerms};
+use crate::link_budget::{Eirp, GOverT, MEDIUM_TEMPERATURE, RxTerms, degraded_sky_temperature};
 use crate::pointing::Pointing;
 use crate::receiver::Receiver;
 use crate::transmitter::AmplifierTransmitter;
@@ -233,6 +233,23 @@ impl RxChain {
     /// where `T_rx` is the receiver's input-referred (chain) noise
     /// temperature, T_feed = 290·(L − 1), and G_feed = 1/L.
     pub fn system_noise_temperature(&self) -> Temperature {
+        self.system_noise_temperature_with(self.antenna_noise_temperature)
+    }
+
+    /// Returns the system noise temperature with the antenna noise
+    /// temperature degraded by absorptive atmospheric loss
+    /// (see [`degraded_sky_temperature`]).
+    pub fn degraded_system_noise_temperature(&self, absorptive: Decibel) -> Temperature {
+        self.system_noise_temperature_with(degraded_sky_temperature(
+            self.antenna_noise_temperature,
+            absorptive,
+            MEDIUM_TEMPERATURE,
+        ))
+    }
+
+    /// Flange-referred system noise temperature for a given antenna noise
+    /// temperature (see [`Self::system_noise_temperature`] for the formula).
+    fn system_noise_temperature_with(&self, antenna_noise_temperature: Temperature) -> Temperature {
         let chain_temperature = match &self.receiver {
             Receiver::NoiseTemperature(rx) => rx.noise_temperature(),
             Receiver::Cascade(rx) => rx.chain_noise_temperature(),
@@ -240,7 +257,7 @@ impl RxChain {
         let loss_linear = self.feed_loss.to_linear();
         let feed_temperature = ROOM_TEMPERATURE.to_kelvin() * (loss_linear - 1.0);
         Temperature::kelvin(
-            self.antenna_noise_temperature.to_kelvin()
+            antenna_noise_temperature.to_kelvin()
                 + feed_temperature
                 + chain_temperature.to_kelvin() * loss_linear,
         )
@@ -277,16 +294,42 @@ impl GOverT for RxChain {
         carrier: Frequency,
         pointing: Pointing,
     ) -> Result<Option<RxTerms>, LinkBudgetError> {
-        check_carrier(carrier, self.band())?;
+        let gain = self.flange_gain(carrier, pointing)?;
+        Ok(Some(RxTerms::new(gain, self.system_noise_temperature())?))
+    }
+
+    /// Returns the receive terms with the antenna noise temperature degraded
+    /// by absorptive atmospheric loss; the signal gain is unaffected.
+    fn rx_terms_degraded(
+        &self,
+        carrier: Frequency,
+        pointing: Pointing,
+        absorptive: Decibel,
+    ) -> Result<Option<RxTerms>, LinkBudgetError> {
+        let gain = self.flange_gain(carrier, pointing)?;
+        Ok(Some(RxTerms::new(
+            gain,
+            self.degraded_system_noise_temperature(absorptive),
+        )?))
+    }
+}
+
+impl RxChain {
+    /// Flange-referred receive system gain toward a pointing.
+    fn flange_gain(
+        &self,
+        carrier: Frequency,
+        pointing: Pointing,
+    ) -> Result<Decibel, LinkBudgetError> {
+        check_carrier(carrier, self.band)?;
         let (theta, phi) = self.pattern_angles(pointing)?;
         let antenna_gain = self.antenna.gain(carrier, theta, phi);
-        let gain = match &self.receiver {
+        Ok(match &self.receiver {
             Receiver::NoiseTemperature(_) => antenna_gain,
             Receiver::Cascade(rx) => {
                 antenna_gain - rx.demodulator_loss() - rx.implementation_loss()
             }
-        };
-        Ok(Some(RxTerms::new(gain, self.system_noise_temperature())?))
+        })
     }
 }
 
@@ -611,6 +654,47 @@ mod tests {
         assert_approx_eq!(terms.gain().as_f64(), 30.0, atol <= 1e-12);
         let gt = rx.gt_at(29.0.ghz(), Pointing::Boresight).unwrap();
         assert_approx_eq!(gt.as_f64(), 30.0 - 10.0 * expected.log10(), atol <= 1e-12);
+    }
+
+    #[test]
+    fn test_degraded_system_noise_temperature() {
+        // Same chain as the flange-referral test; 3 dB of absorption first
+        // degrades T_ant: T_ant' = 150/L_abs + 275·(1 − 1/L_abs), then the
+        // identical referral applies.
+        let rx = RxChain::new(
+            ConstantAntenna::new(30.0.db()).unwrap(),
+            NoiseTempReceiver::new(Temperature::kelvin(500.0)).unwrap(),
+            2.0.db(),
+            Temperature::kelvin(150.0),
+            ka_band(),
+        )
+        .unwrap();
+        let l_abs = 10f64.powf(0.3);
+        let t_ant = 150.0 / l_abs + 275.0 * (1.0 - 1.0 / l_abs);
+        let l_feed = 10f64.powf(0.2);
+        let expected = t_ant + 290.0 * (l_feed - 1.0) + 500.0 * l_feed;
+        assert_approx_eq!(
+            rx.degraded_system_noise_temperature(3.0.db()).to_kelvin(),
+            expected,
+            rtol <= 1e-12
+        );
+        // Zero absorption reproduces the clear-sky figure.
+        assert_approx_eq!(
+            rx.degraded_system_noise_temperature(0.0.db()).to_kelvin(),
+            rx.system_noise_temperature().to_kelvin(),
+            rtol <= 1e-12
+        );
+        // The signal gain is unaffected by the noise degradation.
+        let degraded = rx
+            .rx_terms_degraded(29.0.ghz(), Pointing::Boresight, 3.0.db())
+            .unwrap()
+            .unwrap();
+        assert_approx_eq!(degraded.gain().as_f64(), 30.0, atol <= 1e-12);
+        assert_approx_eq!(
+            degraded.system_noise_temperature().to_kelvin(),
+            expected,
+            rtol <= 1e-12
+        );
     }
 
     #[test]

--- a/crates/lox-space/examples/x_band_downlink.rs
+++ b/crates/lox-space/examples/x_band_downlink.rs
@@ -128,6 +128,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .losses(losses)
         .tx_pointing(tx_pointing)
         .rx_pointing(rx_pointing)
+        .direction(LinkDirection::Downlink)
         .build()?;
     let link = LinkStats::for_link(&tx, &rx, &params)?;
     let modulated = channel.apply(link);
@@ -139,7 +140,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         "Env. losses:     {:>8.2} dB",
         modulated.link.losses.total().as_f64()
     );
-    println!("G/T:             {:>8.2} dB/K", modulated.link.gt.as_f64());
+    println!("G/T (clear-sky): {:>8.2} dB/K", modulated.link.gt.as_f64());
+    let gt_degraded = modulated.link.gt_degraded.expect("downlink with RX chain");
+    println!(
+        "G/T (rain):      {:>8.2} dB/K ({:+.2} dB)",
+        gt_degraded.as_f64(),
+        gt_degraded.as_f64() - modulated.link.gt.as_f64()
+    );
     println!(
         "C/N0:            {:>8.2} dB·Hz",
         modulated.link.c_n0.as_f64()

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1186,8 +1186,11 @@ impl PyLinkStats {
     ///     tx_direction: Line-of-sight direction at transmitter as [x, y, z] (optional).
     ///     rx_direction: Line-of-sight direction at receiver as [x, y, z] (optional).
     ///     losses: PropagationLosses (optional, defaults to none).
+    ///     link_type: "uplink", "downlink", or "crosslink" (optional). On
+    ///         downlinks the budget uses the rain-degraded G/T
+    ///         (ITU-R P.618 §8.2).
     #[staticmethod]
-    #[pyo3(signature = (tx, rx, carrier, bandwidth, range, tx_angle=None, rx_angle=None, tx_direction=None, rx_direction=None, losses=None))]
+    #[pyo3(signature = (tx, rx, carrier, bandwidth, range, tx_angle=None, rx_angle=None, tx_direction=None, rx_direction=None, losses=None, link_type=None))]
     #[allow(clippy::too_many_arguments)]
     fn for_link(
         tx: &Bound<'_, PyAny>,
@@ -1200,6 +1203,7 @@ impl PyLinkStats {
         tx_direction: Option<[f64; 3]>,
         rx_direction: Option<[f64; 3]>,
         losses: Option<&PyPropagationLosses>,
+        link_type: Option<&str>,
     ) -> PyResult<Self> {
         let tx = build_tx_terminal(tx)?;
         let rx = build_rx_terminal(rx)?;
@@ -1209,10 +1213,14 @@ impl PyLinkStats {
             .map(|l| l.0.clone())
             .unwrap_or_else(PropagationLosses::none);
 
-        let params = LinkParameters::builder(carrier.0, bandwidth.0, range.0)
+        let mut builder = LinkParameters::builder(carrier.0, bandwidth.0, range.0)
             .losses(env_losses)
             .tx_pointing(tx_pointing)
-            .rx_pointing(rx_pointing)
+            .rx_pointing(rx_pointing);
+        if let Some(link_type) = link_type {
+            builder = builder.direction(parse_link_direction(link_type)?);
+        }
+        let params = builder
             .build()
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
         LinkStats::for_link(&tx, &rx, &params)
@@ -1238,10 +1246,24 @@ impl PyLinkStats {
         PyDecibel(self.0.eirp)
     }
 
-    /// Receiver G/T in dB/K.
+    /// Receiver G/T in dB/K under clear-sky conditions.
     #[getter]
     fn gt(&self) -> PyDecibel {
         PyDecibel(self.0.gt)
+    }
+
+    /// Rain-degraded receiver G/T in dB/K. ``None`` unless the link is a
+    /// downlink with a component receive chain; when present, this is the
+    /// value the budget used.
+    #[getter]
+    fn gt_degraded(&self) -> Option<PyDecibel> {
+        self.0.gt_degraded.map(PyDecibel)
+    }
+
+    /// Link direction ("uplink", "downlink", or "crosslink"), if specified.
+    #[getter]
+    fn link_type(&self) -> Option<String> {
+        self.0.direction.map(|d| d.to_string())
     }
 
     /// Carrier-to-noise density ratio in dB·Hz.

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -815,6 +815,38 @@ def test_link_stats_end_to_end():
     assert stats.frequency.to_hertz() == pytest.approx(29e9, abs=1.0)
 
 
+def test_link_stats_downlink_degrades_gt():
+    losses = lox.PropagationLosses(
+        rain=2.0 * lox.dB, gaseous=0.5 * lox.dB, cloud=0.2 * lox.dB,
+        scintillation=0.3 * lox.dB,
+    )
+    clear = link_stats(make_tx(), make_rx(), losses=losses)
+    faded = link_stats(make_tx(), make_rx(), losses=losses, link_type="downlink")
+
+    assert clear.gt_degraded is None
+    assert clear.link_type is None
+    assert faded.link_type == "downlink"
+    assert float(faded.gt) == pytest.approx(float(clear.gt), abs=1e-12)
+    assert float(faded.gt_degraded) < float(faded.gt)
+    # The budget uses the degraded G/T.
+    assert float(clear.c_n0) - float(faded.c_n0) == pytest.approx(
+        float(faded.gt) - float(faded.gt_degraded), abs=1e-10
+    )
+
+
+def test_link_stats_uplink_stays_clear_sky():
+    losses = lox.PropagationLosses(rain=2.0 * lox.dB)
+    clear = link_stats(make_tx(), make_rx(), losses=losses)
+    uplink = link_stats(make_tx(), make_rx(), losses=losses, link_type="uplink")
+    assert uplink.gt_degraded is None
+    assert float(uplink.c_n0) == pytest.approx(float(clear.c_n0), abs=1e-12)
+
+
+def test_link_stats_rejects_unknown_link_type():
+    with pytest.raises(ValueError):
+        link_stats(make_tx(), make_rx(), link_type="sideways")
+
+
 def test_link_stats_with_losses():
     ch = lox.Channel(
         link_type="downlink",

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2906,13 +2906,16 @@ class LinkStats:
         tx_direction: list[float] | None = None,
         rx_direction: list[float] | None = None,
         losses: PropagationLosses | None = None,
+        link_type: str | None = None,
     ) -> LinkStats:
         """Computes a modulation-agnostic link budget between two link terminals.
 
         The carrier must lie inside both terminals' frequency ranges. Each
         terminal's pointing is given either as an off-boresight angle or as a
         line-of-sight direction vector in the antenna's parent frame; omitting
-        both assumes ideal (boresight) pointing.
+        both assumes ideal (boresight) pointing. On downlinks
+        (``link_type="downlink"``) the budget uses the rain-degraded G/T
+        (ITU-R P.618 §8.2).
         """
         ...
     @property
@@ -2929,7 +2932,16 @@ class LinkStats:
         ...
     @property
     def gt(self) -> Decibel:
-        """Receiver G/T in dB/K."""
+        """Receiver G/T in dB/K under clear-sky conditions."""
+        ...
+    @property
+    def gt_degraded(self) -> Decibel | None:
+        """Rain-degraded receiver G/T in dB/K. ``None`` unless the link is a
+        downlink with a component receive chain."""
+        ...
+    @property
+    def link_type(self) -> str | None:
+        """Link direction ("uplink", "downlink", or "crosslink"), if specified."""
         ...
     @property
     def c_n0(self) -> Decibel:


### PR DESCRIPTION
- **feat(lox-comms): rain-degraded G/T for downlinks (ITU-R P.618 §8.2)**
- **feat(lox-space)!: expose rain-degraded G/T via link_type in Python API**
