### PR TITLE
Separate channels and modcods

### DIFF
--- a/crates/lox-comms/Cargo.toml
+++ b/crates/lox-comms/Cargo.toml
@@ -27,7 +27,7 @@ serde = ["dep:serde", "lox-core/serde"]
 
 [dev-dependencies]
 lox-test-utils = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["float_roundtrip"] }
 
 [lib]
 doctest = false

--- a/crates/lox-comms/src/channel.rs
+++ b/crates/lox-comms/src/channel.rs
@@ -2,9 +2,21 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-//! Communication channel model (modulation, bandwidth, Es/N0, Eb/N0, DSSS).
+//! Waveform occupancy: how symbols occupy spectrum.
+//!
+//! A [`Channel`] describes the physical waveform — symbol rate, pulse
+//! shaping, and optional DSSS spreading — and nothing else. What is
+//! transmitted on it (modulation and coding) is a
+//! [`ModCod`](crate::modcod::ModCod); link direction lives on
+//! [`LinkParameters`](crate::link_budget::LinkParameters); acceptance
+//! criteria (required Eb/N0, design margin) are evaluation inputs.
+
+use core::fmt;
+use std::str::FromStr;
 
 use lox_core::units::{Decibel, Frequency};
+
+use crate::error::NonPhysicalError;
 
 /// Digital modulation scheme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,8 +27,18 @@ pub enum Modulation {
     Bpsk,
     /// Quadrature Phase-Shift Keying (2 bits/symbol).
     Qpsk,
+    /// Offset Quadrature Phase-Shift Keying (2 bits/symbol).
+    Oqpsk,
     /// 8-Phase-Shift Keying (3 bits/symbol).
     Psk8,
+    /// 8-Amplitude-Phase-Shift Keying (3 bits/symbol, DVB-S2X).
+    Apsk8,
+    /// 16-Amplitude-Phase-Shift Keying (4 bits/symbol, DVB-S2).
+    Apsk16,
+    /// 32-Amplitude-Phase-Shift Keying (5 bits/symbol, DVB-S2).
+    Apsk32,
+    /// 64-Amplitude-Phase-Shift Keying (6 bits/symbol, DVB-S2X).
+    Apsk64,
     /// 16-Quadrature Amplitude Modulation (4 bits/symbol).
     Qam16,
     /// 32-Quadrature Amplitude Modulation (5 bits/symbol).
@@ -27,21 +49,92 @@ pub enum Modulation {
     Qam128,
     /// 256-Quadrature Amplitude Modulation (8 bits/symbol).
     Qam256,
+    /// Gaussian Minimum-Shift Keying (1 bit/symbol).
+    Gmsk,
+    /// Binary Frequency-Shift Keying (1 bit/symbol).
+    Fsk2,
+    /// Quaternary Frequency-Shift Keying (2 bits/symbol).
+    Fsk4,
 }
 
 impl Modulation {
     /// Returns the number of bits per symbol for this modulation scheme.
     pub fn bits_per_symbol(self) -> u8 {
         match self {
-            Modulation::Bpsk => 1,
-            Modulation::Qpsk => 2,
-            Modulation::Psk8 => 3,
-            Modulation::Qam16 => 4,
-            Modulation::Qam32 => 5,
-            Modulation::Qam64 => 6,
+            Modulation::Bpsk | Modulation::Gmsk | Modulation::Fsk2 => 1,
+            Modulation::Qpsk | Modulation::Oqpsk | Modulation::Fsk4 => 2,
+            Modulation::Psk8 | Modulation::Apsk8 => 3,
+            Modulation::Qam16 | Modulation::Apsk16 => 4,
+            Modulation::Qam32 | Modulation::Apsk32 => 5,
+            Modulation::Qam64 | Modulation::Apsk64 => 6,
             Modulation::Qam128 => 7,
             Modulation::Qam256 => 8,
         }
+    }
+
+    /// Returns the conventional name, e.g. `"16APSK"`.
+    pub fn name(self) -> &'static str {
+        match self {
+            Modulation::Bpsk => "BPSK",
+            Modulation::Qpsk => "QPSK",
+            Modulation::Oqpsk => "OQPSK",
+            Modulation::Psk8 => "8PSK",
+            Modulation::Apsk8 => "8APSK",
+            Modulation::Apsk16 => "16APSK",
+            Modulation::Apsk32 => "32APSK",
+            Modulation::Apsk64 => "64APSK",
+            Modulation::Qam16 => "16QAM",
+            Modulation::Qam32 => "32QAM",
+            Modulation::Qam64 => "64QAM",
+            Modulation::Qam128 => "128QAM",
+            Modulation::Qam256 => "256QAM",
+            Modulation::Gmsk => "GMSK",
+            Modulation::Fsk2 => "2FSK",
+            Modulation::Fsk4 => "4FSK",
+        }
+    }
+
+    /// All supported modulation schemes.
+    pub const ALL: [Self; 16] = [
+        Self::Bpsk,
+        Self::Qpsk,
+        Self::Oqpsk,
+        Self::Psk8,
+        Self::Apsk8,
+        Self::Apsk16,
+        Self::Apsk32,
+        Self::Apsk64,
+        Self::Qam16,
+        Self::Qam32,
+        Self::Qam64,
+        Self::Qam128,
+        Self::Qam256,
+        Self::Gmsk,
+        Self::Fsk2,
+        Self::Fsk4,
+    ];
+}
+
+impl fmt::Display for Modulation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// The name does not match a known modulation scheme.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown modulation: '{0}'")]
+pub struct ParseModulationError(String);
+
+impl FromStr for Modulation {
+    type Err = ParseModulationError;
+
+    /// Parses a conventional modulation name, ignoring ASCII case.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|m| s.eq_ignore_ascii_case(m.name()))
+            .ok_or_else(|| ParseModulationError(s.to_owned()))
     }
 }
 
@@ -58,8 +151,8 @@ pub enum LinkDirection {
     Crosslink,
 }
 
-impl std::fmt::Display for LinkDirection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for LinkDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LinkDirection::Uplink => write!(f, "uplink"),
             LinkDirection::Downlink => write!(f, "downlink"),
@@ -68,7 +161,7 @@ impl std::fmt::Display for LinkDirection {
     }
 }
 
-impl std::str::FromStr for LinkDirection {
+impl FromStr for LinkDirection {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -83,41 +176,81 @@ impl std::str::FromStr for LinkDirection {
     }
 }
 
-/// A communication channel.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// A communication channel: the waveform's occupancy of spectrum.
+///
+/// Holds the symbol rate, the pulse-shaping roll-off, and the optional DSSS
+/// chip rate. Valid by construction via [`Channel::builder`].
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "ChannelRepr")
+)]
 pub struct Channel {
-    /// Link direction.
-    pub link_type: LinkDirection,
-    /// Symbol rate.
-    pub symbol_rate: Frequency,
-    /// Required Eb/N0 for the target BER.
-    pub required_eb_n0: Decibel,
-    /// Required link margin.
-    pub margin: Decibel,
-    /// Modulation scheme.
-    pub modulation: Modulation,
-    /// Roll-off factor (excess bandwidth factor).
-    pub roll_off: f64,
-    /// Forward error correction code rate.
-    pub fec: f64,
-    /// Chip rate for DSSS systems (`None` for narrowband).
-    pub chip_rate: Option<Frequency>,
+    symbol_rate: Frequency,
+    roll_off: f64,
+    chip_rate: Option<Frequency>,
 }
 
+/// Serde wire format for [`Channel`]: forces deserialization through the
+/// validated builder.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+struct ChannelRepr {
+    symbol_rate: Frequency,
+    #[serde(default = "default_roll_off")]
+    roll_off: f64,
+    #[serde(default)]
+    chip_rate: Option<Frequency>,
+}
+
+#[cfg(feature = "serde")]
+fn default_roll_off() -> f64 {
+    DEFAULT_ROLL_OFF
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<ChannelRepr> for Channel {
+    type Error = NonPhysicalError;
+
+    fn try_from(repr: ChannelRepr) -> Result<Self, Self::Error> {
+        let mut builder = Channel::builder(repr.symbol_rate).roll_off(repr.roll_off);
+        if let Some(chip_rate) = repr.chip_rate {
+            builder = builder.chip_rate(chip_rate);
+        }
+        builder.build()
+    }
+}
+
+/// Default pulse-shaping roll-off factor.
+const DEFAULT_ROLL_OFF: f64 = 0.35;
+
 impl Channel {
-    /// Returns the raw bit rate in bits per second.
+    /// Starts building a channel with the given symbol rate.
     ///
-    /// R_b = R_s · b
-    pub fn data_rate(&self) -> Frequency {
-        self.modulation.bits_per_symbol() as f64 * self.symbol_rate
+    /// The roll-off defaults to 0.35 and the chip rate to `None`
+    /// (narrowband).
+    pub fn builder(symbol_rate: Frequency) -> ChannelBuilder {
+        ChannelBuilder {
+            symbol_rate,
+            roll_off: DEFAULT_ROLL_OFF,
+            chip_rate: None,
+        }
     }
 
-    /// Returns the information (post-FEC) bit rate in bits per second.
-    ///
-    /// R_info = R_s · b · FEC
-    pub fn information_rate(&self) -> Frequency {
-        self.fec * self.data_rate()
+    /// Returns the symbol rate.
+    pub fn symbol_rate(&self) -> Frequency {
+        self.symbol_rate
+    }
+
+    /// Returns the pulse-shaping roll-off factor.
+    pub fn roll_off(&self) -> f64 {
+        self.roll_off
+    }
+
+    /// Returns the DSSS chip rate, or `None` for narrowband channels.
+    pub fn chip_rate(&self) -> Option<Frequency> {
+        self.chip_rate
     }
 
     /// Returns the occupied channel bandwidth.
@@ -136,27 +269,11 @@ impl Channel {
         c_n0 - Decibel::from_linear(self.symbol_rate.to_hertz())
     }
 
-    /// Computes Eb/N0 (energy per information bit to noise spectral density) from C/N0.
-    ///
-    /// Eb/N0 = Es/N0 − 10·log₁₀(b · FEC)
-    pub fn eb_n0(&self, c_n0: Decibel) -> Decibel {
-        let es_n0 = self.es_n0(c_n0);
-        let bps_fec = self.modulation.bits_per_symbol() as f64 * self.fec;
-        es_n0 - Decibel::from_linear(bps_fec)
-    }
-
     /// Computes C/N (carrier-to-noise ratio) from C/N0.
     ///
     /// C/N = C/N0 − 10·log₁₀(BW_occupied)
     pub fn c_n(&self, c_n0: Decibel) -> Decibel {
         c_n0 - Decibel::from_linear(self.bandwidth().to_hertz())
-    }
-
-    /// Computes the link margin from a given Eb/N0.
-    ///
-    /// Margin = Eb/N0 − required_eb_n0 − margin
-    pub fn link_margin(&self, eb_n0: Decibel) -> Decibel {
-        eb_n0 - self.required_eb_n0 - self.margin
     }
 
     /// Returns the DSSS spreading factor, or `None` for narrowband channels.
@@ -181,26 +298,51 @@ impl Channel {
         self.chip_rate
             .map(|cr| c_n0 - Decibel::from_linear(cr.to_hertz()))
     }
+}
 
-    /// Layers modulation/FEC figures onto a modulation-agnostic [`crate::link_budget::LinkStats`].
+/// Builder for [`Channel`].
+///
+/// Created via [`Channel::builder`]. Inputs are validated at
+/// [`ChannelBuilder::build`].
+#[derive(Debug, Clone)]
+pub struct ChannelBuilder {
+    symbol_rate: Frequency,
+    roll_off: f64,
+    chip_rate: Option<Frequency>,
+}
+
+impl ChannelBuilder {
+    /// Sets the pulse-shaping roll-off factor.
+    pub fn roll_off(mut self, roll_off: f64) -> Self {
+        self.roll_off = roll_off;
+        self
+    }
+
+    /// Sets the DSSS chip rate.
+    pub fn chip_rate(mut self, chip_rate: Frequency) -> Self {
+        self.chip_rate = Some(chip_rate);
+        self
+    }
+
+    /// Builds the channel, validating all inputs.
     ///
-    /// Computes `Es/N0`, `Eb/N0`, and link margin from the channel's modulation, FEC,
-    /// symbol rate, required `Eb/N0`, and required margin.
-    pub fn apply(
-        &self,
-        link: crate::link_budget::LinkStats,
-    ) -> crate::link_budget::ModulatedLinkStats {
-        let es_n0 = self.es_n0(link.c_n0);
-        let eb_n0 = self.eb_n0(link.c_n0);
-        let margin = self.link_margin(eb_n0);
-        crate::link_budget::ModulatedLinkStats {
-            link,
-            channel: self.clone(),
-            symbol_rate: self.symbol_rate,
-            es_n0,
-            eb_n0,
-            margin,
+    /// Rejects a non-finite or non-positive symbol rate, a non-finite or
+    /// negative roll-off, and a chip rate below the symbol rate.
+    pub fn build(self) -> Result<Channel, NonPhysicalError> {
+        NonPhysicalError::check_positive("symbol rate [Hz]", self.symbol_rate.to_hertz())?;
+        NonPhysicalError::check_non_negative("roll-off factor", self.roll_off)?;
+        if let Some(chip_rate) = self.chip_rate {
+            NonPhysicalError::check_positive("chip rate [Hz]", chip_rate.to_hertz())?;
+            NonPhysicalError::check_non_negative(
+                "chip rate minus symbol rate [Hz]",
+                chip_rate.to_hertz() - self.symbol_rate.to_hertz(),
+            )?;
         }
+        Ok(Channel {
+            symbol_rate: self.symbol_rate,
+            roll_off: self.roll_off,
+            chip_rate: self.chip_rate,
+        })
     }
 }
 
@@ -212,66 +354,59 @@ mod tests {
     use super::*;
 
     fn narrowband_channel() -> Channel {
-        Channel {
-            link_type: LinkDirection::Downlink,
-            symbol_rate: 5.0.mhz(),
-            required_eb_n0: 10.0.db(),
-            margin: 3.0.db(),
-            modulation: Modulation::Qpsk,
-            roll_off: 0.35,
-            fec: 0.5,
-            chip_rate: None,
-        }
+        Channel::builder(5.0.mhz()).build().unwrap()
+    }
+
+    fn dsss_channel() -> Channel {
+        Channel::builder(0.01.mhz())
+            .chip_rate(4.0.mhz())
+            .build()
+            .unwrap()
     }
 
     #[test]
     fn test_bits_per_symbol() {
         assert_eq!(Modulation::Bpsk.bits_per_symbol(), 1);
         assert_eq!(Modulation::Qpsk.bits_per_symbol(), 2);
+        assert_eq!(Modulation::Oqpsk.bits_per_symbol(), 2);
         assert_eq!(Modulation::Psk8.bits_per_symbol(), 3);
+        assert_eq!(Modulation::Apsk8.bits_per_symbol(), 3);
+        assert_eq!(Modulation::Apsk16.bits_per_symbol(), 4);
+        assert_eq!(Modulation::Apsk32.bits_per_symbol(), 5);
+        assert_eq!(Modulation::Apsk64.bits_per_symbol(), 6);
         assert_eq!(Modulation::Qam16.bits_per_symbol(), 4);
         assert_eq!(Modulation::Qam32.bits_per_symbol(), 5);
         assert_eq!(Modulation::Qam64.bits_per_symbol(), 6);
         assert_eq!(Modulation::Qam128.bits_per_symbol(), 7);
         assert_eq!(Modulation::Qam256.bits_per_symbol(), 8);
+        assert_eq!(Modulation::Gmsk.bits_per_symbol(), 1);
+        assert_eq!(Modulation::Fsk2.bits_per_symbol(), 1);
+        assert_eq!(Modulation::Fsk4.bits_per_symbol(), 2);
     }
 
     #[test]
-    fn test_data_rate() {
-        let ch = narrowband_channel();
-        // QPSK: 2 bits/symbol, symbol_rate=5 MHz → data_rate=10 MHz
-        assert_approx_eq!(ch.data_rate().to_hertz(), 10e6, rtol <= 1e-10);
-    }
-
-    #[test]
-    fn test_information_rate() {
-        let ch = narrowband_channel();
-        // data_rate=10 MHz, fec=0.5 → information_rate=5 MHz
-        assert_approx_eq!(ch.information_rate().to_hertz(), 5e6, rtol <= 1e-10);
+    fn test_modulation_name_parse_round_trip() {
+        for m in Modulation::ALL {
+            assert_eq!(m.name().parse::<Modulation>(), Ok(m));
+            assert_eq!(m.to_string(), m.name());
+        }
+        // Parsing ignores ASCII case.
+        assert_eq!("qpsk".parse::<Modulation>(), Ok(Modulation::Qpsk));
+        assert_eq!("16apsk".parse::<Modulation>(), Ok(Modulation::Apsk16));
+        assert!("3PSK".parse::<Modulation>().is_err());
     }
 
     #[test]
     fn test_bandwidth_narrowband() {
-        // QPSK, symbol_rate=5 MHz, roll-off=0.35
-        // BW = 5e6 * 1.35 = 6.75 MHz
+        // symbol_rate=5 MHz, default roll-off=0.35: BW = 5e6 * 1.35 = 6.75 MHz
         let ch = narrowband_channel();
         assert_approx_eq!(ch.bandwidth().to_hertz(), 6.75e6, rtol <= 1e-10);
     }
 
     #[test]
-    fn test_bandwidth_bpsk() {
-        // BPSK, symbol_rate=1 MHz, roll-off=0.5
-        // BW = 1e6 * 1.5 = 1.5 MHz
-        let ch = Channel {
-            link_type: LinkDirection::Downlink,
-            symbol_rate: 1.0.mhz(),
-            required_eb_n0: 10.0.db(),
-            margin: 3.0.db(),
-            modulation: Modulation::Bpsk,
-            roll_off: 0.5,
-            fec: 0.5,
-            chip_rate: None,
-        };
+    fn test_bandwidth_with_roll_off() {
+        // symbol_rate=1 MHz, roll-off=0.5: BW = 1e6 * 1.5 = 1.5 MHz
+        let ch = Channel::builder(1.0.mhz()).roll_off(0.5).build().unwrap();
         assert_approx_eq!(ch.bandwidth().to_hertz(), 1.5e6, rtol <= 1e-10);
     }
 
@@ -285,33 +420,8 @@ mod tests {
     }
 
     #[test]
-    fn test_eb_n0() {
-        // C/N0 = 80 dBHz, symbol_rate = 5 MHz, QPSK (2 bps), fec = 0.5
-        // Es/N0 = 80 - 10*log10(5e6) = 13.0103
-        // Eb/N0 = 13.0103 - 10*log10(2 * 0.5) = 13.0103 - 0 = 13.0103
-        let ch = narrowband_channel();
-        let eb_n0 = ch.eb_n0(80.0.db());
-        assert_approx_eq!(eb_n0.as_f64(), 13.0103, atol <= 0.001);
-    }
-
-    #[test]
-    fn test_eb_n0_with_higher_code_rate() {
-        // symbol_rate=5 MHz, QPSK (2 bps), fec=5/6
-        // Es/N0 = 80 - 10*log10(5e6) = 13.0103
-        // Eb/N0 = 13.0103 - 10*log10(2 * 5/6) = 13.0103 - 2.2185 = 10.7918
-        let ch = Channel {
-            fec: 5.0 / 6.0,
-            ..narrowband_channel()
-        };
-        let eb_n0 = ch.eb_n0(80.0.db());
-        let expected = 13.0103 - 10.0 * (2.0 * 5.0 / 6.0_f64).log10();
-        assert_approx_eq!(eb_n0.as_f64(), expected, atol <= 0.001);
-    }
-
-    #[test]
     fn test_c_n() {
         // C/N0 = 80 dBHz, BW = 6.75 MHz
-        // C/N = 80 - 10*log10(6.75e6) = 80 - 68.29 = 11.71 dB
         let ch = narrowband_channel();
         let c_n = ch.c_n(80.0.db());
         let expected = 80.0 - 10.0 * 6.75e6_f64.log10();
@@ -319,65 +429,24 @@ mod tests {
     }
 
     #[test]
-    fn test_link_margin() {
-        // Eb/N0 = 15 dB, required = 10 dB, margin = 3 dB → link margin = 2 dB
-        let ch = narrowband_channel();
-        let margin = ch.link_margin(15.0.db());
-        assert_approx_eq!(margin.as_f64(), 2.0, atol <= 1e-10);
-    }
-
-    #[test]
-    fn test_dsss_spreading_factor() {
-        let ch = Channel {
-            chip_rate: Some(4.0.mhz()),
-            symbol_rate: 0.01.mhz(),
-            modulation: Modulation::Bpsk,
-            ..narrowband_channel()
-        };
+    fn test_dsss_spreading_factor_and_processing_gain() {
+        let ch = dsss_channel();
         assert_approx_eq!(ch.spreading_factor().unwrap(), 400.0, rtol <= 1e-10);
-    }
-
-    #[test]
-    fn test_dsss_processing_gain() {
-        let ch = Channel {
-            chip_rate: Some(4.0.mhz()),
-            symbol_rate: 0.01.mhz(),
-            modulation: Modulation::Bpsk,
-            ..narrowband_channel()
-        };
         // PG = 10*log10(400) = 26.02 dB
         assert_approx_eq!(
             ch.processing_gain().unwrap().as_f64(),
             26.0206,
             atol <= 0.001
         );
-    }
-
-    #[test]
-    fn test_dsss_bandwidth() {
         // DSSS: BW = chip_rate * (1 + roll_off) = 4e6 * 1.35 = 5.4 MHz
-        let ch = Channel {
-            chip_rate: Some(4.0.mhz()),
-            symbol_rate: 0.01.mhz(),
-            modulation: Modulation::Bpsk,
-            ..narrowband_channel()
-        };
         assert_approx_eq!(ch.bandwidth().to_hertz(), 5.4e6, rtol <= 1e-10);
     }
 
     #[test]
     fn test_dsss_es_n0_spread_vs_despread() {
-        let ch = Channel {
-            chip_rate: Some(4.0.mhz()),
-            symbol_rate: 0.01.mhz(),
-            modulation: Modulation::Bpsk,
-            ..narrowband_channel()
-        };
+        let ch = dsss_channel();
         let c_n0 = 60.0.db();
-        let es_n0_spread = ch.es_n0_spread(c_n0).unwrap();
-        let es_n0_despread = ch.es_n0(c_n0);
-        // Difference should equal processing gain
-        let diff = es_n0_despread - es_n0_spread;
+        let diff = ch.es_n0(c_n0) - ch.es_n0_spread(c_n0).unwrap();
         assert_approx_eq!(
             diff.as_f64(),
             ch.processing_gain().unwrap().as_f64(),
@@ -394,14 +463,56 @@ mod tests {
     }
 
     #[test]
-    fn test_link_direction_display() {
-        assert_eq!(LinkDirection::Uplink.to_string(), "uplink");
-        assert_eq!(LinkDirection::Downlink.to_string(), "downlink");
-        assert_eq!(LinkDirection::Crosslink.to_string(), "crosslink");
+    fn test_channel_rejects_non_physical_inputs() {
+        assert!(Channel::builder(Frequency::hertz(0.0)).build().is_err());
+        assert!(Channel::builder(Frequency::hertz(-5e6)).build().is_err());
+        assert!(Channel::builder(5.0.mhz()).roll_off(-0.1).build().is_err());
+        assert!(
+            Channel::builder(5.0.mhz())
+                .roll_off(f64::NAN)
+                .build()
+                .is_err()
+        );
+        // Chip rate below the symbol rate is not a spreading system.
+        assert!(
+            Channel::builder(5.0.mhz())
+                .chip_rate(1.0.mhz())
+                .build()
+                .is_err()
+        );
+        // Chip rate equal to the symbol rate is allowed (SF = 1).
+        assert!(
+            Channel::builder(5.0.mhz())
+                .chip_rate(5.0.mhz())
+                .build()
+                .is_ok()
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_channel_serde_round_trip_and_validation() {
+        let ch = dsss_channel();
+        let json = serde_json::to_string(&ch).unwrap();
+        let round_trip: Channel = serde_json::from_str(&json).unwrap();
+        assert_eq!(ch, round_trip);
+
+        // Roll-off defaults when omitted.
+        let minimal: Channel = serde_json::from_str(r#"{"symbol_rate":5.0e6}"#).unwrap();
+        assert_approx_eq!(minimal.roll_off(), 0.35, atol <= 1e-15);
+
+        // Non-physical inputs are rejected at deserialization time.
+        assert!(serde_json::from_str::<Channel>(r#"{"symbol_rate":-5.0e6}"#).is_err());
+        assert!(
+            serde_json::from_str::<Channel>(r#"{"symbol_rate":5.0e6,"roll_off":-1.0}"#).is_err()
+        );
     }
 
     #[test]
-    fn test_link_direction_from_str() {
+    fn test_link_direction_display_and_parse() {
+        assert_eq!(LinkDirection::Uplink.to_string(), "uplink");
+        assert_eq!(LinkDirection::Downlink.to_string(), "downlink");
+        assert_eq!(LinkDirection::Crosslink.to_string(), "crosslink");
         assert_eq!(
             "uplink".parse::<LinkDirection>().unwrap(),
             LinkDirection::Uplink

--- a/crates/lox-comms/src/channel.rs
+++ b/crates/lox-comms/src/channel.rs
@@ -431,6 +431,8 @@ mod tests {
     #[test]
     fn test_dsss_spreading_factor_and_processing_gain() {
         let ch = dsss_channel();
+        assert_approx_eq!(ch.chip_rate().unwrap().to_hertz(), 4e6, rtol <= 1e-12);
+        assert_approx_eq!(ch.symbol_rate().to_hertz(), 1e4, rtol <= 1e-12);
         assert_approx_eq!(ch.spreading_factor().unwrap(), 400.0, rtol <= 1e-10);
         // PG = 10*log10(400) = 26.02 dB
         assert_approx_eq!(

--- a/crates/lox-comms/src/error.rs
+++ b/crates/lox-comms/src/error.rs
@@ -75,6 +75,19 @@ pub enum LinkBudgetError {
         /// The link end's frequency range.
         band: FrequencyRange,
     },
+    /// The link budget's noise bandwidth does not match the channel's
+    /// occupied bandwidth.
+    #[error(
+        "link noise bandwidth {} Hz does not match the channel bandwidth {} Hz",
+        link.to_hertz(),
+        channel.to_hertz()
+    )]
+    BandwidthMismatch {
+        /// The noise bandwidth the link budget was computed with.
+        link: Frequency,
+        /// The channel's occupied bandwidth.
+        channel: Frequency,
+    },
 }
 
 #[cfg(test)]

--- a/crates/lox-comms/src/lib.rs
+++ b/crates/lox-comms/src/lib.rs
@@ -13,6 +13,7 @@ pub mod antenna;
 pub mod channel;
 pub mod error;
 pub mod link_budget;
+pub mod modcod;
 pub mod pattern;
 pub mod pfd;
 pub mod pointing;

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -14,6 +14,7 @@ use lox_core::units::{Decibel, Distance, Frequency, Power, Temperature};
 
 use crate::channel::{Channel, LinkDirection};
 use crate::error::NonPhysicalError;
+use crate::modcod::ModCod;
 use crate::pointing::Pointing;
 use crate::utils::free_space_path_loss;
 use crate::{BOLTZMANN_CONSTANT, LinkBudgetError};
@@ -466,25 +467,64 @@ impl LinkStats {
     }
 }
 
-/// Link-budget output with modulation/coding figures applied.
+/// Link-budget output with a modulation and coding scheme applied.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModulatedLinkStats {
     /// The modulation-agnostic link budget.
     pub link: LinkStats,
-    /// The channel (modulation, FEC, required Eb/N₀, margin) applied.
+    /// The waveform the link is evaluated on.
     pub channel: Channel,
-    /// Symbol rate from the channel.
-    pub symbol_rate: Frequency,
+    /// The modulation and coding scheme the link is evaluated against.
+    pub modcod: ModCod,
+    /// Design margin applied on top of the MODCOD threshold.
+    pub design_margin: Decibel,
     /// Es/N0 (energy per symbol to noise spectral density).
     pub es_n0: Decibel,
     /// Eb/N0 (energy per information bit to noise spectral density).
     pub eb_n0: Decibel,
-    /// Link margin.
+    /// Link margin: Eb/N0 − required Eb/N0 − design margin.
     pub margin: Decibel,
 }
 
 impl ModulatedLinkStats {
+    /// Evaluates a link budget against a waveform and a MODCOD.
+    ///
+    /// Computes Es/N0 from the channel's symbol rate, Eb/N0 through the
+    /// MODCOD's exact information bits per symbol, and the link margin
+    /// against the MODCOD's threshold plus the design margin.
+    pub fn evaluate(
+        link: LinkStats,
+        channel: &Channel,
+        modcod: &ModCod,
+        design_margin: Decibel,
+    ) -> Self {
+        let es_n0 = channel.es_n0(link.c_n0);
+        let eb_n0 = es_n0 - Decibel::from_linear(modcod.mode().info_bits_per_symbol());
+        let margin = eb_n0 - modcod.required_eb_n0() - design_margin;
+        Self {
+            link,
+            channel: channel.clone(),
+            modcod: modcod.clone(),
+            design_margin,
+            es_n0,
+            eb_n0,
+            margin,
+        }
+    }
+
+    /// Returns the symbol rate of the underlying channel.
+    pub fn symbol_rate(&self) -> Frequency {
+        self.channel.symbol_rate()
+    }
+
+    /// Returns the information bit rate: symbol rate × info bits per symbol.
+    pub fn information_rate(&self) -> Frequency {
+        self.modcod
+            .mode()
+            .information_rate(self.channel.symbol_rate())
+    }
+
     /// Returns interference statistics for the given interferer power.
     ///
     /// Returns an error when absolute carrier or noise power is unavailable
@@ -555,6 +595,7 @@ mod tests {
 
     use crate::antenna::ConstantAntenna;
     use crate::channel::{LinkDirection, Modulation};
+    use crate::modcod::ErrorMetric;
     use crate::receiver::NoiseTempReceiver;
     use crate::terminal::{EirpModel, GtModel, RxChain, TxChain};
     use crate::transmitter::AmplifierTransmitter;
@@ -589,16 +630,20 @@ mod tests {
     }
 
     fn channel() -> Channel {
-        Channel {
-            link_type: LinkDirection::Downlink,
-            symbol_rate: 5.0.mhz(),
-            required_eb_n0: 10.0.db(),
-            margin: 3.0.db(),
-            modulation: Modulation::Qpsk,
-            roll_off: 0.35,
-            fec: 0.5,
-            chip_rate: None,
-        }
+        Channel::builder(5.0.mhz()).build().unwrap()
+    }
+
+    /// QPSK rate 1/2 requiring Eb/N0 = 10 dB at BER 1e-6.
+    fn modcod() -> ModCod {
+        ModCod::from_required_eb_n0(
+            "test downlink",
+            Modulation::Qpsk,
+            0.5,
+            10.0.db(),
+            ErrorMetric::Ber,
+            1e-6,
+        )
+        .unwrap()
     }
 
     fn link_params(bandwidth: Frequency) -> LinkParameters {
@@ -978,18 +1023,21 @@ mod tests {
     }
 
     #[test]
-    fn test_channel_apply_produces_modulated_stats() {
+    fn test_evaluate_produces_modulated_stats() {
         let stats = component_stats();
-        let m = channel().apply(stats);
-        // Eb/N0 ≈ 37.91 (QPSK, fec=0.5, C/N0 ≈ 104.91 dB·Hz)
+        let m = ModulatedLinkStats::evaluate(stats, &channel(), &modcod(), 3.0.db());
+        // Eb/N0 ≈ 37.91 (QPSK 1/2 → 1 info bit/symbol, C/N0 ≈ 104.91 dB·Hz)
         assert_approx_eq!(m.eb_n0.as_f64(), 37.91, atol <= 0.02);
-        // required_eb_n0 = 10, margin field = 3 → link_margin ≈ 24.91
+        // required_eb_n0 = 10, design margin = 3 → margin ≈ 24.91
         assert_approx_eq!(m.margin.as_f64(), 24.91, atol <= 0.02);
+        // Information rate: 5 Msps × 1 info bit/symbol.
+        assert_approx_eq!(m.information_rate().to_hertz(), 5e6, rtol <= 1e-12);
+        assert_approx_eq!(m.symbol_rate().to_hertz(), 5e6, rtol <= 1e-12);
     }
 
     #[test]
     fn test_modulated_with_interference_reduces_margin() {
-        let m = channel().apply(component_stats());
+        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db());
         let interference = m.with_interference(Power::watts(1e-12)).unwrap();
         assert!(interference.margin_with_interference.as_f64() <= m.margin.as_f64());
         assert!(interference.eb_n0i0.as_f64() <= m.eb_n0.as_f64());
@@ -997,7 +1045,7 @@ mod tests {
 
     #[test]
     fn test_with_interference_rejects_non_physical_power() {
-        let m = channel().apply(component_stats());
+        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db());
         for power in [-1e-12, f64::NAN, f64::INFINITY] {
             let err = m.with_interference(Power::watts(power)).unwrap_err();
             assert!(matches!(err, LinkBudgetError::NonPhysical { .. }));
@@ -1013,8 +1061,7 @@ mod tests {
 
     #[test]
     fn test_lumped_modulated_with_interference_is_error() {
-        let err = channel()
-            .apply(lumped_stats())
+        let err = ModulatedLinkStats::evaluate(lumped_stats(), &channel(), &modcod(), 3.0.db())
             .with_interference(Power::watts(1e-12))
             .unwrap_err();
         assert_eq!(err, LinkBudgetError::AbsolutePowerUnavailable);

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -493,16 +493,31 @@ impl ModulatedLinkStats {
     /// Computes Es/N0 from the channel's symbol rate, Eb/N0 through the
     /// MODCOD's exact information bits per symbol, and the link margin
     /// against the MODCOD's threshold plus the design margin.
+    ///
+    /// The link's noise bandwidth must match the channel's occupied
+    /// bandwidth (within 1 ppm) — the link's noise power and C/N were
+    /// computed with it, and a mismatch would silently skew interference
+    /// margins. Compute the budget with
+    /// [`Channel::bandwidth`](crate::channel::Channel::bandwidth).
     pub fn evaluate(
         link: LinkStats,
         channel: &Channel,
         modcod: &ModCod,
         design_margin: Decibel,
-    ) -> Self {
+    ) -> Result<Self, LinkBudgetError> {
+        let link_bw = link.bandwidth.to_hertz();
+        let channel_bw = channel.bandwidth().to_hertz();
+        if (link_bw - channel_bw).abs() > 1e-6 * channel_bw {
+            return Err(LinkBudgetError::BandwidthMismatch {
+                link: link.bandwidth,
+                channel: channel.bandwidth(),
+            });
+        }
+
         let es_n0 = channel.es_n0(link.c_n0);
         let eb_n0 = es_n0 - Decibel::from_linear(modcod.mode().info_bits_per_symbol());
         let margin = eb_n0 - modcod.required_eb_n0() - design_margin;
-        Self {
+        Ok(Self {
             link,
             channel: channel.clone(),
             modcod: modcod.clone(),
@@ -510,7 +525,7 @@ impl ModulatedLinkStats {
             es_n0,
             eb_n0,
             margin,
-        }
+        })
     }
 
     /// Returns the symbol rate of the underlying channel.
@@ -668,6 +683,25 @@ mod tests {
             &link_params(5.0.mhz()),
         )
         .unwrap()
+    }
+
+    fn lumped_stats_with_channel_bandwidth() -> LinkStats {
+        LinkStats::for_link(
+            &EirpModel::new(ka_band(), 55.0.db()).unwrap(),
+            &GtModel::new(ka_band(), 3.01.db()).unwrap(),
+            &link_params(channel().bandwidth()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_evaluate_rejects_bandwidth_mismatch() {
+        // The lumped fixture was computed with a 5 MHz noise bandwidth, not
+        // the channel's 6.75 MHz occupied bandwidth.
+        let err = ModulatedLinkStats::evaluate(lumped_stats(), &channel(), &modcod(), 0.0.db())
+            .unwrap_err();
+        assert!(matches!(err, LinkBudgetError::BandwidthMismatch { .. }));
+        assert!(err.to_string().contains("does not match"));
     }
 
     /// Custom link ends only need the trait surface: a fixed-EIRP transmitter
@@ -1025,7 +1059,7 @@ mod tests {
     #[test]
     fn test_evaluate_produces_modulated_stats() {
         let stats = component_stats();
-        let m = ModulatedLinkStats::evaluate(stats, &channel(), &modcod(), 3.0.db());
+        let m = ModulatedLinkStats::evaluate(stats, &channel(), &modcod(), 3.0.db()).unwrap();
         // Eb/N0 ≈ 37.91 (QPSK 1/2 → 1 info bit/symbol, C/N0 ≈ 104.91 dB·Hz)
         assert_approx_eq!(m.eb_n0.as_f64(), 37.91, atol <= 0.02);
         // required_eb_n0 = 10, design margin = 3 → margin ≈ 24.91
@@ -1037,7 +1071,8 @@ mod tests {
 
     #[test]
     fn test_modulated_with_interference_reduces_margin() {
-        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db());
+        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db())
+            .unwrap();
         let interference = m.with_interference(Power::watts(1e-12)).unwrap();
         assert!(interference.margin_with_interference.as_f64() <= m.margin.as_f64());
         assert!(interference.eb_n0i0.as_f64() <= m.eb_n0.as_f64());
@@ -1045,7 +1080,8 @@ mod tests {
 
     #[test]
     fn test_with_interference_rejects_non_physical_power() {
-        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db());
+        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db())
+            .unwrap();
         for power in [-1e-12, f64::NAN, f64::INFINITY] {
             let err = m.with_interference(Power::watts(power)).unwrap_err();
             assert!(matches!(err, LinkBudgetError::NonPhysical { .. }));
@@ -1061,9 +1097,15 @@ mod tests {
 
     #[test]
     fn test_lumped_modulated_with_interference_is_error() {
-        let err = ModulatedLinkStats::evaluate(lumped_stats(), &channel(), &modcod(), 3.0.db())
-            .with_interference(Power::watts(1e-12))
-            .unwrap_err();
+        let err = ModulatedLinkStats::evaluate(
+            lumped_stats_with_channel_bandwidth(),
+            &channel(),
+            &modcod(),
+            3.0.db(),
+        )
+        .unwrap()
+        .with_interference(Power::watts(1e-12))
+        .unwrap_err();
         assert_eq!(err, LinkBudgetError::AbsolutePowerUnavailable);
     }
 

--- a/crates/lox-comms/src/modcod.rs
+++ b/crates/lox-comms/src/modcod.rs
@@ -577,6 +577,53 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_accessors_round_trip() {
+        let code = Code::new("LDPC", 0.5).unwrap();
+        assert_eq!(code.name(), "LDPC");
+        assert_approx_eq!(code.rate(), 0.5, atol <= 1e-15);
+
+        let mode = LinkMode::new("test", Modulation::Qpsk, vec![code.clone()], "a ref");
+        assert_eq!(mode.name(), "test");
+        assert_eq!(mode.modulation(), Modulation::Qpsk);
+        assert_eq!(mode.codes(), &[code]);
+        assert_eq!(mode.reference(), "a ref");
+
+        let perf = ModePerformance::new(ErrorMetric::Wer, 1e-5, 4.0.db(), "b ref").unwrap();
+        assert_eq!(perf.metric(), ErrorMetric::Wer);
+        assert_approx_eq!(perf.error_rate(), 1e-5, atol <= 1e-20);
+        assert_approx_eq!(perf.eb_n0().as_f64(), 4.0, atol <= 1e-15);
+        assert_eq!(perf.reference(), "b ref");
+
+        let mc = ModCod::new(mode.clone(), perf.clone());
+        assert_eq!(mc.mode(), &mode);
+        assert_eq!(mc.performance(), &perf);
+    }
+
+    #[test]
+    fn test_error_metric_display() {
+        assert_eq!(ErrorMetric::Ber.to_string(), "BER");
+        assert_eq!(ErrorMetric::Wer.to_string(), "WER");
+        assert_eq!(ErrorMetric::Fer.to_string(), "FER");
+        assert_eq!(ErrorMetric::Per.to_string(), "PER");
+    }
+
+    #[test]
+    fn test_from_required_eb_n0_uncoded() {
+        // A unity code rate yields an empty coding chain.
+        let mc = ModCod::from_required_eb_n0(
+            "uncoded",
+            Modulation::Bpsk,
+            1.0,
+            9.6.db(),
+            ErrorMetric::Ber,
+            1e-5,
+        )
+        .unwrap();
+        assert!(mc.mode().codes().is_empty());
+        assert_approx_eq!(mc.mode().info_bits_per_symbol(), 1.0, atol <= 1e-15);
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn test_modcod_serde_round_trip_and_validation() {

--- a/crates/lox-comms/src/modcod.rs
+++ b/crates/lox-comms/src/modcod.rs
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! Modulation and coding: what is transmitted on a [`Channel`].
+//!
+//! A [`LinkMode`] pairs a modulation with an ordered chain of [`Code`]s —
+//! every PHY component that adds overhead (FEC codes, framing structures)
+//! contributes one rate factor, so concatenated codes and framing are
+//! handled uniformly and the information rate is exact. A
+//! [`ModePerformance`] records the published operating point (metric, error
+//! rate, Eb/N0 threshold, provenance); together they form a [`ModCod`].
+//! Tables like [`dvb_s2`] hold the standard mode sets;
+//! [`ModCod::select`] picks the best closing mode for adaptive coding and
+//! modulation.
+//!
+//! [`Channel`]: crate::channel::Channel
+
+use core::fmt;
+use std::sync::LazyLock;
+
+use lox_core::units::{Decibel, Frequency};
+
+use crate::channel::Modulation;
+use crate::error::NonPhysicalError;
+
+/// One PHY-layer component that adds overhead: an FEC code, a framing
+/// structure, or any other element with a fixed information-to-channel-bit
+/// ratio.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "CodeRepr")
+)]
+pub struct Code {
+    name: String,
+    rate: f64,
+}
+
+/// Serde wire format for [`Code`]: forces deserialization through the
+/// validated constructor.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+struct CodeRepr {
+    name: String,
+    rate: f64,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<CodeRepr> for Code {
+    type Error = NonPhysicalError;
+
+    fn try_from(repr: CodeRepr) -> Result<Self, Self::Error> {
+        Code::new(repr.name, repr.rate)
+    }
+}
+
+impl Code {
+    /// Creates a code with the given rate.
+    ///
+    /// The rate is the ratio of information bits to total bits and must lie
+    /// in (0, 1].
+    pub fn new(name: impl Into<String>, rate: f64) -> Result<Self, NonPhysicalError> {
+        NonPhysicalError::check_unit_interval("code rate", rate)?;
+        Ok(Self {
+            name: name.into(),
+            rate,
+        })
+    }
+
+    /// Returns the name of the code.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the code rate (information bits / total bits).
+    pub fn rate(&self) -> f64 {
+        self.rate
+    }
+}
+
+/// A modulation paired with its coding chain: the structure of what is
+/// transmitted.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LinkMode {
+    name: String,
+    modulation: Modulation,
+    codes: Vec<Code>,
+    reference: String,
+}
+
+impl LinkMode {
+    /// Creates a link mode from a modulation and a coding chain.
+    ///
+    /// `codes` lists every overhead-adding PHY component in encoding order
+    /// from outermost to innermost; an empty list means uncoded.
+    /// `reference` records the source of the definition (may be empty).
+    pub fn new(
+        name: impl Into<String>,
+        modulation: Modulation,
+        codes: Vec<Code>,
+        reference: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            modulation,
+            codes,
+            reference: reference.into(),
+        }
+    }
+
+    /// Returns the name of this mode.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the modulation scheme.
+    pub fn modulation(&self) -> Modulation {
+        self.modulation
+    }
+
+    /// Returns the coding chain in encoding order.
+    pub fn codes(&self) -> &[Code] {
+        &self.codes
+    }
+
+    /// Returns the source of this mode definition.
+    pub fn reference(&self) -> &str {
+        &self.reference
+    }
+
+    /// Returns the overall code rate: the product of the chain's rates.
+    pub fn code_rate(&self) -> f64 {
+        self.codes.iter().map(Code::rate).product()
+    }
+
+    /// Returns the information bits per symbol — the true spectral
+    /// efficiency including all framing and coding overhead.
+    pub fn info_bits_per_symbol(&self) -> f64 {
+        self.modulation.bits_per_symbol() as f64 * self.code_rate()
+    }
+
+    /// Returns the information bit rate at the given symbol rate.
+    pub fn information_rate(&self, symbol_rate: Frequency) -> Frequency {
+        self.info_bits_per_symbol() * symbol_rate
+    }
+
+    /// Returns the symbol rate required for the given information bit rate.
+    pub fn symbol_rate_for(&self, information_rate: Frequency) -> Frequency {
+        Frequency::hertz(information_rate.to_hertz() / self.info_bits_per_symbol())
+    }
+}
+
+/// The error metric a performance figure refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum ErrorMetric {
+    /// Bit error rate.
+    Ber,
+    /// Codeword error rate.
+    Wer,
+    /// Frame error rate.
+    Fer,
+    /// Packet error rate.
+    Per,
+}
+
+impl fmt::Display for ErrorMetric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorMetric::Ber => write!(f, "BER"),
+            ErrorMetric::Wer => write!(f, "WER"),
+            ErrorMetric::Fer => write!(f, "FER"),
+            ErrorMetric::Per => write!(f, "PER"),
+        }
+    }
+}
+
+/// A published operating point for a link mode: the Eb/N0 at which the mode
+/// achieves a given error rate.
+///
+/// This is the threshold form of performance data (e.g. the quasi-error-free
+/// points standards like DVB-S2 publish). Interpolated error-rate curves are
+/// a future extension.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "ModePerformanceRepr")
+)]
+pub struct ModePerformance {
+    metric: ErrorMetric,
+    error_rate: f64,
+    eb_n0: Decibel,
+    reference: String,
+}
+
+/// Serde wire format for [`ModePerformance`]: forces deserialization through
+/// the validated constructor.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+struct ModePerformanceRepr {
+    metric: ErrorMetric,
+    error_rate: f64,
+    eb_n0: Decibel,
+    #[serde(default)]
+    reference: String,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<ModePerformanceRepr> for ModePerformance {
+    type Error = NonPhysicalError;
+
+    fn try_from(repr: ModePerformanceRepr) -> Result<Self, Self::Error> {
+        ModePerformance::new(repr.metric, repr.error_rate, repr.eb_n0, repr.reference)
+    }
+}
+
+impl ModePerformance {
+    /// Creates a performance threshold.
+    ///
+    /// Rejects an error rate outside (0, 1] and a non-finite Eb/N0.
+    pub fn new(
+        metric: ErrorMetric,
+        error_rate: f64,
+        eb_n0: Decibel,
+        reference: impl Into<String>,
+    ) -> Result<Self, NonPhysicalError> {
+        NonPhysicalError::check_unit_interval("error rate", error_rate)?;
+        NonPhysicalError::check_finite("Eb/N0 threshold [dB]", eb_n0.as_f64())?;
+        Ok(Self {
+            metric,
+            error_rate,
+            eb_n0,
+            reference: reference.into(),
+        })
+    }
+
+    /// Returns the error metric.
+    pub fn metric(&self) -> ErrorMetric {
+        self.metric
+    }
+
+    /// Returns the error rate at the threshold.
+    pub fn error_rate(&self) -> f64 {
+        self.error_rate
+    }
+
+    /// Returns the Eb/N0 threshold.
+    pub fn eb_n0(&self) -> Decibel {
+        self.eb_n0
+    }
+
+    /// Returns the source of the performance data.
+    pub fn reference(&self) -> &str {
+        &self.reference
+    }
+}
+
+/// A link mode together with its performance: one row of a MODCOD table.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ModCod {
+    mode: LinkMode,
+    performance: ModePerformance,
+}
+
+impl ModCod {
+    /// Creates a MODCOD from a mode and its performance.
+    pub fn new(mode: LinkMode, performance: ModePerformance) -> Self {
+        Self { mode, performance }
+    }
+
+    /// Creates a MODCOD from the classic hand-rolled specification: a
+    /// modulation, an aggregate code rate, and the Eb/N0 required for a
+    /// target error rate.
+    pub fn from_required_eb_n0(
+        name: impl Into<String>,
+        modulation: Modulation,
+        code_rate: f64,
+        required_eb_n0: Decibel,
+        metric: ErrorMetric,
+        error_rate: f64,
+    ) -> Result<Self, NonPhysicalError> {
+        let name = name.into();
+        let codes = if code_rate == 1.0 {
+            Vec::new()
+        } else {
+            vec![Code::new("FEC", code_rate)?]
+        };
+        let mode = LinkMode::new(name, modulation, codes, "");
+        let performance = ModePerformance::new(metric, error_rate, required_eb_n0, "")?;
+        Ok(Self { mode, performance })
+    }
+
+    /// Returns the link mode.
+    pub fn mode(&self) -> &LinkMode {
+        &self.mode
+    }
+
+    /// Returns the performance threshold.
+    pub fn performance(&self) -> &ModePerformance {
+        &self.performance
+    }
+
+    /// Returns the Eb/N0 this MODCOD requires.
+    pub fn required_eb_n0(&self) -> Decibel {
+        self.performance.eb_n0
+    }
+
+    /// Returns the Es/N0 this MODCOD requires:
+    /// Es/N0 = Eb/N0 + 10·log₁₀(info bits per symbol).
+    pub fn required_es_n0(&self) -> Decibel {
+        self.performance.eb_n0 + Decibel::from_linear(self.mode.info_bits_per_symbol())
+    }
+
+    /// Selects the highest-efficiency MODCOD that closes at the given Es/N0
+    /// with the given margin, or `None` when none does.
+    ///
+    /// Selection compares Es/N0 because it is fixed by the link and the
+    /// symbol rate, while Eb/N0 differs between candidate modes.
+    pub fn select(es_n0: Decibel, margin: Decibel, table: &[ModCod]) -> Option<&ModCod> {
+        table
+            .iter()
+            .filter(|mc| mc.required_es_n0().as_f64() + margin.as_f64() <= es_n0.as_f64())
+            .max_by(|a, b| {
+                a.mode
+                    .info_bits_per_symbol()
+                    .total_cmp(&b.mode.info_bits_per_symbol())
+            })
+    }
+}
+
+/// DVB-S2 reference for the table entries.
+const DVB_S2_REF: &str = "ETSI EN 302 307-1 V1.4.1";
+
+/// Builds one DVB-S2 MODCOD (normal FECFRAME, no pilots).
+///
+/// The coding chain carries the exact overheads: the 80-bit BBHEADER, the
+/// BCH and LDPC codes, and the 90-symbol PLHEADER per `slots`-slot PLFRAME.
+/// Its product reproduces the spectral efficiencies of Table 13 exactly;
+/// the Eb/N0 threshold derives from the table's ideal Es/N0 at
+/// quasi-error-free operation (PER ≤ 1e-7).
+fn dvb_s2_modcod(
+    modulation: Modulation,
+    rate_name: &str,
+    k_bch: u32,
+    n_bch: u32,
+    slots: u32,
+    es_n0_db: f64,
+) -> ModCod {
+    let codes = vec![
+        Code::new(
+            "BBFRAME overhead (80 bits)",
+            (k_bch - 80) as f64 / k_bch as f64,
+        )
+        .unwrap(),
+        Code::new(
+            format!("BCH ({n_bch}, {k_bch})"),
+            k_bch as f64 / n_bch as f64,
+        )
+        .unwrap(),
+        Code::new(format!("LDPC (64800, {n_bch})"), n_bch as f64 / 64800.0).unwrap(),
+        Code::new(
+            "PLFRAME overhead (no pilots)",
+            slots as f64 / (slots + 1) as f64,
+        )
+        .unwrap(),
+    ];
+    let mode = LinkMode::new(
+        format!("{modulation} {rate_name}"),
+        modulation,
+        codes,
+        DVB_S2_REF,
+    );
+    let eb_n0 = Decibel::new(es_n0_db) - Decibel::from_linear(mode.info_bits_per_symbol());
+    let performance = ModePerformance::new(ErrorMetric::Per, 1e-7, eb_n0, DVB_S2_REF).unwrap();
+    ModCod::new(mode, performance)
+}
+
+static DVB_S2: LazyLock<Vec<ModCod>> = LazyLock::new(|| {
+    use Modulation::{Apsk16, Apsk32, Psk8, Qpsk};
+    vec![
+        // (modulation, rate, k_bch, n_bch = k_ldpc, PLFRAME slots, Es/N0 [dB])
+        dvb_s2_modcod(Qpsk, "1/4", 16008, 16200, 360, -2.35),
+        dvb_s2_modcod(Qpsk, "1/3", 21408, 21600, 360, -1.24),
+        dvb_s2_modcod(Qpsk, "2/5", 25728, 25920, 360, -0.30),
+        dvb_s2_modcod(Qpsk, "1/2", 32208, 32400, 360, 1.00),
+        dvb_s2_modcod(Qpsk, "3/5", 38688, 38880, 360, 2.23),
+        dvb_s2_modcod(Qpsk, "2/3", 43040, 43200, 360, 3.10),
+        dvb_s2_modcod(Qpsk, "3/4", 48408, 48600, 360, 4.03),
+        dvb_s2_modcod(Qpsk, "4/5", 51648, 51840, 360, 4.68),
+        dvb_s2_modcod(Qpsk, "5/6", 53840, 54000, 360, 5.18),
+        dvb_s2_modcod(Qpsk, "8/9", 57472, 57600, 360, 6.20),
+        dvb_s2_modcod(Qpsk, "9/10", 58192, 58320, 360, 6.42),
+        dvb_s2_modcod(Psk8, "3/5", 38688, 38880, 240, 5.50),
+        dvb_s2_modcod(Psk8, "2/3", 43040, 43200, 240, 6.62),
+        dvb_s2_modcod(Psk8, "3/4", 48408, 48600, 240, 7.91),
+        dvb_s2_modcod(Psk8, "5/6", 53840, 54000, 240, 9.35),
+        dvb_s2_modcod(Psk8, "8/9", 57472, 57600, 240, 10.69),
+        dvb_s2_modcod(Psk8, "9/10", 58192, 58320, 240, 10.98),
+        dvb_s2_modcod(Apsk16, "2/3", 43040, 43200, 180, 8.97),
+        dvb_s2_modcod(Apsk16, "3/4", 48408, 48600, 180, 10.21),
+        dvb_s2_modcod(Apsk16, "4/5", 51648, 51840, 180, 11.03),
+        dvb_s2_modcod(Apsk16, "5/6", 53840, 54000, 180, 11.61),
+        dvb_s2_modcod(Apsk16, "8/9", 57472, 57600, 180, 12.89),
+        dvb_s2_modcod(Apsk16, "9/10", 58192, 58320, 180, 13.13),
+        dvb_s2_modcod(Apsk32, "3/4", 48408, 48600, 144, 12.73),
+        dvb_s2_modcod(Apsk32, "4/5", 51648, 51840, 144, 13.64),
+        dvb_s2_modcod(Apsk32, "5/6", 53840, 54000, 144, 14.28),
+        dvb_s2_modcod(Apsk32, "8/9", 57472, 57600, 144, 15.69),
+        dvb_s2_modcod(Apsk32, "9/10", 58192, 58320, 144, 16.05),
+    ]
+});
+
+/// Returns the DVB-S2 MODCOD table (normal FECFRAME, no pilots).
+///
+/// 28 modes from QPSK 1/4 through 32APSK 9/10 with ideal Es/N0 thresholds
+/// at quasi-error-free operation (PER ≤ 1e-7), per ETSI EN 302 307-1
+/// Table 13. DVB-S2X and CCSDS tables are not included yet.
+pub fn dvb_s2() -> &'static [ModCod] {
+    &DVB_S2
+}
+
+#[cfg(test)]
+mod tests {
+    use lox_core::units::{DecibelUnits, FrequencyUnits};
+    use lox_test_utils::assert_approx_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_code_rejects_invalid_rates() {
+        for rate in [0.0, -0.5, 1.5, f64::NAN] {
+            assert!(Code::new("FEC", rate).is_err());
+        }
+        assert!(Code::new("uncoded", 1.0).is_ok());
+    }
+
+    #[test]
+    fn test_link_mode_chain_rate_is_product() {
+        // CCSDS-style concatenated coding: RS(255,223) + convolutional 1/2.
+        let mode = LinkMode::new(
+            "CCSDS RS+conv",
+            Modulation::Bpsk,
+            vec![
+                Code::new("Reed-Solomon (255, 223)", 223.0 / 255.0).unwrap(),
+                Code::new("Convolutional (7, 1/2)", 0.5).unwrap(),
+            ],
+            "CCSDS 131.0-B-5",
+        );
+        assert_approx_eq!(mode.code_rate(), 223.0 / 510.0, rtol <= 1e-12);
+        assert_approx_eq!(mode.info_bits_per_symbol(), 223.0 / 510.0, rtol <= 1e-12);
+        // 1 Msps → 437.25 kbit/s information rate, and back.
+        let info = mode.information_rate(1.0.mhz());
+        assert_approx_eq!(info.to_hertz(), 1e6 * 223.0 / 510.0, rtol <= 1e-12);
+        assert_approx_eq!(mode.symbol_rate_for(info).to_hertz(), 1e6, rtol <= 1e-12);
+    }
+
+    #[test]
+    fn test_uncoded_mode_has_unity_rate() {
+        let mode = LinkMode::new("uncoded QPSK", Modulation::Qpsk, Vec::new(), "");
+        assert_approx_eq!(mode.code_rate(), 1.0, atol <= 1e-15);
+        assert_approx_eq!(mode.info_bits_per_symbol(), 2.0, atol <= 1e-15);
+    }
+
+    /// The coding chains must reproduce the spectral efficiencies of
+    /// ETSI EN 302 307-1 Table 13 exactly.
+    #[test]
+    fn test_dvb_s2_efficiencies_match_table_13() {
+        let table = dvb_s2();
+        assert_eq!(table.len(), 28);
+        for (name, expected) in [
+            ("QPSK 1/4", 0.490243),
+            ("QPSK 1/2", 0.988858),
+            ("QPSK 2/3", 1.322253),
+            ("QPSK 9/10", 1.788612),
+            ("8PSK 3/5", 1.779991),
+            ("8PSK 3/4", 2.228124),
+            ("8PSK 9/10", 2.679207),
+            ("16APSK 2/3", 2.637201),
+            ("16APSK 9/10", 3.567342),
+            ("32APSK 3/4", 3.703295),
+            ("32APSK 9/10", 4.453027),
+        ] {
+            let mc = table
+                .iter()
+                .find(|mc| mc.mode().name() == name)
+                .unwrap_or_else(|| panic!("missing {name}"));
+            assert_approx_eq!(mc.mode().info_bits_per_symbol(), expected, atol <= 5e-7);
+        }
+    }
+
+    /// Eb/N0 thresholds must round-trip to the published Es/N0 values.
+    #[test]
+    fn test_dvb_s2_thresholds_round_trip_to_es_n0() {
+        for (name, es_n0) in [
+            ("QPSK 1/4", -2.35),
+            ("QPSK 1/2", 1.00),
+            ("8PSK 3/4", 7.91),
+            ("16APSK 2/3", 8.97),
+            ("32APSK 9/10", 16.05),
+        ] {
+            let mc = dvb_s2().iter().find(|mc| mc.mode().name() == name).unwrap();
+            assert_approx_eq!(mc.required_es_n0().as_f64(), es_n0, atol <= 1e-10);
+        }
+        // Cross-check against spacelink's independently derived Eb/N0 for
+        // 16APSK 2/3 (8.97 − 10·log10(2.637201) = 4.76 dB).
+        let mc = dvb_s2()
+            .iter()
+            .find(|mc| mc.mode().name() == "16APSK 2/3")
+            .unwrap();
+        assert_approx_eq!(mc.required_eb_n0().as_f64(), 4.76, atol <= 5e-3);
+    }
+
+    #[test]
+    fn test_dvb_s2_is_monotonic_in_es_n0_and_efficiency() {
+        // Within each modulation, higher code rate needs more Es/N0 and
+        // yields more bits per symbol.
+        let table = dvb_s2();
+        for pair in table.windows(2) {
+            if pair[0].mode().modulation() == pair[1].mode().modulation() {
+                assert!(pair[0].required_es_n0().as_f64() < pair[1].required_es_n0().as_f64());
+                assert!(
+                    pair[0].mode().info_bits_per_symbol() < pair[1].mode().info_bits_per_symbol()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_select_picks_highest_closing_efficiency() {
+        let table = dvb_s2();
+        // Plenty of Es/N0: the top mode closes.
+        let best = ModCod::select(20.0.db(), 0.0.db(), table).unwrap();
+        assert_eq!(best.mode().name(), "32APSK 9/10");
+        // 10 dB with 1 dB margin: best mode with Es/N0 ≤ 9 dB is 16APSK 2/3
+        // (8.97 dB, 2.637 bit/sym) — more efficient than 8PSK 3/4 (7.91 dB,
+        // 2.228 bit/sym) which also closes.
+        let mc = ModCod::select(10.0.db(), 1.0.db(), table).unwrap();
+        assert_eq!(mc.mode().name(), "16APSK 2/3");
+        // Below the weakest mode nothing closes.
+        assert!(ModCod::select(-3.0.db(), 0.0.db(), table).is_none());
+        // Exactly on a threshold closes (inclusive).
+        let mc = ModCod::select(1.0.db(), 0.0.db(), table).unwrap();
+        assert_eq!(mc.mode().name(), "QPSK 1/2");
+    }
+
+    #[test]
+    fn test_from_required_eb_n0() {
+        let mc = ModCod::from_required_eb_n0(
+            "my downlink",
+            Modulation::Qpsk,
+            0.5,
+            10.0.db(),
+            ErrorMetric::Ber,
+            1e-6,
+        )
+        .unwrap();
+        assert_approx_eq!(mc.mode().info_bits_per_symbol(), 1.0, atol <= 1e-15);
+        assert_approx_eq!(mc.required_eb_n0().as_f64(), 10.0, atol <= 1e-15);
+        // Es/N0 = Eb/N0 + 10·log10(1.0) = Eb/N0.
+        assert_approx_eq!(mc.required_es_n0().as_f64(), 10.0, atol <= 1e-12);
+        assert!(
+            ModCod::from_required_eb_n0(
+                "bad",
+                Modulation::Qpsk,
+                1.5,
+                10.0.db(),
+                ErrorMetric::Ber,
+                1e-6
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_modcod_serde_round_trip_and_validation() {
+        let mc = dvb_s2()[3].clone();
+        let json = serde_json::to_string(&mc).unwrap();
+        let round_trip: ModCod = serde_json::from_str(&json).unwrap();
+        assert_eq!(mc, round_trip);
+
+        // Invalid code rates and error rates are rejected.
+        assert!(serde_json::from_str::<Code>(r#"{"name":"FEC","rate":1.5}"#).is_err());
+        assert!(
+            serde_json::from_str::<ModePerformance>(
+                r#"{"metric":"Ber","error_rate":2.0,"eb_n0":10.0}"#
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/lox-space/docs/comms.md
+++ b/crates/lox-space/docs/comms.md
@@ -12,12 +12,12 @@ RF link budget analysis for space communication systems.
 
 | Name | Bits per Symbol |
 |------|-----------------|
-| `BPSK` | 1 |
-| `QPSK` | 2 |
-| `8PSK` | 3 |
-| `16QAM` | 4 |
-| `32QAM` | 5 |
-| `64QAM` | 6 |
+| `BPSK`, `GMSK`, `2FSK` | 1 |
+| `QPSK`, `OQPSK`, `4FSK` | 2 |
+| `8PSK`, `8APSK` | 3 |
+| `16QAM`, `16APSK` | 4 |
+| `32QAM`, `32APSK` | 5 |
+| `64QAM`, `64APSK` | 6 |
 | `128QAM` | 7 |
 | `256QAM` | 8 |
 
@@ -165,21 +165,31 @@ the absolute carrier and noise power are not recoverable from EIRP and G/T
 alone. The carrier-to-noise density ratio (`c_n0`) and carrier-to-noise ratio
 (`c_n`) remain available.
 
-To compute modulation-aware figures (`Es/N0`, `Eb/N0`, link margin), apply a
-`Channel`:
+To compute modulation-aware figures (`Es/N0`, `Eb/N0`, link margin),
+evaluate the link on a `Channel` (the waveform: symbol rate, roll-off,
+optional DSSS chip rate) against a `ModCod` (the modulation and coding
+scheme with its Eb/N0 threshold). The design margin is an input to the
+evaluation:
 
 ```python
-channel = lox.Channel(
-    link_type="downlink",
-    symbol_rate=5 * lox.MHz,
-    required_eb_n0=10.0 * lox.dB,
-    margin=3.0 * lox.dB,
-    modulation=lox.Modulation("QPSK"),
-    roll_off=0.35,
-    fec=0.5,
-)
-modulated = channel.apply(link)
+channel = lox.Channel(symbol_rate=5 * lox.MHz)
+modcod = lox.ModCod("QPSK 1/2", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
+modulated = modcod.evaluate(link, channel, design_margin=3.0 * lox.dB)
 print(f"Margin = {float(modulated.margin):.2f} dB")
+```
+
+For standards-based links, use the built-in DVB-S2 table — 28 modes whose
+coding chains (BBFRAME, BCH, LDPC, PLFRAME) reproduce the spectral
+efficiencies and quasi-error-free thresholds of ETSI EN 302 307-1 Table 13
+exactly — and `ModCod.select` for adaptive coding and modulation:
+
+```python
+table = lox.ModCod.dvb_s2()
+modcod = next(mc for mc in table if mc.name == "QPSK 3/4")
+modulated = modcod.evaluate(link, channel, design_margin=3.0 * lox.dB)
+
+# The highest-efficiency mode that closes at this Es/N0:
+best = lox.ModCod.select(modulated.es_n0, 3.0 * lox.dB, table)
 ```
 
 Use the component tier (configure antennas, amplifiers, receiver noise) when
@@ -229,26 +239,21 @@ ground_station = lox.RxChain(
 
 # Atmospherics at X-band, 5° elevation (static values; lox-itur computes
 # them from the ITU-R P-series maps)
-losses = lox.EnvironmentalLosses.from_values(
+losses = lox.PropagationLosses(
     rain=1.2 * lox.dB,
     gaseous=0.4 * lox.dB,
     scintillation=0.3 * lox.dB,
     cloud=0.1 * lox.dB,
 )
 
-# DVB-S2-style channel: QPSK 3/4 at 150 Msps → 225 Mbit/s net
-channel = lox.Channel(
-    link_type="downlink",
-    symbol_rate=150 * lox.MHz,
-    required_eb_n0=4.5 * lox.dB,
-    margin=3.0 * lox.dB,
-    modulation=lox.Modulation("QPSK"),
-    roll_off=0.25,
-    fec=0.75,
-)
+# DVB-S2 QPSK 3/4 at 150 Msps; the table carries the exact Table 13
+# thresholds and coding chains.
+channel = lox.Channel(symbol_rate=150 * lox.MHz, roll_off=0.25)
+modcod = next(mc for mc in lox.ModCod.dvb_s2() if mc.name == "QPSK 3/4")
 
 # 2° residual pointing error on the spacecraft gimbal; the station
-# autotracks on boresight.
+# autotracks on boresight. On downlinks the budget uses the rain-degraded
+# G/T (ITU-R P.618 §8.2).
 link = lox.LinkStats.for_link(
     spacecraft,
     ground_station,
@@ -257,15 +262,17 @@ link = lox.LinkStats.for_link(
     range=slant_range,
     tx_angle=2.0 * lox.deg,
     losses=losses,
+    link_type="downlink",
 )
-modulated = channel.apply(link)
+modulated = modcod.evaluate(link, channel, design_margin=3.0 * lox.dB)
 
 print(f"EIRP:        {float(link.eirp):.2f} dBW")
 print(f"FSPL:        {float(link.fspl):.2f} dB")
-print(f"G/T:         {float(link.gt):.2f} dB/K")
+print(f"G/T:         {float(link.gt):.2f} dB/K (clear sky)")
+print(f"G/T:         {float(link.gt_degraded):.2f} dB/K (rain)")
 print(f"C/N0:        {float(link.c_n0):.2f} dB·Hz")
 print(f"Eb/N0:       {float(modulated.eb_n0):.2f} dB")
-print(f"Data rate:   {float(channel.information_rate()) / 1e6:.1f} Mbit/s")
+print(f"Data rate:   {float(modulated.information_rate()) / 1e6:.1f} Mbit/s")
 print(f"Link margin: {float(modulated.margin):.2f} dB")
 
 # Regulatory check: PFD on the ground vs. the RR Art. 21.16 mask
@@ -332,17 +339,23 @@ loss = lox.fspl(distance=1000 * lox.km, frequency=29 * lox.GHz)
 print(f"FSPL: {float(loss):.1f} dB")
 ```
 
-### Environmental Losses
+### Propagation Losses
+
+`PropagationLosses` holds itemized excess-path losses as labelled lines.
+`total()` is the carrier attenuation; `absorptive()` is the part that also
+heats the receive antenna (rain, gaseous, cloud — used for the rain-degraded
+G/T on downlinks):
 
 ```python
 import lox_space as lox
 
-losses = lox.EnvironmentalLosses.from_values(
+losses = lox.PropagationLosses(
     rain=2.0 * lox.dB,
     gaseous=0.3 * lox.dB,
-    atmospheric=0.5 * lox.dB,
+    other=[("Radome wetting", 0.5 * lox.dB, True)],
 )
 print(f"Total: {float(losses.total()):.1f} dB")
+print(f"Absorptive: {float(losses.absorptive()):.1f} dB")
 
 # Pass to LinkStats.for_link via the losses parameter
 link = lox.LinkStats.for_link(
@@ -435,7 +448,13 @@ link = lox.LinkStats.for_link(
 
 ---
 
-::: lox_space.EnvironmentalLosses
+::: lox_space.ModCod
+    options:
+      show_source: false
+
+---
+
+::: lox_space.PropagationLosses
     options:
       show_source: false
 

--- a/crates/lox-space/docs/index.md
+++ b/crates/lox-space/docs/index.md
@@ -60,7 +60,7 @@ future_state = propagator.propagate(t + lox.TimeDelta.from_hours(1.5))
 | [Ground Stations](ground.md) | `GroundLocation`, `ElevationMask`, `Observables`, `Pass` |
 | [Events & Visibility](events.md) | `Event`, `Interval`, `find_events`, `find_windows`, `intersect_intervals`, `union_intervals`, `complement_intervals`, `GroundStation`, `Spacecraft`, `Scenario`, `Ensemble`, `VisibilityAnalysis`, `VisibilityResults`, `PowerBudgetAnalysis`, `PowerBudgetResults` |
 | [Imaging](imaging.md) | `Aoi`, `OpticalPayload`, `OpticalAccessAnalysis`, `SarPayload`, `LookSide`, `SarAccessAnalysis`, `AccessResults` |
-| [Communications](comms.md) | `TxChain`, `RxChain`, `AmplifierTransmitter`, `NoiseTempReceiver`, `CascadeReceiver`, `Channel`, `LinkStats`, `EnvironmentalLosses`, `fspl`, `freq_overlap` |
+| [Communications](comms.md) | `TxChain`, `RxChain`, `AmplifierTransmitter`, `NoiseTempReceiver`, `CascadeReceiver`, `Channel`, `ModCod`, `LinkStats`, `PropagationLosses`, `fspl`, `freq_overlap` |
 | [Constellations](constellations.md) | `Constellation`, `ConstellationSatellite` |
 | [Data Providers](data.md) | `EOPProvider`, `Series` |
 | [Units](units.md) | `Angle`, `Distance`, `Frequency`, `Velocity` |

--- a/crates/lox-space/docs/itur.md
+++ b/crates/lox-space/docs/itur.md
@@ -32,8 +32,7 @@ Compute the total atmospheric attenuation for a ground station in Madrid
 receiving at 14.25 GHz from a satellite at 30° elevation:
 
 ```python
-losses = lox.EnvironmentalLosses(
-    provider,
+losses = provider.propagation_losses(
     lat=40.4 * lox.deg,
     lon=-3.7 * lox.deg,
     frequency=14.25 * lox.GHz,
@@ -42,29 +41,24 @@ losses = lox.EnvironmentalLosses(
     diameter=1.2 * lox.m,   # antenna diameter
 )
 
-print(f"Rain:          {losses.rain}")
-print(f"Gaseous:       {losses.gaseous}")
-print(f"Cloud:         {losses.cloud}")
-print(f"Scintillation: {losses.scintillation}")
-print(f"Total:         {losses.atmospheric}")
+for label, value, absorptive in losses.lines:
+    print(f"{label}: {value}")
+print(f"Total:      {losses.total()}")
+print(f"Absorptive: {losses.absorptive()}")
 ```
 
-The same computation is also available as a provider method:
+The rain, gaseous, and cloud lines carry the raw model outputs; the
+combination residual of the ITU-R P.618 total is booked on the
+scintillation line, so `total()` equals the combined attenuation and
+`absorptive()` is exactly the part that raises the antenna noise
+temperature (used for the rain-degraded G/T on downlinks).
+
+For link budgets with known loss values, build `PropagationLosses`
+directly:
 
 ```python
-losses = provider.atmospheric_attenuation_slant_path(
-    lat=40.4 * lox.deg, lon=-3.7 * lox.deg,
-    frequency=14.25 * lox.GHz, elevation=30.0 * lox.deg,
-    probability=0.01, diameter=1.2 * lox.m,
-)
-```
-
-For link budgets with known loss values, use `EnvironmentalLosses.from_values`
-or `EnvironmentalLosses.none`:
-
-```python
-losses = lox.EnvironmentalLosses.from_values(rain=2.0 * lox.dB, gaseous=0.5 * lox.dB)
-losses = lox.EnvironmentalLosses.none()
+losses = lox.PropagationLosses(rain=2.0 * lox.dB, gaseous=0.5 * lox.dB)
+losses = lox.PropagationLosses.none()
 ```
 
 The result plugs directly into `LinkStats.for_link` for link budget analysis.
@@ -164,13 +158,12 @@ print(f"Rain height: {h.to_kilometers():.1f} km")
 
 ## Link Budget Integration
 
-`EnvironmentalLosses` can be passed directly to `LinkStats.for_link`, where
+`PropagationLosses` can be passed directly to `LinkStats.for_link`, where
 `tx` is a `TxChain` or `EirpModel` and `rx` is an `RxChain` or `GtModel` (see
 [Communications](comms.md)):
 
 ```python
-losses = lox.EnvironmentalLosses(
-    provider,
+losses = provider.propagation_losses(
     lat=40.4 * lox.deg,
     lon=-3.7 * lox.deg,
     frequency=29.0 * lox.GHz,
@@ -222,7 +215,7 @@ for the packaging workflow.
 
 ---
 
-::: lox_space.EnvironmentalLosses
+::: lox_space.PropagationLosses
     options:
       show_source: false
 

--- a/crates/lox-space/examples/x_band_downlink.rs
+++ b/crates/lox-space/examples/x_band_downlink.rs
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .direction(LinkDirection::Downlink)
         .build()?;
     let link = LinkStats::for_link(&tx, &rx, &params)?;
-    let modulated = ModulatedLinkStats::evaluate(link, &channel, modcod, design_margin);
+    let modulated = ModulatedLinkStats::evaluate(link, &channel, modcod, design_margin)?;
 
     println!("\n--- Link budget at {} GHz ---", carrier.to_gigahertz());
     println!("EIRP:            {:>8.2} dBW", modulated.link.eirp.as_f64());

--- a/crates/lox-space/examples/x_band_downlink.rs
+++ b/crates/lox-space/examples/x_band_downlink.rs
@@ -21,8 +21,11 @@ use std::error::Error;
 
 use lox_space::comms::FrequencyRange;
 use lox_space::comms::antenna::Antenna;
-use lox_space::comms::channel::{Channel, LinkDirection, Modulation};
-use lox_space::comms::link_budget::{Eirp, GOverT, LinkParameters, LinkStats, PropagationLosses};
+use lox_space::comms::channel::{Channel, LinkDirection};
+use lox_space::comms::link_budget::{
+    Eirp, GOverT, LinkParameters, LinkStats, ModulatedLinkStats, PropagationLosses,
+};
+use lox_space::comms::modcod::{ModCod, dvb_s2};
 use lox_space::comms::pfd::{PfdMask, power_flux_density};
 use lox_space::comms::pointing::Pointing;
 use lox_space::comms::receiver::CascadeReceiver;
@@ -111,18 +114,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     // ------------------------------------------------------------------
-    // DVB-S2-style channel: QPSK 3/4 at 150 Msps → 225 Mbit/s net.
+    // DVB-S2 QPSK 3/4 at 150 Msps; the MODCOD table carries the exact
+    // Table 13 thresholds and coding chains (BBFRAME, BCH, LDPC, PLFRAME).
     // ------------------------------------------------------------------
-    let channel = Channel {
-        link_type: LinkDirection::Downlink,
-        symbol_rate: 150.0.mhz(),
-        required_eb_n0: 4.5.db(),
-        margin: 3.0.db(),
-        modulation: Modulation::Qpsk,
-        roll_off: 0.25,
-        fec: 0.75,
-        chip_rate: None,
-    };
+    let channel = Channel::builder(150.0.mhz()).roll_off(0.25).build()?;
+    let modcod = dvb_s2()
+        .iter()
+        .find(|mc| mc.mode().name() == "QPSK 3/4")
+        .expect("table mode");
+    let design_margin = 3.0.db();
 
     let params = LinkParameters::builder(carrier, channel.bandwidth(), range)
         .losses(losses)
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .direction(LinkDirection::Downlink)
         .build()?;
     let link = LinkStats::for_link(&tx, &rx, &params)?;
-    let modulated = channel.apply(link);
+    let modulated = ModulatedLinkStats::evaluate(link, &channel, modcod, design_margin);
 
     println!("\n--- Link budget at {} GHz ---", carrier.to_gigahertz());
     println!("EIRP:            {:>8.2} dBW", modulated.link.eirp.as_f64());
@@ -156,12 +156,26 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Eb/N0:           {:>8.2} dB", modulated.eb_n0.as_f64());
     println!(
         "Data rate:       {:>8.1} Mbit/s",
-        channel.information_rate().to_megahertz()
+        modulated.information_rate().to_megahertz()
     );
     println!("Link margin:     {:>8.2} dB", modulated.margin.as_f64());
     assert!(
         modulated.margin.as_f64() > 0.0,
         "the downlink should close at worst-case geometry"
+    );
+
+    // ------------------------------------------------------------------
+    // ACM: the best DVB-S2 mode that closes at this Es/N0 with the same
+    // design margin.
+    // ------------------------------------------------------------------
+    let best = ModCod::select(modulated.es_n0, design_margin, dvb_s2()).expect("a mode closes");
+    println!(
+        "\nBest ACM mode:   {} ({:.1} Mbit/s, +{:.0} %)",
+        best.mode().name(),
+        best.mode()
+            .information_rate(channel.symbol_rate())
+            .to_megahertz(),
+        (best.mode().info_bits_per_symbol() / modcod.mode().info_bits_per_symbol() - 1.0) * 100.0
     );
 
     // ------------------------------------------------------------------

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -15,6 +15,7 @@ use lox_comms::link_budget::{Eirp, GOverT};
 use lox_comms::link_budget::{
     InterferenceStats, LinkParameters, LinkStats, ModulatedLinkStats, frequency_overlap_factor,
 };
+use lox_comms::modcod::{self, ErrorMetric, ModCod};
 use lox_comms::pattern::{AntennaPattern, DipolePattern, GaussianPattern, ParabolicPattern};
 use lox_comms::pfd;
 use lox_comms::pointing::Pointing;
@@ -34,20 +35,6 @@ fn repr_f64(v: f64) -> String {
         format!("{s}.0")
     } else {
         s
-    }
-}
-
-fn modulation_name(m: Modulation) -> &'static str {
-    match m {
-        Modulation::Bpsk => "BPSK",
-        Modulation::Qpsk => "QPSK",
-        Modulation::Psk8 => "8PSK",
-        Modulation::Qam16 => "16QAM",
-        Modulation::Qam32 => "32QAM",
-        Modulation::Qam64 => "64QAM",
-        Modulation::Qam128 => "128QAM",
-        Modulation::Qam256 => "256QAM",
-        _ => unreachable!("unknown modulation variant"),
     }
 }
 
@@ -137,18 +124,11 @@ pub struct PyModulation(pub Modulation);
 impl PyModulation {
     #[new]
     fn new(name: &str) -> PyResult<Self> {
-        let m = match name {
-            "BPSK" => Modulation::Bpsk,
-            "QPSK" => Modulation::Qpsk,
-            "8PSK" => Modulation::Psk8,
-            "16QAM" => Modulation::Qam16,
-            "32QAM" => Modulation::Qam32,
-            "64QAM" => Modulation::Qam64,
-            "128QAM" => Modulation::Qam128,
-            "256QAM" => Modulation::Qam256,
-            _ => return Err(PyValueError::new_err(format!("unknown modulation: {name}"))),
-        };
-        Ok(Self(m))
+        name.parse()
+            .map(Self)
+            .map_err(|e: lox_comms::channel::ParseModulationError| {
+                PyValueError::new_err(e.to_string())
+            })
     }
 
     /// Returns the number of bits per symbol.
@@ -161,11 +141,11 @@ impl PyModulation {
     }
 
     fn __getnewargs__(&self) -> (&str,) {
-        (modulation_name(self.0),)
+        (self.0.name(),)
     }
 
     fn __repr__(&self) -> String {
-        format!("Modulation('{}')", modulation_name(self.0))
+        format!("Modulation('{}')", self.0.name())
     }
 }
 
@@ -868,16 +848,11 @@ impl PyCascadeReceiver {
 
 // --- Channel ---
 
-/// A communication channel.
+/// A communication channel: the waveform's occupancy of spectrum.
 ///
 /// Args:
-///     link_type: "uplink", "downlink", or "crosslink".
 ///     symbol_rate: Symbol rate in symbols per second.
-///     required_eb_n0: Required Eb/N0 as Decibel.
-///     margin: Required link margin as Decibel.
-///     modulation: Modulation scheme.
-///     roll_off: Roll-off factor (default 0.35).
-///     fec: Forward error correction code rate (default 0.5).
+///     roll_off: Pulse-shaping roll-off factor (default 0.35).
 ///     chip_rate: Chip rate for DSSS in chips per second (optional).
 #[pyclass(name = "Channel", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
@@ -890,39 +865,38 @@ fn parse_link_direction(s: &str) -> PyResult<LinkDirection> {
 #[pymethods]
 impl PyChannel {
     #[new]
-    #[pyo3(signature = (link_type, symbol_rate, required_eb_n0, margin, modulation, roll_off=0.35, fec=0.5, chip_rate=None))]
-    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (symbol_rate, roll_off=0.35, chip_rate=None))]
     fn new(
-        link_type: &str,
         symbol_rate: PyFrequency,
-        required_eb_n0: PyDecibel,
-        margin: PyDecibel,
-        modulation: &PyModulation,
         roll_off: f64,
-        fec: f64,
         chip_rate: Option<PyFrequency>,
     ) -> PyResult<Self> {
-        let lt = parse_link_direction(link_type)?;
-        Ok(Self(Channel {
-            link_type: lt,
-            symbol_rate: symbol_rate.0,
-            required_eb_n0: required_eb_n0.0,
-            margin: margin.0,
-            modulation: modulation.0,
-            roll_off,
-            fec,
-            chip_rate: chip_rate.map(|cr| cr.0),
-        }))
+        let mut builder = Channel::builder(symbol_rate.0).roll_off(roll_off);
+        if let Some(chip_rate) = chip_rate {
+            builder = builder.chip_rate(chip_rate.0);
+        }
+        builder
+            .build()
+            .map(Self)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
-    /// Returns the raw bit rate.
-    fn data_rate(&self) -> PyFrequency {
-        PyFrequency(self.0.data_rate())
+    /// Symbol rate.
+    #[getter]
+    fn symbol_rate(&self) -> PyFrequency {
+        PyFrequency(self.0.symbol_rate())
     }
 
-    /// Returns the information (post-FEC) bit rate.
-    fn information_rate(&self) -> PyFrequency {
-        PyFrequency(self.0.information_rate())
+    /// Pulse-shaping roll-off factor.
+    #[getter]
+    fn roll_off(&self) -> f64 {
+        self.0.roll_off()
+    }
+
+    /// DSSS chip rate, or None for narrowband.
+    #[getter]
+    fn chip_rate(&self) -> Option<PyFrequency> {
+        self.0.chip_rate().map(PyFrequency)
     }
 
     /// Returns the occupied channel bandwidth.
@@ -935,19 +909,9 @@ impl PyChannel {
         PyDecibel(self.0.es_n0(c_n0.0))
     }
 
-    /// Computes Eb/N0 from a given C/N0.
-    fn eb_n0(&self, c_n0: &PyDecibel) -> PyDecibel {
-        PyDecibel(self.0.eb_n0(c_n0.0))
-    }
-
     /// Computes C/N from a given C/N0.
     fn c_n(&self, c_n0: &PyDecibel) -> PyDecibel {
         PyDecibel(self.0.c_n(c_n0.0))
-    }
-
-    /// Computes the link margin from a given Eb/N0.
-    fn link_margin(&self, eb_n0: &PyDecibel) -> PyDecibel {
-        PyDecibel(self.0.link_margin(eb_n0.0))
     }
 
     /// Returns the DSSS spreading factor, or None for narrowband.
@@ -960,60 +924,204 @@ impl PyChannel {
         self.0.processing_gain().map(PyDecibel)
     }
 
-    /// Layers modulation/FEC figures onto a modulation-agnostic link budget.
-    fn apply(&self, link: PyLinkStats) -> PyModulatedLinkStats {
-        PyModulatedLinkStats(self.0.apply(link.0))
+    fn __eq__(&self, other: &PyChannel) -> bool {
+        self.0 == other.0
     }
 
-    #[allow(clippy::type_complexity)]
-    fn __getnewargs__<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> (
-        &str,
-        PyFrequency,
-        PyDecibel,
-        PyDecibel,
-        Bound<'py, PyAny>,
-        f64,
-        f64,
-        Option<PyFrequency>,
-    ) {
-        let lt = match self.0.link_type {
-            LinkDirection::Uplink => "uplink",
-            LinkDirection::Downlink => "downlink",
-            LinkDirection::Crosslink => "crosslink",
-            _ => unreachable!("unknown link direction variant"),
-        };
-        let modulation = Bound::new(py, PyModulation(self.0.modulation))
-            .unwrap()
-            .into_any();
+    fn __getnewargs__(&self) -> (PyFrequency, f64, Option<PyFrequency>) {
         (
-            lt,
-            PyFrequency(self.0.symbol_rate),
-            PyDecibel(self.0.required_eb_n0),
-            PyDecibel(self.0.margin),
-            modulation,
-            self.0.roll_off,
-            self.0.fec,
-            self.0.chip_rate.map(PyFrequency),
+            PyFrequency(self.0.symbol_rate()),
+            self.0.roll_off(),
+            self.0.chip_rate().map(PyFrequency),
         )
     }
 
     fn __repr__(&self) -> String {
-        let chip = self.0.chip_rate.map_or(String::new(), |cr| {
+        let chip = self.0.chip_rate().map_or(String::new(), |cr| {
             format!(", chip_rate={}", PyFrequency(cr).__repr__())
         });
         format!(
-            "Channel(link_type='{}', symbol_rate={}, required_eb_n0={}, margin={}, modulation=Modulation('{}'), roll_off={}, fec={}{})",
-            self.0.link_type,
-            PyFrequency(self.0.symbol_rate).__repr__(),
-            PyDecibel(self.0.required_eb_n0).__repr__(),
-            PyDecibel(self.0.margin).__repr__(),
-            modulation_name(self.0.modulation),
-            repr_f64(self.0.roll_off),
-            repr_f64(self.0.fec),
-            chip,
+            "Channel(symbol_rate={}, roll_off={}{})",
+            PyFrequency(self.0.symbol_rate()).__repr__(),
+            repr_f64(self.0.roll_off()),
+            chip
+        )
+    }
+}
+
+// --- ModCod ---
+
+/// A modulation and coding scheme with its performance threshold.
+///
+/// Constructed from the classic hand-rolled specification — a modulation,
+/// an aggregate code rate, and the Eb/N0 required for a target error rate —
+/// or taken from a built-in table such as ``ModCod.dvb_s2()``.
+///
+/// Args:
+///     name: Name of the scheme.
+///     modulation: Modulation scheme.
+///     code_rate: Aggregate code rate in (0, 1].
+///     required_eb_n0: Eb/N0 threshold as Decibel.
+///     metric: Error metric ("BER", "WER", "FER", or "PER"; default "BER").
+///     error_rate: Error rate at the threshold (default 1e-6).
+#[pyclass(name = "ModCod", module = "lox_space", frozen, from_py_object)]
+#[derive(Debug, Clone)]
+pub struct PyModCod(pub ModCod);
+
+fn parse_error_metric(s: &str) -> PyResult<ErrorMetric> {
+    match s.to_ascii_uppercase().as_str() {
+        "BER" => Ok(ErrorMetric::Ber),
+        "WER" => Ok(ErrorMetric::Wer),
+        "FER" => Ok(ErrorMetric::Fer),
+        "PER" => Ok(ErrorMetric::Per),
+        _ => Err(PyValueError::new_err(format!(
+            "unknown error metric: '{s}', expected 'BER', 'WER', 'FER', or 'PER'"
+        ))),
+    }
+}
+
+#[pymethods]
+impl PyModCod {
+    #[new]
+    #[pyo3(signature = (name, modulation, code_rate, required_eb_n0, metric="BER", error_rate=1e-6))]
+    fn new(
+        name: &str,
+        modulation: &PyModulation,
+        code_rate: f64,
+        required_eb_n0: PyDecibel,
+        metric: &str,
+        error_rate: f64,
+    ) -> PyResult<Self> {
+        ModCod::from_required_eb_n0(
+            name,
+            modulation.0,
+            code_rate,
+            required_eb_n0.0,
+            parse_error_metric(metric)?,
+            error_rate,
+        )
+        .map(Self)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Returns the DVB-S2 MODCOD table (normal FECFRAME, no pilots).
+    ///
+    /// 28 modes from QPSK 1/4 through 32APSK 9/10 with quasi-error-free
+    /// thresholds per ETSI EN 302 307-1 Table 13.
+    #[staticmethod]
+    fn dvb_s2() -> Vec<PyModCod> {
+        modcod::dvb_s2().iter().cloned().map(PyModCod).collect()
+    }
+
+    /// Selects the highest-efficiency MODCOD that closes at the given Es/N0
+    /// with the given margin, or None when none does.
+    #[staticmethod]
+    fn select(es_n0: PyDecibel, margin: PyDecibel, table: Vec<PyModCod>) -> Option<PyModCod> {
+        let table: Vec<ModCod> = table.into_iter().map(|mc| mc.0).collect();
+        ModCod::select(es_n0.0, margin.0, &table)
+            .cloned()
+            .map(PyModCod)
+    }
+
+    /// Name of the scheme.
+    #[getter]
+    fn name(&self) -> String {
+        self.0.mode().name().to_owned()
+    }
+
+    /// Modulation scheme.
+    #[getter]
+    fn modulation(&self) -> PyModulation {
+        PyModulation(self.0.mode().modulation())
+    }
+
+    /// Overall code rate: the product of the coding chain's rates.
+    #[getter]
+    fn code_rate(&self) -> f64 {
+        self.0.mode().code_rate()
+    }
+
+    /// The coding chain as (name, rate) tuples in encoding order.
+    #[getter]
+    fn codes(&self) -> Vec<(String, f64)> {
+        self.0
+            .mode()
+            .codes()
+            .iter()
+            .map(|c| (c.name().to_owned(), c.rate()))
+            .collect()
+    }
+
+    /// Information bits per symbol including all coding and framing overhead.
+    #[getter]
+    fn info_bits_per_symbol(&self) -> f64 {
+        self.0.mode().info_bits_per_symbol()
+    }
+
+    /// Required Eb/N0 threshold.
+    #[getter]
+    fn required_eb_n0(&self) -> PyDecibel {
+        PyDecibel(self.0.required_eb_n0())
+    }
+
+    /// Required Es/N0 threshold.
+    #[getter]
+    fn required_es_n0(&self) -> PyDecibel {
+        PyDecibel(self.0.required_es_n0())
+    }
+
+    /// Error metric of the threshold ("BER", "WER", "FER", or "PER").
+    #[getter]
+    fn metric(&self) -> String {
+        self.0.performance().metric().to_string()
+    }
+
+    /// Error rate at the threshold.
+    #[getter]
+    fn error_rate(&self) -> f64 {
+        self.0.performance().error_rate()
+    }
+
+    /// Source of the mode definition.
+    #[getter]
+    fn reference(&self) -> String {
+        self.0.mode().reference().to_owned()
+    }
+
+    /// Returns the information bit rate at the given symbol rate.
+    fn information_rate(&self, symbol_rate: PyFrequency) -> PyFrequency {
+        PyFrequency(self.0.mode().information_rate(symbol_rate.0))
+    }
+
+    /// Evaluates a link budget on a channel against this MODCOD.
+    ///
+    /// Args:
+    ///     link: The modulation-agnostic link budget.
+    ///     channel: The waveform the link runs on.
+    ///     design_margin: Margin applied on top of the threshold (default 0 dB).
+    #[pyo3(signature = (link, channel, design_margin=None))]
+    fn evaluate(
+        &self,
+        link: PyLinkStats,
+        channel: &PyChannel,
+        design_margin: Option<PyDecibel>,
+    ) -> PyModulatedLinkStats {
+        let margin = design_margin.map(|m| m.0).unwrap_or(Decibel::new(0.0));
+        PyModulatedLinkStats(ModulatedLinkStats::evaluate(
+            link.0, &channel.0, &self.0, margin,
+        ))
+    }
+
+    fn __eq__(&self, other: &PyModCod) -> bool {
+        self.0 == other.0
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ModCod('{}', required_eb_n0={:.2} dB, info_bits_per_symbol={:.3})",
+            self.0.mode().name(),
+            self.0.required_eb_n0().as_f64(),
+            self.0.mode().info_bits_per_symbol(),
         )
     }
 }
@@ -1382,16 +1490,33 @@ impl PyModulatedLinkStats {
         PyLinkStats(self.0.link.clone())
     }
 
-    /// The channel (modulation, FEC, required Eb/N0, margin) applied.
+    /// The waveform the link was evaluated on.
     #[getter]
     fn channel(&self) -> PyChannel {
         PyChannel(self.0.channel.clone())
     }
 
+    /// The modulation and coding scheme the link was evaluated against.
+    #[getter]
+    fn modcod(&self) -> PyModCod {
+        PyModCod(self.0.modcod.clone())
+    }
+
+    /// Design margin applied on top of the MODCOD threshold.
+    #[getter]
+    fn design_margin(&self) -> PyDecibel {
+        PyDecibel(self.0.design_margin)
+    }
+
     /// Symbol rate from the channel.
     #[getter]
     fn symbol_rate(&self) -> PyFrequency {
-        PyFrequency(self.0.symbol_rate)
+        PyFrequency(self.0.symbol_rate())
+    }
+
+    /// Information bit rate: symbol rate × info bits per symbol.
+    fn information_rate(&self) -> PyFrequency {
+        PyFrequency(self.0.information_rate())
     }
 
     /// Es/N0 (energy per symbol to noise spectral density) in dB.

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1105,11 +1105,11 @@ impl PyModCod {
         link: PyLinkStats,
         channel: &PyChannel,
         design_margin: Option<PyDecibel>,
-    ) -> PyModulatedLinkStats {
+    ) -> PyResult<PyModulatedLinkStats> {
         let margin = design_margin.map(|m| m.0).unwrap_or(Decibel::new(0.0));
-        PyModulatedLinkStats(ModulatedLinkStats::evaluate(
-            link.0, &channel.0, &self.0, margin,
-        ))
+        ModulatedLinkStats::evaluate(link.0, &channel.0, &self.0, margin)
+            .map(PyModulatedLinkStats)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     fn __eq__(&self, other: &PyModCod) -> bool {

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -14,7 +14,7 @@ use crate::bodies::python::PyOrigin;
 use crate::comms::python::{
     PyAmplifierTransmitter, PyAntennaFrame, PyCascadeReceiver, PyChannel, PyConstantAntenna,
     PyDecibel, PyDipolePattern, PyEirpModel, PyFrequencyRange, PyGaussianPattern, PyGtModel,
-    PyInterferenceStats, PyLinkStats, PyModulatedLinkStats, PyModulation, PyNoiseStage,
+    PyInterferenceStats, PyLinkStats, PyModCod, PyModulatedLinkStats, PyModulation, PyNoiseStage,
     PyNoiseTempReceiver, PyParabolicPattern, PyPatternedAntenna, PyPfdMask, PyPropagationLosses,
     PyRxChain, PyTxChain, freq_overlap, fspl, power_flux_density, slant_range,
 };
@@ -70,6 +70,7 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCascadeReceiver>()?;
     m.add_class::<PyNoiseStage>()?;
     m.add_class::<PyChannel>()?;
+    m.add_class::<PyModCod>()?;
     m.add_class::<PyItuProvider>()?;
     m.add_class::<PyPropagationLosses>()?;
     m.add_class::<PyLinkStats>()?;

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -612,86 +612,103 @@ def test_complex_receiver_repr_roundtrip():
 
 
 def test_channel_bandwidth():
-    # BPSK, 1 Msps, roll-off=0.5 -> BW = 1.5 MHz
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=1 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("BPSK"),
-        roll_off=0.5,
-        fec=0.5,
-    )
+    # 1 Msps, roll-off=0.5 -> BW = 1.5 MHz
+    ch = lox.Channel(symbol_rate=1 * lox.MHz, roll_off=0.5)
     assert ch.bandwidth().to_hertz() == pytest.approx(1.5e6, rel=1e-10)
 
 
-def test_channel_eb_n0():
-    # QPSK, 500 ksps, fec=0.5 -> data_rate=1 Mbps (=symbol_rate * bps * fec for Eb/N0)
-    # Es/N0 = 80 - 10*log10(500e3) = 80 - 56.99 = 23.01
-    # Eb/N0 = 23.01 - 10*log10(2*0.5) = 23.01
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=500 * lox.kHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
-    eb_n0 = ch.eb_n0(80.0 * lox.dB)
-    expected = 80.0 - 10.0 * math.log10(500e3) - 10.0 * math.log10(2 * 0.5)
-    assert float(eb_n0) == pytest.approx(expected, abs=1e-6)
+def test_channel_es_n0():
+    # Es/N0 = 80 - 10*log10(500e3) = 23.01
+    ch = lox.Channel(symbol_rate=500 * lox.kHz)
+    es_n0 = ch.es_n0(80.0 * lox.dB)
+    expected = 80.0 - 10.0 * math.log10(500e3)
+    assert float(es_n0) == pytest.approx(expected, abs=1e-6)
 
 
-def test_channel_link_margin():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=500 * lox.kHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
-    margin = ch.link_margin(15.0 * lox.dB)
-    assert float(margin) == pytest.approx(2.0, abs=1e-10)
+def test_channel_rejects_invalid():
+    with pytest.raises(ValueError):
+        lox.Channel(symbol_rate=0 * lox.Hz)
+    with pytest.raises(ValueError):
+        lox.Channel(symbol_rate=1 * lox.MHz, roll_off=-0.1)
+    with pytest.raises(ValueError):
+        lox.Channel(symbol_rate=5 * lox.MHz, chip_rate=1 * lox.MHz)
 
 
-def test_channel_invalid_link_type():
-    with pytest.raises(ValueError, match="unknown link direction"):
-        lox.Channel(
-            link_type="invalid",
-            symbol_rate=1 * lox.MHz,
-            required_eb_n0=10.0 * lox.dB,
-            margin=3.0 * lox.dB,
-            modulation=lox.Modulation("BPSK"),
-        )
+def test_channel_dsss():
+    ch = lox.Channel(symbol_rate=10 * lox.kHz, chip_rate=4 * lox.MHz)
+    assert ch.spreading_factor() == pytest.approx(400.0, rel=1e-10)
+    assert float(ch.processing_gain()) == pytest.approx(26.02, abs=0.01)
 
 
 def test_channel_pickle():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=1 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        roll_off=0.35,
-        fec=0.5,
-    )
+    ch = lox.Channel(symbol_rate=1 * lox.MHz, roll_off=0.25)
     restored = pickle.loads(pickle.dumps(ch))
-    # Channel doesn't have __eq__, verify via bandwidth
-    assert restored.bandwidth().to_hertz() == pytest.approx(
-        ch.bandwidth().to_hertz(), abs=1e-10
-    )
+    assert restored == ch
 
 
 def test_channel_repr():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=1 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    ch = lox.Channel(symbol_rate=1 * lox.MHz)
     r = repr(ch)
-    assert "link_type='downlink'" in r
-    assert "modulation=Modulation('QPSK')" in r
+    assert "symbol_rate=" in r
+    assert "roll_off=0.35" in r
+
+
+# --- ModCod ---
+
+
+def test_modcod_from_required_eb_n0():
+    mc = lox.ModCod(
+        "my downlink", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB
+    )
+    assert mc.name == "my downlink"
+    assert mc.info_bits_per_symbol == pytest.approx(1.0, abs=1e-12)
+    assert float(mc.required_eb_n0) == pytest.approx(10.0, abs=1e-12)
+    assert float(mc.required_es_n0) == pytest.approx(10.0, abs=1e-9)
+    assert mc.metric == "BER"
+    assert mc.error_rate == pytest.approx(1e-6)
+
+
+def test_modcod_rejects_invalid():
+    with pytest.raises(ValueError):
+        lox.ModCod("bad", lox.Modulation("QPSK"), 1.5, 10.0 * lox.dB)
+    with pytest.raises(ValueError, match="unknown error metric"):
+        lox.ModCod("bad", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB, metric="XYZ")
+
+
+def test_modcod_dvb_s2_table():
+    table = lox.ModCod.dvb_s2()
+    assert len(table) == 28
+    qpsk12 = next(mc for mc in table if mc.name == "QPSK 1/2")
+    # ETSI EN 302 307-1 Table 13: efficiency 0.988858, Es/N0 = 1.0 dB.
+    assert qpsk12.info_bits_per_symbol == pytest.approx(0.988858, abs=5e-7)
+    assert float(qpsk12.required_es_n0) == pytest.approx(1.0, abs=1e-9)
+    assert qpsk12.reference.startswith("ETSI")
+    # The coding chain is exposed.
+    names = [name for name, _ in qpsk12.codes]
+    assert any("LDPC" in n for n in names)
+
+
+def test_modcod_select():
+    table = lox.ModCod.dvb_s2()
+    best = lox.ModCod.select(20.0 * lox.dB, 0.0 * lox.dB, table)
+    assert best.name == "32APSK 9/10"
+    assert lox.ModCod.select(-3.0 * lox.dB, 0.0 * lox.dB, table) is None
+
+
+def test_modcod_evaluate():
+    losses = lox.PropagationLosses(rain=2.0 * lox.dB)
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
+    stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth(), losses=losses)
+    m = mc.evaluate(stats, ch, design_margin=3.0 * lox.dB)
+    # Es/N0 = C/N0 - 10*log10(5e6); Eb/N0 = Es/N0 (1 info bit/symbol)
+    assert float(m.es_n0) == pytest.approx(float(stats.c_n0) - 10 * math.log10(5e6), abs=1e-9)
+    assert float(m.eb_n0) == pytest.approx(float(m.es_n0), abs=1e-9)
+    assert float(m.margin) == pytest.approx(float(m.eb_n0) - 10.0 - 3.0, abs=1e-9)
+    assert m.information_rate().to_hertz() == pytest.approx(5e6, rel=1e-10)
+    assert m.modcod == mc
+    assert m.channel == ch
+    assert float(m.design_margin) == pytest.approx(3.0)
 
 
 # --- Propagation Losses ---
@@ -778,15 +795,8 @@ def test_link_stats_noise_power():
 
 
 def test_link_stats_end_to_end():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        roll_off=0.35,
-        fec=0.5,
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("QPSK 1/2 test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
 
     stats = link_stats(
         make_tx(),
@@ -795,7 +805,7 @@ def test_link_stats_end_to_end():
         tx_angle=0.0 * lox.deg,
         rx_angle=0.0 * lox.deg,
     )
-    modulated = ch.apply(stats)
+    modulated = mc.evaluate(stats, ch, design_margin=3.0 * lox.dB)
 
     # EIRP = 46 + 10 - 1 = 55 dBW
     assert float(stats.eirp) == pytest.approx(55.0, abs=0.01)
@@ -812,6 +822,7 @@ def test_link_stats_end_to_end():
     # Properties
     assert stats.slant_range.to_kilometers() == pytest.approx(1000.0, abs=1e-6)
     assert modulated.symbol_rate.to_hertz() == pytest.approx(5e6, abs=1e-6)
+    assert modulated.information_rate().to_hertz() == pytest.approx(5e6, abs=1e-6)
     assert stats.frequency.to_hertz() == pytest.approx(29e9, abs=1.0)
 
 
@@ -848,15 +859,8 @@ def test_link_stats_rejects_unknown_link_type():
 
 
 def test_link_stats_with_losses():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        roll_off=0.35,
-        fec=0.5,
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("QPSK 1/2 test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
 
     losses = lox.PropagationLosses(rain=2.0 * lox.dB, other=[("Atmospheric", 1.0 * lox.dB, True)])
 
@@ -866,8 +870,8 @@ def test_link_stats_with_losses():
     stats_loss = link_stats(
         make_tx(), make_rx(), bandwidth=ch.bandwidth(), losses=losses
     )
-    modulated_no_loss = ch.apply(stats_no_loss)
-    modulated_loss = ch.apply(stats_loss)
+    modulated_no_loss = mc.evaluate(stats_no_loss, ch, design_margin=3.0 * lox.dB)
+    modulated_loss = mc.evaluate(stats_loss, ch, design_margin=3.0 * lox.dB)
 
     # 3 dB of environmental losses should reduce margin by 3 dB
     margin_diff = float(modulated_no_loss.margin) - float(modulated_loss.margin)
@@ -877,53 +881,8 @@ def test_link_stats_with_losses():
 # --- Channel additional methods ---
 
 
-def test_channel_data_rate():
-    # QPSK (2 bps), 5 Msps -> data_rate = 10 Mbps
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
-    assert ch.data_rate().to_hertz() == pytest.approx(10e6, rel=1e-10)
-
-
-def test_channel_information_rate():
-    # data_rate=10 Mbps, fec=0.5 -> info_rate=5 Mbps
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        fec=0.5,
-    )
-    assert ch.information_rate().to_hertz() == pytest.approx(5e6, rel=1e-10)
-
-
-def test_channel_es_n0():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
-    es_n0 = ch.es_n0(80.0 * lox.dB)
-    expected = 80.0 - 10.0 * math.log10(5e6)
-    assert float(es_n0) == pytest.approx(expected, abs=1e-3)
-
-
 def test_channel_c_n():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        roll_off=0.35,
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
     c_n = ch.c_n(80.0 * lox.dB)
     bw = 5e6 * 1.35
     expected = 80.0 - 10.0 * math.log10(bw)
@@ -931,53 +890,15 @@ def test_channel_c_n():
 
 
 def test_channel_spreading_factor_narrowband():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=1 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("BPSK"),
-    )
+    ch = lox.Channel(symbol_rate=1 * lox.MHz)
     assert ch.spreading_factor() is None
     assert ch.processing_gain() is None
 
 
-def test_channel_spreading_factor_dsss():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=10 * lox.kHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("BPSK"),
-        chip_rate=4 * lox.MHz,
-    )
-    assert ch.spreading_factor() == pytest.approx(400.0, rel=1e-10)
-    pg = ch.processing_gain()
-    assert float(pg) == pytest.approx(10.0 * math.log10(400.0), abs=1e-3)
-
-
-def test_channel_uplink_and_crosslink():
-    for lt in ("uplink", "crosslink"):
-        ch = lox.Channel(
-            link_type=lt,
-            symbol_rate=1 * lox.MHz,
-            required_eb_n0=10.0 * lox.dB,
-            margin=3.0 * lox.dB,
-            modulation=lox.Modulation("BPSK"),
-        )
-        assert lt in repr(ch)
-
-
-def test_channel_repr_with_chip_rate():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=10 * lox.kHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("BPSK"),
-        chip_rate=4 * lox.MHz,
-    )
-    assert "chip_rate=" in repr(ch)
+def test_modcod_information_rate():
+    # QPSK rate 1/2 at 5 Msps: 5 Mbit/s information rate.
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
+    assert mc.information_rate(5 * lox.MHz).to_hertz() == pytest.approx(5e6, rel=1e-10)
 
 
 # --- LinkStats additional outputs ---
@@ -1080,15 +1001,7 @@ def test_noise_stage_pickle():
 
 
 def test_link_stats_all_getters():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        roll_off=0.35,
-        fec=0.5,
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
 
     stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
 
@@ -1103,16 +1016,11 @@ def test_link_stats_all_getters():
 
 
 def test_link_stats_repr():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
 
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
     stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
-    modulated = ch.apply(stats)
+    modulated = mc.evaluate(stats, ch, design_margin=3.0 * lox.dB)
     r = repr(stats)
     assert "LinkStats" in r
     assert "c_n0=" in r
@@ -1210,15 +1118,10 @@ def test_tx_chain_rejects_negative_feed_loss():
 def test_lumped_link_interference_requires_absolute_power():
     tx = lox.EirpModel(KA_BAND, 55.0 * lox.dB)
     rx = lox.GtModel(KA_BAND, 3.01 * lox.dB)
-    channel = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5.0 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    channel = lox.Channel(symbol_rate=5.0 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
     link = link_stats(tx, rx, bandwidth=channel.bandwidth())
-    modulated = channel.apply(link)
+    modulated = mc.evaluate(link, channel, design_margin=3.0 * lox.dB)
 
     with pytest.raises(ValueError, match="absolute carrier and noise powers"):
         modulated.with_interference(1e-12 * lox.W)
@@ -1228,18 +1131,13 @@ def test_lumped_link_interference_requires_absolute_power():
 
 
 def test_modulated_with_interference_component_tier():
-    channel = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5.0 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    channel = lox.Channel(symbol_rate=5.0 * lox.MHz)
 
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
     link = link_stats(
         make_tx(), make_rx(), bandwidth=channel.bandwidth()
     )
-    modulated = channel.apply(link)
+    modulated = mc.evaluate(link, channel, design_margin=3.0 * lox.dB)
     interference = modulated.with_interference(1e-12 * lox.W)
 
     assert float(interference.margin_with_interference) < float(modulated.margin)
@@ -1261,14 +1159,7 @@ def test_simple_receiver_repr():
 
 
 def test_channel_dsss_pickle():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=10 * lox.kHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("BPSK"),
-        chip_rate=4 * lox.MHz,
-    )
+    ch = lox.Channel(symbol_rate=10 * lox.kHz, chip_rate=4 * lox.MHz)
     restored = pickle.loads(pickle.dumps(ch))
     assert restored.spreading_factor() == pytest.approx(ch.spreading_factor(), rel=1e-10)
     assert float(restored.processing_gain()) == pytest.approx(float(ch.processing_gain()), abs=1e-10)
@@ -1324,37 +1215,29 @@ def test_link_stats_rejects_angle_and_direction():
 
 
 def test_modulated_link_stats_link_and_channel_getters():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
     stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
-    modulated = ch.apply(stats)
+    modulated = mc.evaluate(stats, ch)
 
     # link getter returns the underlying PyLinkStats
     assert modulated.link.c_n0 == stats.c_n0
-    # channel getter returns the PyChannel
-    assert "QPSK" in repr(modulated.channel)
+    # channel and modcod getters round-trip
+    assert modulated.channel == ch
+    assert modulated.modcod == mc
+    assert float(modulated.design_margin) == pytest.approx(0.0)
 
 
 # --- InterferenceStats c_n0i0 and repr ---
 
 
 def test_interference_stats_c_n0i0_and_repr():
-    channel = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5.0 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    channel = lox.Channel(symbol_rate=5.0 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
     link = link_stats(
         make_tx(), make_rx(), bandwidth=channel.bandwidth()
     )
-    modulated = channel.apply(link)
+    modulated = mc.evaluate(link, channel, design_margin=3.0 * lox.dB)
     interference = modulated.with_interference(1e-12 * lox.W)
 
     assert math.isfinite(float(interference.c_n0i0))
@@ -1367,15 +1250,10 @@ def test_interference_stats_c_n0i0_and_repr():
 
 
 def test_modulated_link_stats_repr():
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=5 * lox.MHz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-    )
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
     stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
-    modulated = ch.apply(stats)
+    modulated = mc.evaluate(stats, ch)
     r = repr(modulated)
     assert "ModulatedLinkStats" in r
     assert "eb_n0=" in r
@@ -1404,6 +1282,14 @@ def test_modulation_repr_all_variants():
         "64QAM": "Modulation('64QAM')",
         "128QAM": "Modulation('128QAM')",
         "256QAM": "Modulation('256QAM')",
+        "OQPSK": "Modulation('OQPSK')",
+        "8APSK": "Modulation('8APSK')",
+        "16APSK": "Modulation('16APSK')",
+        "32APSK": "Modulation('32APSK')",
+        "64APSK": "Modulation('64APSK')",
+        "GMSK": "Modulation('GMSK')",
+        "2FSK": "Modulation('2FSK')",
+        "4FSK": "Modulation('4FSK')",
     }
     for name, expected_repr in expected.items():
         assert repr(lox.Modulation(name)) == expected_repr

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -895,6 +895,16 @@ def test_channel_spreading_factor_narrowband():
     assert ch.processing_gain() is None
 
 
+def test_modcod_evaluate_rejects_bandwidth_mismatch():
+    # The link was computed with a 5 MHz noise bandwidth, not the channel's
+    # 6.75 MHz occupied bandwidth.
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
+    stats = link_stats(make_tx(), make_rx(), bandwidth=5 * lox.MHz)
+    with pytest.raises(ValueError, match="does not match"):
+        mc.evaluate(stats, ch)
+
+
 def test_modcod_information_rate():
     # QPSK rate 1/2 at 5 Msps: 5 Mbit/s information rate.
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -905,6 +905,39 @@ def test_modcod_evaluate_rejects_bandwidth_mismatch():
         mc.evaluate(stats, ch)
 
 
+def test_modcod_getters_and_repr():
+    mc = lox.ModCod("my link", lox.Modulation("8PSK"), 0.75, 6.0 * lox.dB)
+    assert mc.modulation == lox.Modulation("8PSK")
+    assert mc.code_rate == pytest.approx(0.75)
+    assert mc.codes == [("FEC", 0.75)]
+    r = repr(mc)
+    assert "my link" in r
+    assert "required_eb_n0=6.00 dB" in r
+
+
+@pytest.mark.parametrize("metric", ["WER", "FER", "PER", "wer"])
+def test_modcod_metric_variants(metric):
+    mc = lox.ModCod(
+        "m", lox.Modulation("QPSK"), 0.5, 4.0 * lox.dB, metric=metric, error_rate=1e-7
+    )
+    assert mc.metric == metric.upper()
+    assert mc.error_rate == pytest.approx(1e-7)
+
+
+def test_channel_chip_rate_getter_and_repr():
+    ch = lox.Channel(symbol_rate=10 * lox.kHz, chip_rate=4 * lox.MHz)
+    assert ch.chip_rate.to_hertz() == pytest.approx(4e6, rel=1e-12)
+    assert "chip_rate=" in repr(ch)
+    assert lox.Channel(symbol_rate=10 * lox.kHz).chip_rate is None
+
+
+def test_propagation_losses_repr_non_absorptive():
+    losses = lox.PropagationLosses(other=[("Pointing margin", 0.4 * lox.dB, False)])
+    r = repr(losses)
+    assert "Pointing margin" in r
+    assert "False" in r
+
+
 def test_modcod_information_rate():
     # QPSK rate 1/2 at 5 Msps: 5 Mbit/s information rate.
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)

--- a/crates/lox-space/tests/test_spacelink_comms.py
+++ b/crates/lox-space/tests/test_spacelink_comms.py
@@ -224,8 +224,10 @@ def test_chain_noise_temperature_degenerate(noise_figure_db):
 # ---------------------------------------------------------------------------
 # Test 7: C/N0 → Eb/N0
 #
-# lox.Channel.eb_n0(cn0) computes Eb/N0 = C/N0 − 10·log10(R).
-# spacelink.core.noise.cn0_to_ebn0() implements the same relation.
+# A BPSK rate-1 ModCod evaluated on a Channel computes
+# Eb/N0 = C/N0 − 10·log10(R); spacelink.core.noise.cn0_to_ebn0() implements
+# the same relation. Es/N0 == Eb/N0 at 1 info bit/symbol, so Channel.es_n0
+# is compared directly.
 # ---------------------------------------------------------------------------
 
 # (cn0_dbhz, data_rate_hz)
@@ -241,15 +243,9 @@ CN0_CASES = [
 
 @pytest.mark.parametrize("cn0_dbhz,data_rate_hz", CN0_CASES)
 def test_cn0_to_ebn0(cn0_dbhz, data_rate_hz):
-    ch = lox.Channel(
-        link_type="downlink",
-        symbol_rate=lox.Frequency(data_rate_hz),
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("BPSK"),
-        fec=1.0,
-    )
-    lox_ebn0 = float(ch.eb_n0(cn0_dbhz * lox.dB))
+    # BPSK uncoded: 1 info bit/symbol, so Es/N0 == Eb/N0.
+    ch = lox.Channel(symbol_rate=lox.Frequency(data_rate_hz))
+    lox_ebn0 = float(ch.es_n0(cn0_dbhz * lox.dB))
     sl_ebn0 = float(
         sl_cn0_to_ebn0(
             u.LogQuantity(cn0_dbhz, unit=u.dB(u.Hz)),
@@ -506,16 +502,9 @@ def test_tdrs_ka_band_return_link():
     sl_t_rx = float(sl_nf_to_temp(rx_nf_db * u.dB).value)
     assert t_rx == pytest.approx(sl_t_rx, abs=0.01)
 
-    # --- Channel ---
-    channel = lox.Channel(
-        link_type="downlink",
-        symbol_rate=25e6 * lox.Hz,
-        required_eb_n0=10.0 * lox.dB,
-        margin=3.0 * lox.dB,
-        modulation=lox.Modulation("QPSK"),
-        fec=0.5,
-        roll_off=0.35,
-    )
+    # --- Channel and MODCOD ---
+    channel = lox.Channel(symbol_rate=25e6 * lox.Hz)
+    modcod = lox.ModCod("QPSK 1/2", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
 
     # --- Link budget ---
     range_km = 40000.0
@@ -527,7 +516,7 @@ def test_tdrs_ka_band_return_link():
         bandwidth=channel.bandwidth(),
         range=range_km * lox.km,
     )
-    modulated = channel.apply(stats)
+    modulated = modcod.evaluate(stats, channel, design_margin=3.0 * lox.dB)
 
     # Verify T_sys via Friis: T_ant + T_LNA + T_rx/G_LNA (zero feed loss)
     g_lna = 10.0 ** (lna_gain_db / 10.0)

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2712,12 +2712,17 @@ class ModCod:
         channel: Channel,
         design_margin: Decibel | None = None,
     ) -> ModulatedLinkStats:
-        """Evaluates a link budget on a channel against this MODCOD."""
+        """Evaluates a link budget on a channel against this MODCOD.
+
+        Raises:
+            ValueError: if the link's noise bandwidth does not match the
+                channel's occupied bandwidth.
+        """
         ...
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
-class PropagationLosses:class PropagationLosses:
+class PropagationLosses:
     """Itemized excess propagation losses along a link path, beyond
     free-space path loss.
 

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2590,34 +2590,30 @@ class CascadeReceiver:
     def __repr__(self) -> str: ...
 
 class Channel:
-    """A communication channel.
+    """A communication channel: the waveform's occupancy of spectrum.
 
     Args:
-        link_type: "uplink", "downlink", or "crosslink".
         symbol_rate: Symbol rate as Frequency.
-        required_eb_n0: Required Eb/N0 as Decibel.
-        margin: Required link margin as Decibel.
-        modulation: Modulation scheme.
-        roll_off: Roll-off factor (default 0.35).
-        fec: Forward error correction code rate (default 0.5).
+        roll_off: Pulse-shaping roll-off factor (default 0.35).
         chip_rate: Chip rate for DSSS as Frequency (optional).
     """
     def __new__(
         cls,
-        link_type: str,
         symbol_rate: Frequency,
-        required_eb_n0: Decibel,
-        margin: Decibel,
-        modulation: Modulation,
         roll_off: float = 0.35,
-        fec: float = 0.5,
         chip_rate: Frequency | None = None,
     ) -> Self: ...
-    def data_rate(self) -> Frequency:
-        """Returns the raw bit rate."""
+    @property
+    def symbol_rate(self) -> Frequency:
+        """Symbol rate."""
         ...
-    def information_rate(self) -> Frequency:
-        """Returns the information (post-FEC) bit rate."""
+    @property
+    def roll_off(self) -> float:
+        """Pulse-shaping roll-off factor."""
+        ...
+    @property
+    def chip_rate(self) -> Frequency | None:
+        """DSSS chip rate, or None for narrowband."""
         ...
     def bandwidth(self) -> Frequency:
         """Returns the occupied channel bandwidth."""
@@ -2625,14 +2621,8 @@ class Channel:
     def es_n0(self, c_n0: Decibel) -> Decibel:
         """Computes Es/N0 from a given C/N0."""
         ...
-    def eb_n0(self, c_n0: Decibel) -> Decibel:
-        """Computes Eb/N0 from a given C/N0."""
-        ...
     def c_n(self, c_n0: Decibel) -> Decibel:
         """Computes C/N from a given C/N0."""
-        ...
-    def link_margin(self, eb_n0: Decibel) -> Decibel:
-        """Computes the link margin from a given Eb/N0."""
         ...
     def spreading_factor(self) -> float | None:
         """Returns the DSSS spreading factor, or None for narrowband."""
@@ -2640,12 +2630,94 @@ class Channel:
     def processing_gain(self) -> Decibel | None:
         """Returns the DSSS processing gain in dB, or None for narrowband."""
         ...
-    def apply(self, link: LinkStats) -> ModulatedLinkStats:
-        """Layers modulation/FEC figures onto a modulation-agnostic link budget."""
-        ...
+    def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
-class PropagationLosses:
+class ModCod:
+    """A modulation and coding scheme with its performance threshold.
+
+    Args:
+        name: Name of the scheme.
+        modulation: Modulation scheme.
+        code_rate: Aggregate code rate in (0, 1].
+        required_eb_n0: Eb/N0 threshold as Decibel.
+        metric: Error metric ("BER", "WER", "FER", or "PER"; default "BER").
+        error_rate: Error rate at the threshold (default 1e-6).
+    """
+    def __new__(
+        cls,
+        name: str,
+        modulation: Modulation,
+        code_rate: float,
+        required_eb_n0: Decibel,
+        metric: str = "BER",
+        error_rate: float = 1e-6,
+    ) -> Self: ...
+    @staticmethod
+    def dvb_s2() -> list[ModCod]:
+        """Returns the DVB-S2 MODCOD table (normal FECFRAME, no pilots),
+        per ETSI EN 302 307-1 Table 13."""
+        ...
+    @staticmethod
+    def select(es_n0: Decibel, margin: Decibel, table: list[ModCod]) -> ModCod | None:
+        """Selects the highest-efficiency MODCOD that closes at the given
+        Es/N0 with the given margin, or None when none does."""
+        ...
+    @property
+    def name(self) -> str:
+        """Name of the scheme."""
+        ...
+    @property
+    def modulation(self) -> Modulation:
+        """Modulation scheme."""
+        ...
+    @property
+    def code_rate(self) -> float:
+        """Overall code rate: the product of the coding chain's rates."""
+        ...
+    @property
+    def codes(self) -> list[tuple[str, float]]:
+        """The coding chain as (name, rate) tuples in encoding order."""
+        ...
+    @property
+    def info_bits_per_symbol(self) -> float:
+        """Information bits per symbol including all coding and framing overhead."""
+        ...
+    @property
+    def required_eb_n0(self) -> Decibel:
+        """Required Eb/N0 threshold."""
+        ...
+    @property
+    def required_es_n0(self) -> Decibel:
+        """Required Es/N0 threshold."""
+        ...
+    @property
+    def metric(self) -> str:
+        """Error metric of the threshold."""
+        ...
+    @property
+    def error_rate(self) -> float:
+        """Error rate at the threshold."""
+        ...
+    @property
+    def reference(self) -> str:
+        """Source of the mode definition."""
+        ...
+    def information_rate(self, symbol_rate: Frequency) -> Frequency:
+        """Returns the information bit rate at the given symbol rate."""
+        ...
+    def evaluate(
+        self,
+        link: LinkStats,
+        channel: Channel,
+        design_margin: Decibel | None = None,
+    ) -> ModulatedLinkStats:
+        """Evaluates a link budget on a channel against this MODCOD."""
+        ...
+    def __eq__(self, other: object) -> bool: ...
+    def __repr__(self) -> str: ...
+
+class PropagationLosses:class PropagationLosses:
     """Itemized excess propagation losses along a link path, beyond
     free-space path loss.
 
@@ -2990,18 +3062,29 @@ class InterferenceStats:
     def __repr__(self) -> str: ...
 
 class ModulatedLinkStats:
-    """Link-budget output with modulation/coding figures applied."""
+    """Link-budget output with a modulation and coding scheme applied."""
     @property
     def link(self) -> LinkStats:
         """The underlying modulation-agnostic link budget."""
         ...
     @property
     def channel(self) -> Channel:
-        """The channel (modulation, FEC, required Eb/N0, margin) applied."""
+        """The waveform the link was evaluated on."""
+        ...
+    @property
+    def modcod(self) -> ModCod:
+        """The modulation and coding scheme the link was evaluated against."""
+        ...
+    @property
+    def design_margin(self) -> Decibel:
+        """Design margin applied on top of the MODCOD threshold."""
         ...
     @property
     def symbol_rate(self) -> Frequency:
         """Symbol rate from the channel."""
+        ...
+    def information_rate(self) -> Frequency:
+        """Information bit rate: symbol rate × info bits per symbol."""
         ...
     @property
     def es_n0(self) -> Decibel:


### PR DESCRIPTION
- **refactor(lox-comms)!: restructure channel layer around waveform/modcod split**
- **feat(lox-space)!: rebind Python channel API to waveform/modcod split**
- **fix: bandwidth-mismatch guard in evaluate, stale docs, broken pyi stub**
