### PR TITLE
Refactor high-level link budget API

### DIFF
--- a/crates/lox-comms/src/channel.rs
+++ b/crates/lox-comms/src/channel.rs
@@ -8,7 +8,7 @@
 //! shaping, and optional DSSS spreading — and nothing else. What is
 //! transmitted on it (modulation and coding) is a
 //! [`ModCod`](crate::modcod::ModCod); link direction lives on
-//! [`LinkParameters`](crate::link_budget::LinkParameters); acceptance
+//! [`LinkConditions`](crate::link_budget::LinkConditions); acceptance
 //! criteria (required Eb/N0, design margin) are evaluation inputs.
 
 use core::fmt;

--- a/crates/lox-comms/src/error.rs
+++ b/crates/lox-comms/src/error.rs
@@ -75,19 +75,6 @@ pub enum LinkBudgetError {
         /// The link end's frequency range.
         band: FrequencyRange,
     },
-    /// The link budget's noise bandwidth does not match the channel's
-    /// occupied bandwidth.
-    #[error(
-        "link noise bandwidth {} Hz does not match the channel bandwidth {} Hz",
-        link.to_hertz(),
-        channel.to_hertz()
-    )]
-    BandwidthMismatch {
-        /// The noise bandwidth the link budget was computed with.
-        link: Frequency,
-        /// The channel's occupied bandwidth.
-        channel: Frequency,
-    },
 }
 
 #[cfg(test)]

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -467,20 +467,27 @@ impl LinkBudget {
 
     /// Returns the carrier-to-noise ratio in the given noise bandwidth:
     /// C/N = C/N₀ − 10·log₁₀(BW).
-    pub fn c_n(&self, bandwidth: Frequency) -> Decibel {
-        self.c_n0 - Decibel::from_linear(bandwidth.to_hertz())
+    ///
+    /// Rejects a non-finite or non-positive bandwidth.
+    pub fn c_n(&self, bandwidth: Frequency) -> Result<Decibel, LinkBudgetError> {
+        NonPhysicalError::check_positive("noise bandwidth [Hz]", bandwidth.to_hertz())?;
+        Ok(self.c_n0 - Decibel::from_linear(bandwidth.to_hertz()))
     }
 
     /// Returns the noise power in the given bandwidth, when the receive end
     /// exposes absolute terms: N = k·T_sys·BW.
-    pub fn noise_power(&self, bandwidth: Frequency) -> Option<Decibel> {
-        self.rx_terms.as_ref().map(|terms| {
+    ///
+    /// `Ok(None)` for aggregate-figure ends; rejects a non-finite or
+    /// non-positive bandwidth.
+    pub fn noise_power(&self, bandwidth: Frequency) -> Result<Option<Decibel>, LinkBudgetError> {
+        NonPhysicalError::check_positive("noise bandwidth [Hz]", bandwidth.to_hertz())?;
+        Ok(self.rx_terms.as_ref().map(|terms| {
             Decibel::from_linear(
                 terms.system_noise_temperature().to_kelvin()
                     * BOLTZMANN_CONSTANT
                     * bandwidth.to_hertz(),
             )
-        })
+        }))
     }
 
     /// Selects and applies the best MODCOD from a table: the
@@ -585,7 +592,7 @@ impl ModulatedLinkBudget {
         let bandwidth = self.channel.bandwidth();
         let noise_linear = self
             .budget
-            .noise_power(bandwidth)
+            .noise_power(bandwidth)?
             .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?
             .to_linear();
         let carrier = self
@@ -750,7 +757,7 @@ mod tests {
         // The default rx_terms is None: no absolute powers.
         assert!(stats.carrier_rx_power.is_none());
         assert!(stats.rx_terms.is_none());
-        assert!(stats.noise_power(5.0.mhz()).is_none());
+        assert!(stats.noise_power(5.0.mhz()).unwrap().is_none());
     }
 
     #[test]
@@ -787,7 +794,7 @@ mod tests {
             atol <= 0.01
         );
         assert!(stats.rx_terms.is_some());
-        assert!(stats.noise_power(5.0.mhz()).is_some());
+        assert!(stats.noise_power(5.0.mhz()).unwrap().is_some());
     }
 
     #[test]
@@ -796,7 +803,7 @@ mod tests {
         let stats = component_stats();
         let bandwidth = 5.0.mhz();
         let c_n0_from_power = stats.carrier_rx_power.unwrap()
-            - stats.noise_power(bandwidth).unwrap()
+            - stats.noise_power(bandwidth).unwrap().unwrap()
             + Decibel::from_linear(bandwidth.to_hertz());
         assert_approx_eq!(stats.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
     }
@@ -807,7 +814,7 @@ mod tests {
         assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.01);
         assert!(stats.carrier_rx_power.is_none());
         assert!(stats.rx_terms.is_none());
-        assert!(stats.noise_power(5.0.mhz()).is_none());
+        assert!(stats.noise_power(5.0.mhz()).unwrap().is_none());
     }
 
     #[test]
@@ -933,7 +940,7 @@ mod tests {
         // C/N0 consistency holds with the degraded noise power.
         let bandwidth = 5.0.mhz();
         let c_n0_from_power = faded.carrier_rx_power.unwrap()
-            - faded.noise_power(bandwidth).unwrap()
+            - faded.noise_power(bandwidth).unwrap().unwrap()
             + Decibel::from_linear(bandwidth.to_hertz());
         assert_approx_eq!(faded.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
     }
@@ -1057,11 +1064,31 @@ mod tests {
         // C/N derives from the channel's occupied bandwidth.
         assert_approx_eq!(
             m.c_n.as_f64(),
-            m.budget.c_n(channel().bandwidth()).as_f64(),
+            m.budget.c_n(channel().bandwidth()).unwrap().as_f64(),
             atol <= 1e-12
         );
         // The link closes comfortably.
         assert!(m.closes());
+    }
+
+    #[test]
+    fn test_views_reject_non_physical_bandwidth() {
+        let budget = component_stats();
+        for bandwidth in [
+            Frequency::hertz(0.0),
+            Frequency::hertz(-5e6),
+            Frequency::hertz(f64::NAN),
+            Frequency::hertz(f64::INFINITY),
+        ] {
+            assert!(matches!(
+                budget.c_n(bandwidth),
+                Err(LinkBudgetError::NonPhysical { .. })
+            ));
+            assert!(matches!(
+                budget.noise_power(bandwidth),
+                Err(LinkBudgetError::NonPhysical { .. })
+            ));
+        }
     }
 
     #[test]

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -474,20 +474,23 @@ impl LinkBudget {
         Ok(self.c_n0 - Decibel::from_linear(bandwidth.to_hertz()))
     }
 
-    /// Returns the noise power in the given bandwidth, when the receive end
-    /// exposes absolute terms: N = k·T_sys·BW.
+    /// Returns the noise power in the given bandwidth: N = k·T_sys·BW.
     ///
-    /// `Ok(None)` for aggregate-figure ends; rejects a non-finite or
-    /// non-positive bandwidth.
-    pub fn noise_power(&self, bandwidth: Frequency) -> Result<Option<Decibel>, LinkBudgetError> {
+    /// Rejects a non-finite or non-positive bandwidth, and returns
+    /// [`LinkBudgetError::AbsolutePowerUnavailable`] for aggregate-figure
+    /// ends (check [`Self::rx_terms`] to probe availability without an
+    /// error).
+    pub fn noise_power(&self, bandwidth: Frequency) -> Result<Decibel, LinkBudgetError> {
         NonPhysicalError::check_positive("noise bandwidth [Hz]", bandwidth.to_hertz())?;
-        Ok(self.rx_terms.as_ref().map(|terms| {
-            Decibel::from_linear(
-                terms.system_noise_temperature().to_kelvin()
-                    * BOLTZMANN_CONSTANT
-                    * bandwidth.to_hertz(),
-            )
-        }))
+        let terms = self
+            .rx_terms
+            .as_ref()
+            .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?;
+        Ok(Decibel::from_linear(
+            terms.system_noise_temperature().to_kelvin()
+                * BOLTZMANN_CONSTANT
+                * bandwidth.to_hertz(),
+        ))
     }
 
     /// Selects and applies the best MODCOD from a table: the
@@ -590,11 +593,7 @@ impl ModulatedLinkBudget {
             interference_power.to_watts(),
         )?;
         let bandwidth = self.channel.bandwidth();
-        let noise_linear = self
-            .budget
-            .noise_power(bandwidth)?
-            .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?
-            .to_linear();
+        let noise_linear = self.budget.noise_power(bandwidth)?.to_linear();
         let carrier = self
             .budget
             .carrier_rx_power
@@ -757,7 +756,10 @@ mod tests {
         // The default rx_terms is None: no absolute powers.
         assert!(stats.carrier_rx_power.is_none());
         assert!(stats.rx_terms.is_none());
-        assert!(stats.noise_power(5.0.mhz()).unwrap().is_none());
+        assert!(matches!(
+            stats.noise_power(5.0.mhz()),
+            Err(LinkBudgetError::AbsolutePowerUnavailable)
+        ));
     }
 
     #[test]
@@ -794,7 +796,7 @@ mod tests {
             atol <= 0.01
         );
         assert!(stats.rx_terms.is_some());
-        assert!(stats.noise_power(5.0.mhz()).unwrap().is_some());
+        assert!(stats.noise_power(5.0.mhz()).is_ok());
     }
 
     #[test]
@@ -803,7 +805,7 @@ mod tests {
         let stats = component_stats();
         let bandwidth = 5.0.mhz();
         let c_n0_from_power = stats.carrier_rx_power.unwrap()
-            - stats.noise_power(bandwidth).unwrap().unwrap()
+            - stats.noise_power(bandwidth).unwrap()
             + Decibel::from_linear(bandwidth.to_hertz());
         assert_approx_eq!(stats.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
     }
@@ -814,7 +816,10 @@ mod tests {
         assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.01);
         assert!(stats.carrier_rx_power.is_none());
         assert!(stats.rx_terms.is_none());
-        assert!(stats.noise_power(5.0.mhz()).unwrap().is_none());
+        assert!(matches!(
+            stats.noise_power(5.0.mhz()),
+            Err(LinkBudgetError::AbsolutePowerUnavailable)
+        ));
     }
 
     #[test]
@@ -940,7 +945,7 @@ mod tests {
         // C/N0 consistency holds with the degraded noise power.
         let bandwidth = 5.0.mhz();
         let c_n0_from_power = faded.carrier_rx_power.unwrap()
-            - faded.noise_power(bandwidth).unwrap().unwrap()
+            - faded.noise_power(bandwidth).unwrap()
             + Decibel::from_linear(bandwidth.to_hertz());
         assert_approx_eq!(faded.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
     }

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -4,9 +4,9 @@
 
 //! Link budget calculations and the contracts they consume.
 //!
-//! [`LinkStats::for_link`] computes a modulation-agnostic budget between any
+//! [`LinkBudget::new`] computes a modulation-agnostic budget between any
 //! transmit end implementing [`Eirp`] and any receive end implementing
-//! [`GOverT`], under the conditions captured in [`LinkParameters`]. The
+//! [`GOverT`], under the conditions captured in [`LinkConditions`]. The
 //! built-in implementors live in [`terminal`](crate::terminal); custom ends
 //! only need to answer the trait questions.
 
@@ -72,9 +72,32 @@ pub trait Eirp {
 /// Available when the receive end is more than an aggregate figure; they
 /// allow absolute carrier and noise powers (and thus interference analysis).
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "RxTermsRepr")
+)]
 pub struct RxTerms {
     gain: Decibel,
     system_noise_temperature: Temperature,
+}
+
+/// Serde wire format for [`RxTerms`]: forces deserialization through the
+/// validated constructor.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+struct RxTermsRepr {
+    gain: Decibel,
+    system_noise_temperature: Temperature,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<RxTermsRepr> for RxTerms {
+    type Error = NonPhysicalError;
+
+    fn try_from(repr: RxTermsRepr) -> Result<Self, Self::Error> {
+        RxTerms::new(repr.gain, repr.system_noise_temperature)
+    }
 }
 
 impl RxTerms {
@@ -174,22 +197,20 @@ pub struct InterferenceStats {
     pub margin_with_interference: Decibel,
 }
 
-/// The conditions a link budget is evaluated under: carrier, noise
-/// bandwidth, slant range, environmental losses, and the pointing at each
-/// end.
+/// The conditions a link budget is evaluated under: carrier, slant range,
+/// environmental losses, link direction, and the pointing at each end.
 ///
-/// Valid by construction — [`LinkParameters::builder`] validates the
-/// physical inputs, so [`LinkStats::for_link`] only fails on physics (a
+/// Valid by construction — [`LinkConditions::builder`] validates the
+/// physical inputs, so [`LinkBudget::new`] only fails on physics (a
 /// carrier outside a terminal's band or an unresolvable pointing).
 #[derive(Debug, Clone)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
-    serde(try_from = "LinkParametersRepr")
+    serde(try_from = "LinkConditionsRepr")
 )]
-pub struct LinkParameters {
+pub struct LinkConditions {
     carrier: Frequency,
-    bandwidth: Frequency,
     range: Distance,
     losses: PropagationLosses,
     tx_pointing: Pointing,
@@ -197,13 +218,12 @@ pub struct LinkParameters {
     direction: Option<LinkDirection>,
 }
 
-/// Serde wire format for [`LinkParameters`]: forces deserialization through
+/// Serde wire format for [`LinkConditions`]: forces deserialization through
 /// the validated builder.
 #[cfg(feature = "serde")]
 #[derive(serde::Deserialize)]
-struct LinkParametersRepr {
+struct LinkConditionsRepr {
     carrier: Frequency,
-    bandwidth: Frequency,
     range: Distance,
     #[serde(default = "PropagationLosses::none")]
     losses: PropagationLosses,
@@ -216,11 +236,11 @@ struct LinkParametersRepr {
 }
 
 #[cfg(feature = "serde")]
-impl TryFrom<LinkParametersRepr> for LinkParameters {
+impl TryFrom<LinkConditionsRepr> for LinkConditions {
     type Error = NonPhysicalError;
 
-    fn try_from(repr: LinkParametersRepr) -> Result<Self, Self::Error> {
-        let mut builder = LinkParameters::builder(repr.carrier, repr.bandwidth, repr.range)
+    fn try_from(repr: LinkConditionsRepr) -> Result<Self, Self::Error> {
+        let mut builder = LinkConditions::builder(repr.carrier, repr.range)
             .losses(repr.losses)
             .tx_pointing(repr.tx_pointing)
             .rx_pointing(repr.rx_pointing);
@@ -231,19 +251,15 @@ impl TryFrom<LinkParametersRepr> for LinkParameters {
     }
 }
 
-impl LinkParameters {
-    /// Starts building link parameters for the given carrier, noise
-    /// bandwidth, and slant range.
+impl LinkConditions {
+    /// Starts building link conditions for the given carrier and slant
+    /// range.
     ///
-    /// Losses default to none and both pointings to boresight.
-    pub fn builder(
-        carrier: Frequency,
-        bandwidth: Frequency,
-        range: Distance,
-    ) -> LinkParametersBuilder {
-        LinkParametersBuilder {
+    /// Losses default to none, both pointings to boresight, and the
+    /// direction to unspecified.
+    pub fn builder(carrier: Frequency, range: Distance) -> LinkConditionsBuilder {
+        LinkConditionsBuilder {
             carrier,
-            bandwidth,
             range,
             losses: PropagationLosses::none(),
             tx_pointing: Pointing::Boresight,
@@ -255,11 +271,6 @@ impl LinkParameters {
     /// Returns the carrier frequency.
     pub fn carrier(&self) -> Frequency {
         self.carrier
-    }
-
-    /// Returns the noise bandwidth.
-    pub fn bandwidth(&self) -> Frequency {
-        self.bandwidth
     }
 
     /// Returns the slant range between TX and RX.
@@ -288,14 +299,13 @@ impl LinkParameters {
     }
 }
 
-/// Builder for [`LinkParameters`].
+/// Builder for [`LinkConditions`].
 ///
-/// Created via [`LinkParameters::builder`]. Inputs are validated at
-/// [`LinkParametersBuilder::build`].
+/// Created via [`LinkConditions::builder`]. Inputs are validated at
+/// [`LinkConditionsBuilder::build`].
 #[derive(Debug, Clone)]
-pub struct LinkParametersBuilder {
+pub struct LinkConditionsBuilder {
     carrier: Frequency,
-    bandwidth: Frequency,
     range: Distance,
     losses: PropagationLosses,
     tx_pointing: Pointing,
@@ -303,7 +313,7 @@ pub struct LinkParametersBuilder {
     direction: Option<LinkDirection>,
 }
 
-impl LinkParametersBuilder {
+impl LinkConditionsBuilder {
     /// Sets the environmental losses.
     pub fn losses(mut self, losses: PropagationLosses) -> Self {
         self.losses = losses;
@@ -334,21 +344,19 @@ impl LinkParametersBuilder {
         self
     }
 
-    /// Builds the link parameters, validating all physical inputs.
+    /// Builds the link conditions, validating all physical inputs.
     ///
-    /// Rejects a non-finite or non-positive carrier frequency, noise
-    /// bandwidth, or slant range.
-    pub fn build(self) -> Result<LinkParameters, NonPhysicalError> {
+    /// Rejects a non-finite or non-positive carrier frequency or slant
+    /// range.
+    pub fn build(self) -> Result<LinkConditions, NonPhysicalError> {
         for (quantity, value) in [
             ("carrier frequency [Hz]", self.carrier.to_hertz()),
-            ("noise bandwidth [Hz]", self.bandwidth.to_hertz()),
             ("slant range [m]", self.range.to_meters()),
         ] {
             NonPhysicalError::check_positive(quantity, value)?;
         }
-        Ok(LinkParameters {
+        Ok(LinkConditions {
             carrier: self.carrier,
-            bandwidth: self.bandwidth,
             range: self.range,
             losses: self.losses,
             tx_pointing: self.tx_pointing,
@@ -361,7 +369,7 @@ impl LinkParametersBuilder {
 /// Modulation-agnostic link budget output.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct LinkStats {
+pub struct LinkBudget {
     /// Slant range between TX and RX.
     pub slant_range: Distance,
     /// Carrier frequency.
@@ -382,18 +390,14 @@ pub struct LinkStats {
     pub losses: PropagationLosses,
     /// Received carrier power. `None` for receive ends without [`RxTerms`].
     pub carrier_rx_power: Option<Decibel>,
-    /// Noise power in the channel bandwidth. `None` for receive ends without
-    /// [`RxTerms`].
-    pub noise_power: Option<Decibel>,
-    /// Channel noise bandwidth.
-    pub bandwidth: Frequency,
+    /// Effective receive terms the budget was computed with (rain-degraded
+    /// on downlinks). `None` for aggregate-figure ends.
+    pub rx_terms: Option<RxTerms>,
     /// Carrier-to-noise density ratio (C/N₀).
     pub c_n0: Decibel,
-    /// Carrier-to-noise ratio (C/N).
-    pub c_n: Decibel,
 }
 
-impl LinkStats {
+impl LinkBudget {
     /// Computes a modulation-agnostic link budget between two link ends
     /// under the given conditions.
     ///
@@ -402,13 +406,18 @@ impl LinkStats {
     /// budget uses the rain-degraded G/T when the receive end exposes
     /// degradable terms (see [`GOverT::rx_terms_degraded`]); aggregate G/T
     /// figures stay at their clear-sky value.
-    pub fn for_link(
+    ///
+    /// All outputs are bandwidth-free; carrier-to-noise ratio and noise
+    /// power are derived views ([`Self::c_n`], [`Self::noise_power`]), and
+    /// [`Self::modulate`] takes everything bandwidth-dependent from the
+    /// channel.
+    pub fn new(
         tx: &impl Eirp,
         rx: &impl GOverT,
-        params: &LinkParameters,
+        conditions: &LinkConditions,
     ) -> Result<Self, LinkBudgetError> {
+        let params = conditions;
         let carrier = params.carrier;
-        let bandwidth = params.bandwidth;
 
         let eirp = tx.eirp_at(carrier, params.tx_pointing)?;
         let rx_terms = rx.rx_terms(carrier, params.rx_pointing)?;
@@ -436,18 +445,10 @@ impl LinkStats {
         let env_loss = params.losses.total();
 
         let c_n0 = eirp + effective_gt - fspl - env_loss - BOLTZMANN_CONSTANT_DB;
-        let c_n = c_n0 - Decibel::from_linear(bandwidth.to_hertz());
 
         let carrier_rx_power = effective_terms
             .as_ref()
             .map(|terms| eirp - fspl - env_loss + terms.gain());
-        let noise_power = effective_terms.as_ref().map(|terms| {
-            Decibel::from_linear(
-                terms.system_noise_temperature().to_kelvin()
-                    * BOLTZMANN_CONSTANT
-                    * bandwidth.to_hertz(),
-            )
-        });
 
         Ok(Self {
             slant_range: params.range,
@@ -459,20 +460,64 @@ impl LinkStats {
             direction: params.direction,
             losses: params.losses.clone(),
             carrier_rx_power,
-            noise_power,
-            bandwidth,
+            rx_terms: effective_terms,
             c_n0,
-            c_n,
         })
+    }
+
+    /// Returns the carrier-to-noise ratio in the given noise bandwidth:
+    /// C/N = C/N₀ − 10·log₁₀(BW).
+    pub fn c_n(&self, bandwidth: Frequency) -> Decibel {
+        self.c_n0 - Decibel::from_linear(bandwidth.to_hertz())
+    }
+
+    /// Returns the noise power in the given bandwidth, when the receive end
+    /// exposes absolute terms: N = k·T_sys·BW.
+    pub fn noise_power(&self, bandwidth: Frequency) -> Option<Decibel> {
+        self.rx_terms.as_ref().map(|terms| {
+            Decibel::from_linear(
+                terms.system_noise_temperature().to_kelvin()
+                    * BOLTZMANN_CONSTANT
+                    * bandwidth.to_hertz(),
+            )
+        })
+    }
+
+    /// Applies a waveform and a modulation and coding scheme to this budget.
+    ///
+    /// Everything bandwidth-dependent derives from the channel: Es/N0 from
+    /// its symbol rate, C/N from its occupied bandwidth, Eb/N0 through the
+    /// MODCOD's exact information bits per symbol, and the link margin
+    /// against the MODCOD's threshold plus the design margin.
+    pub fn modulate(
+        &self,
+        channel: &Channel,
+        modcod: &ModCod,
+        design_margin: Decibel,
+    ) -> ModulatedLinkBudget {
+        let es_n0 = channel.es_n0(self.c_n0);
+        let c_n = channel.c_n(self.c_n0);
+        let eb_n0 = es_n0 - Decibel::from_linear(modcod.mode().info_bits_per_symbol());
+        let margin = eb_n0 - modcod.required_eb_n0() - design_margin;
+        ModulatedLinkBudget {
+            budget: self.clone(),
+            channel: channel.clone(),
+            modcod: modcod.clone(),
+            design_margin,
+            es_n0,
+            eb_n0,
+            c_n,
+            margin,
+        }
     }
 }
 
 /// Link-budget output with a modulation and coding scheme applied.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ModulatedLinkStats {
+pub struct ModulatedLinkBudget {
     /// The modulation-agnostic link budget.
-    pub link: LinkStats,
+    pub budget: LinkBudget,
     /// The waveform the link is evaluated on.
     pub channel: Channel,
     /// The modulation and coding scheme the link is evaluated against.
@@ -483,49 +528,16 @@ pub struct ModulatedLinkStats {
     pub es_n0: Decibel,
     /// Eb/N0 (energy per information bit to noise spectral density).
     pub eb_n0: Decibel,
+    /// Carrier-to-noise ratio in the channel's occupied bandwidth.
+    pub c_n: Decibel,
     /// Link margin: Eb/N0 − required Eb/N0 − design margin.
     pub margin: Decibel,
 }
 
-impl ModulatedLinkStats {
-    /// Evaluates a link budget against a waveform and a MODCOD.
-    ///
-    /// Computes Es/N0 from the channel's symbol rate, Eb/N0 through the
-    /// MODCOD's exact information bits per symbol, and the link margin
-    /// against the MODCOD's threshold plus the design margin.
-    ///
-    /// The link's noise bandwidth must match the channel's occupied
-    /// bandwidth (within 1 ppm) — the link's noise power and C/N were
-    /// computed with it, and a mismatch would silently skew interference
-    /// margins. Compute the budget with
-    /// [`Channel::bandwidth`](crate::channel::Channel::bandwidth).
-    pub fn evaluate(
-        link: LinkStats,
-        channel: &Channel,
-        modcod: &ModCod,
-        design_margin: Decibel,
-    ) -> Result<Self, LinkBudgetError> {
-        let link_bw = link.bandwidth.to_hertz();
-        let channel_bw = channel.bandwidth().to_hertz();
-        if (link_bw - channel_bw).abs() > 1e-6 * channel_bw {
-            return Err(LinkBudgetError::BandwidthMismatch {
-                link: link.bandwidth,
-                channel: channel.bandwidth(),
-            });
-        }
-
-        let es_n0 = channel.es_n0(link.c_n0);
-        let eb_n0 = es_n0 - Decibel::from_linear(modcod.mode().info_bits_per_symbol());
-        let margin = eb_n0 - modcod.required_eb_n0() - design_margin;
-        Ok(Self {
-            link,
-            channel: channel.clone(),
-            modcod: modcod.clone(),
-            design_margin,
-            es_n0,
-            eb_n0,
-            margin,
-        })
+impl ModulatedLinkBudget {
+    /// Returns whether the link closes: margin ≥ 0.
+    pub fn closes(&self) -> bool {
+        self.margin.as_f64() >= 0.0
     }
 
     /// Returns the symbol rate of the underlying channel.
@@ -552,20 +564,21 @@ impl ModulatedLinkStats {
             "interference power [W]",
             interference_power.to_watts(),
         )?;
+        let bandwidth = self.channel.bandwidth();
         let noise_linear = self
-            .link
-            .noise_power
+            .budget
+            .noise_power(bandwidth)
             .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?
             .to_linear();
         let carrier = self
-            .link
+            .budget
             .carrier_rx_power
             .ok_or(LinkBudgetError::AbsolutePowerUnavailable)?;
 
         let total_ni = noise_linear + interference_power.to_watts();
-        let c_n0i0 = carrier - Decibel::from_linear(total_ni)
-            + Decibel::from_linear(self.link.bandwidth.to_hertz());
-        let c_n0_to_eb_n0 = self.eb_n0 - self.link.c_n0;
+        let c_n0i0 =
+            carrier - Decibel::from_linear(total_ni) + Decibel::from_linear(bandwidth.to_hertz());
+        let c_n0_to_eb_n0 = self.eb_n0 - self.budget.c_n0;
         let eb_n0i0 = c_n0i0 + c_n0_to_eb_n0;
 
         let threshold = self.eb_n0 - self.margin;
@@ -661,47 +674,23 @@ mod tests {
         .unwrap()
     }
 
-    fn link_params(bandwidth: Frequency) -> LinkParameters {
-        LinkParameters::builder(29.0.ghz(), bandwidth, Distance::kilometers(1000.0))
+    fn link_conditions() -> LinkConditions {
+        LinkConditions::builder(29.0.ghz(), Distance::kilometers(1000.0))
             .build()
             .unwrap()
     }
 
-    fn component_stats() -> LinkStats {
-        LinkStats::for_link(
-            &tx_chain(),
-            &rx_chain(),
-            &link_params(channel().bandwidth()),
-        )
-        .unwrap()
+    fn component_stats() -> LinkBudget {
+        LinkBudget::new(&tx_chain(), &rx_chain(), &link_conditions()).unwrap()
     }
 
-    fn lumped_stats() -> LinkStats {
-        LinkStats::for_link(
+    fn lumped_stats() -> LinkBudget {
+        LinkBudget::new(
             &EirpModel::new(ka_band(), 55.0.db()).unwrap(),
             &GtModel::new(ka_band(), 3.01.db()).unwrap(),
-            &link_params(5.0.mhz()),
+            &link_conditions(),
         )
         .unwrap()
-    }
-
-    fn lumped_stats_with_channel_bandwidth() -> LinkStats {
-        LinkStats::for_link(
-            &EirpModel::new(ka_band(), 55.0.db()).unwrap(),
-            &GtModel::new(ka_band(), 3.01.db()).unwrap(),
-            &link_params(channel().bandwidth()),
-        )
-        .unwrap()
-    }
-
-    #[test]
-    fn test_evaluate_rejects_bandwidth_mismatch() {
-        // The lumped fixture was computed with a 5 MHz noise bandwidth, not
-        // the channel's 6.75 MHz occupied bandwidth.
-        let err = ModulatedLinkStats::evaluate(lumped_stats(), &channel(), &modcod(), 0.0.db())
-            .unwrap_err();
-        assert!(matches!(err, LinkBudgetError::BandwidthMismatch { .. }));
-        assert!(err.to_string().contains("does not match"));
     }
 
     /// Custom link ends only need the trait surface: a fixed-EIRP transmitter
@@ -738,11 +727,12 @@ mod tests {
         assert!(tx.band().contains(29.0.ghz()));
         assert!(rx.band().contains(29.0.ghz()));
 
-        let stats = LinkStats::for_link(&FixedTx, &FixedRx, &link_params(5.0.mhz())).unwrap();
+        let stats = LinkBudget::new(&FixedTx, &FixedRx, &link_conditions()).unwrap();
         assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.01);
         // The default rx_terms is None: no absolute powers.
         assert!(stats.carrier_rx_power.is_none());
-        assert!(stats.noise_power.is_none());
+        assert!(stats.rx_terms.is_none());
+        assert!(stats.noise_power(5.0.mhz()).is_none());
     }
 
     #[test]
@@ -778,15 +768,18 @@ mod tests {
             -96.696,
             atol <= 0.01
         );
-        assert!(stats.noise_power.is_some());
+        assert!(stats.rx_terms.is_some());
+        assert!(stats.noise_power(5.0.mhz()).is_some());
     }
 
     #[test]
     fn test_for_link_c_n0_consistency() {
         // C/N0 must equal P_rx − P_noise + 10·log10(BW).
         let stats = component_stats();
-        let c_n0_from_power = stats.carrier_rx_power.unwrap() - stats.noise_power.unwrap()
-            + Decibel::from_linear(stats.bandwidth.to_hertz());
+        let bandwidth = 5.0.mhz();
+        let c_n0_from_power = stats.carrier_rx_power.unwrap()
+            - stats.noise_power(bandwidth).unwrap()
+            + Decibel::from_linear(bandwidth.to_hertz());
         assert_approx_eq!(stats.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
     }
 
@@ -795,20 +788,21 @@ mod tests {
         let stats = lumped_stats();
         assert_approx_eq!(stats.c_n0.as_f64(), 104.913, atol <= 0.01);
         assert!(stats.carrier_rx_power.is_none());
-        assert!(stats.noise_power.is_none());
+        assert!(stats.rx_terms.is_none());
+        assert!(stats.noise_power(5.0.mhz()).is_none());
     }
 
     #[test]
     fn test_for_link_rejects_carrier_out_of_band() {
         // 29 GHz fits the TX band but not the RX band.
-        let err = LinkStats::for_link(
+        let err = LinkBudget::new(
             &EirpModel::new(ka_band(), 55.0.db()).unwrap(),
             &GtModel::new(
                 FrequencyRange::new(17.0.ghz(), 21.0.ghz()).unwrap(),
                 3.01.db(),
             )
             .unwrap(),
-            &link_params(5.0.mhz()),
+            &link_conditions(),
         )
         .unwrap_err();
 
@@ -818,61 +812,38 @@ mod tests {
 
     #[test]
     fn test_for_link_rejects_carrier_out_of_band_on_tx_side() {
-        let err = LinkStats::for_link(
+        let err = LinkBudget::new(
             &EirpModel::new(
                 FrequencyRange::new(17.0.ghz(), 21.0.ghz()).unwrap(),
                 55.0.db(),
             )
             .unwrap(),
             &GtModel::new(ka_band(), 3.01.db()).unwrap(),
-            &link_params(5.0.mhz()),
+            &link_conditions(),
         )
         .unwrap_err();
         assert!(matches!(err, LinkBudgetError::CarrierOutOfBand { .. }));
     }
 
     #[test]
-    fn test_link_parameters_reject_non_physical_inputs() {
-        for (carrier, bandwidth, range) in [
-            (
-                Frequency::hertz(0.0),
-                5.0.mhz(),
-                Distance::kilometers(1000.0),
-            ),
-            (
-                Frequency::hertz(f64::NAN),
-                5.0.mhz(),
-                Distance::kilometers(1000.0),
-            ),
-            (
-                29.0.ghz(),
-                Frequency::hertz(0.0),
-                Distance::kilometers(1000.0),
-            ),
-            (
-                29.0.ghz(),
-                Frequency::hertz(-5e6),
-                Distance::kilometers(1000.0),
-            ),
-            (29.0.ghz(), 5.0.mhz(), Distance::kilometers(0.0)),
-            (29.0.ghz(), 5.0.mhz(), Distance::kilometers(-1.0)),
+    fn test_link_conditions_reject_non_physical_inputs() {
+        for (carrier, range) in [
+            (Frequency::hertz(0.0), Distance::kilometers(1000.0)),
+            (Frequency::hertz(f64::NAN), Distance::kilometers(1000.0)),
+            (29.0.ghz(), Distance::kilometers(0.0)),
+            (29.0.ghz(), Distance::kilometers(-1.0)),
         ] {
-            assert!(
-                LinkParameters::builder(carrier, bandwidth, range)
-                    .build()
-                    .is_err()
-            );
+            assert!(LinkConditions::builder(carrier, range).build().is_err());
         }
     }
 
     #[test]
     fn test_link_parameters_defaults() {
-        let params = link_params(5.0.mhz());
+        let params = link_conditions();
         assert_approx_eq!(params.losses().total().as_f64(), 0.0, atol <= 1e-15);
         assert_eq!(params.tx_pointing(), Pointing::Boresight);
         assert_eq!(params.rx_pointing(), Pointing::Boresight);
         assert_approx_eq!(params.carrier().to_gigahertz(), 29.0, rtol <= 1e-12);
-        assert_approx_eq!(params.bandwidth().to_megahertz(), 5.0, rtol <= 1e-12);
         assert_approx_eq!(params.range().to_meters(), 1e6, rtol <= 1e-12);
     }
 
@@ -887,10 +858,9 @@ mod tests {
             .unwrap()
     }
 
-    fn faded_params(direction: Option<LinkDirection>) -> LinkParameters {
+    fn faded_params(direction: Option<LinkDirection>) -> LinkConditions {
         let mut builder =
-            LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
-                .losses(p618_losses());
+            LinkConditions::builder(29.0.ghz(), Distance::kilometers(1000.0)).losses(p618_losses());
         if let Some(direction) = direction {
             builder = builder.direction(direction);
         }
@@ -917,8 +887,8 @@ mod tests {
 
     #[test]
     fn test_for_link_downlink_degrades_gt() {
-        let clear = LinkStats::for_link(&tx_chain(), &rx_chain(), &faded_params(None)).unwrap();
-        let faded = LinkStats::for_link(
+        let clear = LinkBudget::new(&tx_chain(), &rx_chain(), &faded_params(None)).unwrap();
+        let faded = LinkBudget::new(
             &tx_chain(),
             &rx_chain(),
             &faded_params(Some(LinkDirection::Downlink)),
@@ -943,18 +913,19 @@ mod tests {
         );
 
         // C/N0 consistency holds with the degraded noise power.
-        let c_n0_from_power = faded.carrier_rx_power.unwrap() - faded.noise_power.unwrap()
-            + Decibel::from_linear(faded.bandwidth.to_hertz());
+        let bandwidth = 5.0.mhz();
+        let c_n0_from_power = faded.carrier_rx_power.unwrap()
+            - faded.noise_power(bandwidth).unwrap()
+            + Decibel::from_linear(bandwidth.to_hertz());
         assert_approx_eq!(faded.c_n0.as_f64(), c_n0_from_power.as_f64(), atol <= 1e-10);
     }
 
     #[test]
     fn test_for_link_uplink_and_crosslink_stay_clear_sky() {
-        let clear = LinkStats::for_link(&tx_chain(), &rx_chain(), &faded_params(None)).unwrap();
+        let clear = LinkBudget::new(&tx_chain(), &rx_chain(), &faded_params(None)).unwrap();
         for direction in [LinkDirection::Uplink, LinkDirection::Crosslink] {
             let stats =
-                LinkStats::for_link(&tx_chain(), &rx_chain(), &faded_params(Some(direction)))
-                    .unwrap();
+                LinkBudget::new(&tx_chain(), &rx_chain(), &faded_params(Some(direction))).unwrap();
             assert!(stats.gt_degraded.is_none());
             assert_eq!(stats.direction, Some(direction));
             assert_approx_eq!(stats.c_n0.as_f64(), clear.c_n0.as_f64(), atol <= 1e-12);
@@ -966,20 +937,20 @@ mod tests {
         // An aggregate G/T figure cannot be degraded — documented caveat.
         let tx = EirpModel::new(ka_band(), 55.0.db()).unwrap();
         let rx = GtModel::new(ka_band(), 3.01.db()).unwrap();
-        let clear = LinkStats::for_link(&tx, &rx, &faded_params(None)).unwrap();
+        let clear = LinkBudget::new(&tx, &rx, &faded_params(None)).unwrap();
         let faded =
-            LinkStats::for_link(&tx, &rx, &faded_params(Some(LinkDirection::Downlink))).unwrap();
+            LinkBudget::new(&tx, &rx, &faded_params(Some(LinkDirection::Downlink))).unwrap();
         assert!(faded.gt_degraded.is_none());
         assert_approx_eq!(faded.c_n0.as_f64(), clear.c_n0.as_f64(), atol <= 1e-12);
     }
 
     #[test]
     fn test_for_link_downlink_without_absorption_is_a_no_op() {
-        let params = LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
+        let params = LinkConditions::builder(29.0.ghz(), Distance::kilometers(1000.0))
             .direction(LinkDirection::Downlink)
             .build()
             .unwrap();
-        let stats = LinkStats::for_link(&tx_chain(), &rx_chain(), &params).unwrap();
+        let stats = LinkBudget::new(&tx_chain(), &rx_chain(), &params).unwrap();
         // L_abs = 1: degraded equals clear-sky.
         assert_approx_eq!(
             stats.gt_degraded.unwrap().as_f64(),
@@ -992,7 +963,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_link_parameters_serde_round_trip_and_validation() {
-        let params = LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
+        let params = LinkConditions::builder(29.0.ghz(), Distance::kilometers(1000.0))
             .losses(p618_losses())
             .tx_pointing(Pointing::off_boresight(lox_core::units::Angle::degrees(
                 2.0,
@@ -1001,9 +972,8 @@ mod tests {
             .build()
             .unwrap();
         let json = serde_json::to_string(&params).unwrap();
-        let round_trip: LinkParameters = serde_json::from_str(&json).unwrap();
+        let round_trip: LinkConditions = serde_json::from_str(&json).unwrap();
         assert_eq!(round_trip.carrier(), params.carrier());
-        assert_eq!(round_trip.bandwidth(), params.bandwidth());
         assert_eq!(round_trip.range(), params.range());
         assert_eq!(round_trip.losses(), params.losses());
         assert_eq!(round_trip.tx_pointing(), params.tx_pointing());
@@ -1011,8 +981,8 @@ mod tests {
         assert_eq!(round_trip.direction(), params.direction());
 
         // Optional fields default: no losses, boresight, no direction.
-        let minimal: LinkParameters =
-            serde_json::from_str(r#"{"carrier":29.0e9,"bandwidth":5.0e6,"range":1.0e6}"#).unwrap();
+        let minimal: LinkConditions =
+            serde_json::from_str(r#"{"carrier":29.0e9,"range":1.0e6}"#).unwrap();
         assert_approx_eq!(minimal.losses().total().as_f64(), 0.0, atol <= 1e-15);
         assert_eq!(minimal.tx_pointing(), Pointing::Boresight);
         assert_eq!(minimal.rx_pointing(), Pointing::Boresight);
@@ -1020,11 +990,10 @@ mod tests {
 
         // Non-physical inputs are rejected at deserialization time.
         for bad in [
-            r#"{"carrier":0.0,"bandwidth":5.0e6,"range":1.0e6}"#,
-            r#"{"carrier":29.0e9,"bandwidth":-5.0e6,"range":1.0e6}"#,
-            r#"{"carrier":29.0e9,"bandwidth":5.0e6,"range":0.0}"#,
+            r#"{"carrier":0.0,"range":1.0e6}"#,
+            r#"{"carrier":29.0e9,"range":0.0}"#,
         ] {
-            assert!(serde_json::from_str::<LinkParameters>(bad).is_err());
+            assert!(serde_json::from_str::<LinkConditions>(bad).is_err());
         }
     }
 
@@ -1039,11 +1008,11 @@ mod tests {
             .build()
             .unwrap();
         let clear = lumped_stats();
-        let params = LinkParameters::builder(29.0.ghz(), 5.0.mhz(), Distance::kilometers(1000.0))
+        let params = LinkConditions::builder(29.0.ghz(), Distance::kilometers(1000.0))
             .losses(losses)
             .build()
             .unwrap();
-        let faded = LinkStats::for_link(
+        let faded = LinkBudget::new(
             &EirpModel::new(ka_band(), 55.0.db()).unwrap(),
             &GtModel::new(ka_band(), 3.01.db()).unwrap(),
             &params,
@@ -1057,9 +1026,9 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_produces_modulated_stats() {
+    fn test_modulate_produces_modulated_budget() {
         let stats = component_stats();
-        let m = ModulatedLinkStats::evaluate(stats, &channel(), &modcod(), 3.0.db()).unwrap();
+        let m = stats.modulate(&channel(), &modcod(), 3.0.db());
         // Eb/N0 ≈ 37.91 (QPSK 1/2 → 1 info bit/symbol, C/N0 ≈ 104.91 dB·Hz)
         assert_approx_eq!(m.eb_n0.as_f64(), 37.91, atol <= 0.02);
         // required_eb_n0 = 10, design margin = 3 → margin ≈ 24.91
@@ -1067,12 +1036,47 @@ mod tests {
         // Information rate: 5 Msps × 1 info bit/symbol.
         assert_approx_eq!(m.information_rate().to_hertz(), 5e6, rtol <= 1e-12);
         assert_approx_eq!(m.symbol_rate().to_hertz(), 5e6, rtol <= 1e-12);
+        // C/N derives from the channel's occupied bandwidth.
+        assert_approx_eq!(
+            m.c_n.as_f64(),
+            m.budget.c_n(channel().bandwidth()).as_f64(),
+            atol <= 1e-12
+        );
+        // The link closes comfortably.
+        assert!(m.closes());
+    }
+
+    #[test]
+    fn test_modulate_closes_boundary() {
+        // A MODCOD whose threshold sits exactly at the achieved Eb/N0 closes;
+        // one requiring more does not.
+        let stats = component_stats();
+        let m = stats.modulate(&channel(), &modcod(), 0.0.db());
+        let exact = ModCod::from_required_eb_n0(
+            "exact",
+            Modulation::Qpsk,
+            0.5,
+            m.eb_n0,
+            ErrorMetric::Ber,
+            1e-6,
+        )
+        .unwrap();
+        assert!(stats.modulate(&channel(), &exact, 0.0.db()).closes());
+        let too_hungry = ModCod::from_required_eb_n0(
+            "too hungry",
+            Modulation::Qpsk,
+            0.5,
+            m.eb_n0 + Decibel::new(0.1),
+            ErrorMetric::Ber,
+            1e-6,
+        )
+        .unwrap();
+        assert!(!stats.modulate(&channel(), &too_hungry, 0.0.db()).closes());
     }
 
     #[test]
     fn test_modulated_with_interference_reduces_margin() {
-        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db())
-            .unwrap();
+        let m = component_stats().modulate(&channel(), &modcod(), 3.0.db());
         let interference = m.with_interference(Power::watts(1e-12)).unwrap();
         assert!(interference.margin_with_interference.as_f64() <= m.margin.as_f64());
         assert!(interference.eb_n0i0.as_f64() <= m.eb_n0.as_f64());
@@ -1080,8 +1084,7 @@ mod tests {
 
     #[test]
     fn test_with_interference_rejects_non_physical_power() {
-        let m = ModulatedLinkStats::evaluate(component_stats(), &channel(), &modcod(), 3.0.db())
-            .unwrap();
+        let m = component_stats().modulate(&channel(), &modcod(), 3.0.db());
         for power in [-1e-12, f64::NAN, f64::INFINITY] {
             let err = m.with_interference(Power::watts(power)).unwrap_err();
             assert!(matches!(err, LinkBudgetError::NonPhysical { .. }));
@@ -1097,15 +1100,10 @@ mod tests {
 
     #[test]
     fn test_lumped_modulated_with_interference_is_error() {
-        let err = ModulatedLinkStats::evaluate(
-            lumped_stats_with_channel_bandwidth(),
-            &channel(),
-            &modcod(),
-            3.0.db(),
-        )
-        .unwrap()
-        .with_interference(Power::watts(1e-12))
-        .unwrap_err();
+        let err = lumped_stats()
+            .modulate(&channel(), &modcod(), 3.0.db())
+            .with_interference(Power::watts(1e-12))
+            .unwrap_err();
         assert_eq!(err, LinkBudgetError::AbsolutePowerUnavailable);
     }
 

--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -483,6 +483,24 @@ impl LinkBudget {
         })
     }
 
+    /// Selects and applies the best MODCOD from a table: the
+    /// highest-efficiency mode that closes on this channel with the given
+    /// design margin (adaptive coding and modulation).
+    ///
+    /// Selection and evaluation use the same channel and margin, so the
+    /// returned result always [`closes`](ModulatedLinkBudget::closes);
+    /// `None` means no mode in the table closes.
+    pub fn modulate_best(
+        &self,
+        channel: &Channel,
+        table: &[ModCod],
+        design_margin: Decibel,
+    ) -> Option<ModulatedLinkBudget> {
+        let es_n0 = channel.es_n0(self.c_n0);
+        let modcod = ModCod::select(es_n0, design_margin, table)?;
+        Some(self.modulate(channel, modcod, design_margin))
+    }
+
     /// Applies a waveform and a modulation and coding scheme to this budget.
     ///
     /// Everything bandwidth-dependent derives from the channel: Es/N0 from
@@ -1044,6 +1062,39 @@ mod tests {
         );
         // The link closes comfortably.
         assert!(m.closes());
+    }
+
+    #[test]
+    fn test_modulate_best_selects_and_closes() {
+        use crate::modcod::dvb_s2;
+
+        let budget = component_stats();
+        let m = budget
+            .modulate_best(&channel(), dvb_s2(), 3.0.db())
+            .unwrap();
+        // The integrated path agrees with manual selection + modulation.
+        let es_n0 = channel().es_n0(budget.c_n0);
+        let expected = ModCod::select(es_n0, 3.0.db(), dvb_s2()).unwrap();
+        assert_eq!(&m.modcod, expected);
+        assert_approx_eq!(
+            m.margin.as_f64(),
+            budget
+                .modulate(&channel(), expected, 3.0.db())
+                .margin
+                .as_f64(),
+            atol <= 1e-12
+        );
+        // Some always closes — that is the invariant.
+        assert!(m.closes());
+        // C/N0 ≈ 104.9 dB·Hz at 5 Msps → Es/N0 ≈ 37.9 dB: the top mode closes.
+        assert_eq!(m.modcod.mode().name(), "32APSK 9/10");
+
+        // An impossible margin closes nothing.
+        assert!(
+            budget
+                .modulate_best(&channel(), dvb_s2(), 100.0.db())
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/lox-comms/src/terminal.rs
+++ b/crates/lox-comms/src/terminal.rs
@@ -10,7 +10,7 @@
 //! ([`EirpModel`], [`GtModel`]). [`TxTerminal`] and [`RxTerminal`] are the
 //! storable either-tier types; all of them implement the link-end contracts
 //! [`Eirp`] and [`GOverT`] consumed by
-//! [`LinkStats::for_link`](crate::link_budget::LinkStats::for_link).
+//! [`LinkBudget::new`](crate::link_budget::LinkBudget::new).
 //!
 //! Terminals are anonymous values: naming, selection, and grouping (e.g. a
 //! transceiver sharing one dish, or a transmitter switchable between

--- a/crates/lox-space/docs/comms.md
+++ b/crates/lox-space/docs/comms.md
@@ -120,16 +120,16 @@ gt = rx.gt_at(29.0 * lox.GHz, angle=1.0 * lox.deg)
 t_sys = rx.system_noise_temperature()
 ```
 
-`LinkStats.for_link` computes a link budget between two terminals. The
-carrier is a link-level input and must lie inside both terminals'
-frequency ranges:
+`LinkBudget` computes a link budget between two terminals. The carrier is
+a link-level input and must lie inside both terminals' frequency ranges;
+all outputs are bandwidth-free (C/N and noise power are derived views that
+take an explicit bandwidth):
 
 ```python
-link = lox.LinkStats.for_link(
+link = lox.LinkBudget(
     tx,
     rx,
     carrier=29.0 * lox.GHz,
-    bandwidth=5.0 * lox.MHz,
     range=1000.0 * lox.km,
 )
 print(f"C/N0 = {float(link.c_n0):.2f} dB·Hz")
@@ -150,11 +150,10 @@ lumped `EirpModel` and `GtModel` terminals:
 ```python
 import lox_space as lox
 
-link = lox.LinkStats.for_link(
+link = lox.LinkBudget(
     lox.EirpModel("Ka", 55.0 * lox.dB),
     lox.GtModel("Ka", 3.01 * lox.dB),
     carrier=29.0 * lox.GHz,
-    bandwidth=5.0 * lox.MHz,
     range=1000.0 * lox.km,
 )
 print(f"C/N0 = {float(link.c_n0):.2f} dB·Hz")
@@ -165,17 +164,17 @@ the absolute carrier and noise power are not recoverable from EIRP and G/T
 alone. The carrier-to-noise density ratio (`c_n0`) and carrier-to-noise ratio
 (`c_n`) remain available.
 
-To compute modulation-aware figures (`Es/N0`, `Eb/N0`, link margin),
-evaluate the link on a `Channel` (the waveform: symbol rate, roll-off,
-optional DSSS chip rate) against a `ModCod` (the modulation and coding
-scheme with its Eb/N0 threshold). The design margin is an input to the
-evaluation:
+To compute modulation-aware figures (`Es/N0`, `Eb/N0`, link margin, data
+rate), modulate the budget with a `Channel` (the waveform: symbol rate,
+roll-off, optional DSSS chip rate) and a `ModCod` (the modulation and
+coding scheme with its Eb/N0 threshold). Everything bandwidth-dependent
+derives from the channel; the design margin is an input:
 
 ```python
 channel = lox.Channel(symbol_rate=5 * lox.MHz)
 modcod = lox.ModCod("QPSK 1/2", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-modulated = modcod.evaluate(link, channel, design_margin=3.0 * lox.dB)
-print(f"Margin = {float(modulated.margin):.2f} dB")
+modulated = link.modulate(channel, modcod, design_margin=3.0 * lox.dB)
+print(f"Closes: {modulated.closes()}, margin = {float(modulated.margin):.2f} dB")
 ```
 
 For standards-based links, use the built-in DVB-S2 table — 28 modes whose
@@ -186,7 +185,7 @@ exactly — and `ModCod.select` for adaptive coding and modulation:
 ```python
 table = lox.ModCod.dvb_s2()
 modcod = next(mc for mc in table if mc.name == "QPSK 3/4")
-modulated = modcod.evaluate(link, channel, design_margin=3.0 * lox.dB)
+modulated = link.modulate(channel, modcod, design_margin=3.0 * lox.dB)
 
 # The highest-efficiency mode that closes at this Es/N0:
 best = lox.ModCod.select(modulated.es_n0, 3.0 * lox.dB, table)
@@ -254,17 +253,16 @@ modcod = next(mc for mc in lox.ModCod.dvb_s2() if mc.name == "QPSK 3/4")
 # 2° residual pointing error on the spacecraft gimbal; the station
 # autotracks on boresight. On downlinks the budget uses the rain-degraded
 # G/T (ITU-R P.618 §8.2).
-link = lox.LinkStats.for_link(
+link = lox.LinkBudget(
     spacecraft,
     ground_station,
     carrier=carrier,
-    bandwidth=channel.bandwidth(),
     range=slant_range,
     tx_angle=2.0 * lox.deg,
     losses=losses,
     link_type="downlink",
 )
-modulated = modcod.evaluate(link, channel, design_margin=3.0 * lox.dB)
+modulated = link.modulate(channel, modcod, design_margin=3.0 * lox.dB)
 
 print(f"EIRP:        {float(link.eirp):.2f} dBW")
 print(f"FSPL:        {float(link.fspl):.2f} dB")
@@ -302,11 +300,10 @@ spacecraft = lox.TxChain(
     feed_loss=0.8 * lox.dB,
 )
 
-link = lox.LinkStats.for_link(
+link = lox.LinkBudget(
     spacecraft,
     ground_station,
     carrier=carrier,
-    bandwidth=channel.bandwidth(),
     range=slant_range,
     tx_direction=[0.9, 0.1, 0.0],  # line of sight in the TX parent frame
 )
@@ -357,12 +354,11 @@ losses = lox.PropagationLosses(
 print(f"Total: {float(losses.total()):.1f} dB")
 print(f"Absorptive: {float(losses.absorptive()):.1f} dB")
 
-# Pass to LinkStats.for_link via the losses parameter
-link = lox.LinkStats.for_link(
+# Pass to LinkBudget via the losses parameter
+link = lox.LinkBudget(
     spacecraft,
     ground_station,
     carrier=carrier,
-    bandwidth=channel.bandwidth(),
     range=slant_range,
     losses=losses,
 )
@@ -460,13 +456,13 @@ link = lox.LinkStats.for_link(
 
 ---
 
-::: lox_space.LinkStats
+::: lox_space.LinkBudget
     options:
       show_source: false
 
 ---
 
-::: lox_space.ModulatedLinkStats
+::: lox_space.ModulatedLinkBudget
     options:
       show_source: false
 

--- a/crates/lox-space/docs/comms.md
+++ b/crates/lox-space/docs/comms.md
@@ -187,8 +187,10 @@ table = lox.ModCod.dvb_s2()
 modcod = next(mc for mc in table if mc.name == "QPSK 3/4")
 modulated = link.modulate(channel, modcod, design_margin=3.0 * lox.dB)
 
-# The highest-efficiency mode that closes at this Es/N0:
-best = lox.ModCod.select(modulated.es_n0, 3.0 * lox.dB, table)
+# Adaptive coding and modulation: the highest-efficiency mode that closes,
+# selected and evaluated in one step (the result always closes):
+best = link.modulate_best(channel, table, design_margin=3.0 * lox.dB)
+print(f"{best.modcod.name}: {float(best.information_rate()) / 1e6:.1f} Mbit/s")
 ```
 
 Use the component tier (configure antennas, amplifiers, receiver noise) when

--- a/crates/lox-space/docs/comms.md
+++ b/crates/lox-space/docs/comms.md
@@ -159,10 +159,10 @@ link = lox.LinkBudget(
 print(f"C/N0 = {float(link.c_n0):.2f} dB·Hz")
 ```
 
-For lumped links, `link.carrier_rx_power` and `link.noise_power` are `None` —
-the absolute carrier and noise power are not recoverable from EIRP and G/T
-alone. The carrier-to-noise density ratio (`c_n0`) and carrier-to-noise ratio
-(`c_n`) remain available.
+For lumped links, `link.carrier_rx_power` and `link.noise_power(bandwidth)`
+are `None` — the absolute carrier and noise power are not recoverable from
+EIRP and G/T alone. The carrier-to-noise density ratio (`c_n0`) and the
+carrier-to-noise ratio view (`c_n(bandwidth)`) remain available.
 
 To compute modulation-aware figures (`Es/N0`, `Eb/N0`, link margin, data
 rate), modulate the budget with a `Channel` (the waveform: symbol rate,

--- a/crates/lox-space/docs/index.md
+++ b/crates/lox-space/docs/index.md
@@ -60,7 +60,7 @@ future_state = propagator.propagate(t + lox.TimeDelta.from_hours(1.5))
 | [Ground Stations](ground.md) | `GroundLocation`, `ElevationMask`, `Observables`, `Pass` |
 | [Events & Visibility](events.md) | `Event`, `Interval`, `find_events`, `find_windows`, `intersect_intervals`, `union_intervals`, `complement_intervals`, `GroundStation`, `Spacecraft`, `Scenario`, `Ensemble`, `VisibilityAnalysis`, `VisibilityResults`, `PowerBudgetAnalysis`, `PowerBudgetResults` |
 | [Imaging](imaging.md) | `Aoi`, `OpticalPayload`, `OpticalAccessAnalysis`, `SarPayload`, `LookSide`, `SarAccessAnalysis`, `AccessResults` |
-| [Communications](comms.md) | `TxChain`, `RxChain`, `AmplifierTransmitter`, `NoiseTempReceiver`, `CascadeReceiver`, `Channel`, `ModCod`, `LinkStats`, `PropagationLosses`, `fspl`, `freq_overlap` |
+| [Communications](comms.md) | `TxChain`, `RxChain`, `AmplifierTransmitter`, `NoiseTempReceiver`, `CascadeReceiver`, `Channel`, `ModCod`, `LinkBudget`, `PropagationLosses`, `fspl`, `freq_overlap` |
 | [Constellations](constellations.md) | `Constellation`, `ConstellationSatellite` |
 | [Data Providers](data.md) | `EOPProvider`, `Series` |
 | [Units](units.md) | `Angle`, `Distance`, `Frequency`, `Velocity` |

--- a/crates/lox-space/docs/itur.md
+++ b/crates/lox-space/docs/itur.md
@@ -61,7 +61,7 @@ losses = lox.PropagationLosses(rain=2.0 * lox.dB, gaseous=0.5 * lox.dB)
 losses = lox.PropagationLosses.none()
 ```
 
-The result plugs directly into `LinkStats.for_link` for link budget analysis.
+The result plugs directly into `LinkBudget` for link budget analysis.
 
 ## Individual Models
 
@@ -158,7 +158,7 @@ print(f"Rain height: {h.to_kilometers():.1f} km")
 
 ## Link Budget Integration
 
-`PropagationLosses` can be passed directly to `LinkStats.for_link`, where
+`PropagationLosses` can be passed directly to `LinkBudget`, where
 `tx` is a `TxChain` or `EirpModel` and `rx` is an `RxChain` or `GtModel` (see
 [Communications](comms.md)):
 
@@ -172,11 +172,10 @@ losses = provider.propagation_losses(
     diameter=0.6 * lox.m,
 )
 
-stats = lox.LinkStats.for_link(
+budget = lox.LinkBudget(
     tx,
     rx,
     carrier=29.0 * lox.GHz,
-    bandwidth=5.0 * lox.MHz,
     range=1000.0 * lox.km,
     losses=losses,
 )

--- a/crates/lox-space/examples/x_band_downlink.rs
+++ b/crates/lox-space/examples/x_band_downlink.rs
@@ -23,7 +23,7 @@ use lox_space::comms::FrequencyRange;
 use lox_space::comms::antenna::Antenna;
 use lox_space::comms::channel::{Channel, LinkDirection};
 use lox_space::comms::link_budget::{Eirp, GOverT, LinkBudget, LinkConditions, PropagationLosses};
-use lox_space::comms::modcod::{ModCod, dvb_s2};
+use lox_space::comms::modcod::dvb_s2;
 use lox_space::comms::pfd::{PfdMask, power_flux_density};
 use lox_space::comms::pointing::Pointing;
 use lox_space::comms::receiver::CascadeReceiver;
@@ -178,14 +178,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     // ACM: the best DVB-S2 mode that closes at this Es/N0 with the same
     // design margin.
     // ------------------------------------------------------------------
-    let best = ModCod::select(modulated.es_n0, design_margin, dvb_s2()).expect("a mode closes");
+    let best = budget
+        .modulate_best(&channel, dvb_s2(), design_margin)
+        .expect("a mode closes");
     println!(
         "\nBest ACM mode:   {} ({:.1} Mbit/s, +{:.0} %)",
-        best.mode().name(),
-        best.mode()
-            .information_rate(channel.symbol_rate())
-            .to_megahertz(),
-        (best.mode().info_bits_per_symbol() / modcod.mode().info_bits_per_symbol() - 1.0) * 100.0
+        best.modcod.mode().name(),
+        best.information_rate().to_megahertz(),
+        (best.modcod.mode().info_bits_per_symbol() / modcod.mode().info_bits_per_symbol() - 1.0)
+            * 100.0
     );
 
     // ------------------------------------------------------------------

--- a/crates/lox-space/examples/x_band_downlink.rs
+++ b/crates/lox-space/examples/x_band_downlink.rs
@@ -22,9 +22,7 @@ use std::error::Error;
 use lox_space::comms::FrequencyRange;
 use lox_space::comms::antenna::Antenna;
 use lox_space::comms::channel::{Channel, LinkDirection};
-use lox_space::comms::link_budget::{
-    Eirp, GOverT, LinkParameters, LinkStats, ModulatedLinkStats, PropagationLosses,
-};
+use lox_space::comms::link_budget::{Eirp, GOverT, LinkBudget, LinkConditions, PropagationLosses};
 use lox_space::comms::modcod::{ModCod, dvb_s2};
 use lox_space::comms::pfd::{PfdMask, power_flux_density};
 use lox_space::comms::pointing::Pointing;
@@ -124,34 +122,46 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("table mode");
     let design_margin = 3.0.db();
 
-    let params = LinkParameters::builder(carrier, channel.bandwidth(), range)
+    let conditions = LinkConditions::builder(carrier, range)
         .losses(losses)
         .tx_pointing(tx_pointing)
         .rx_pointing(rx_pointing)
         .direction(LinkDirection::Downlink)
         .build()?;
-    let link = LinkStats::for_link(&tx, &rx, &params)?;
-    let modulated = ModulatedLinkStats::evaluate(link, &channel, modcod, design_margin)?;
+    let budget = LinkBudget::new(&tx, &rx, &conditions)?;
+    let modulated = budget.modulate(&channel, modcod, design_margin);
 
     println!("\n--- Link budget at {} GHz ---", carrier.to_gigahertz());
-    println!("EIRP:            {:>8.2} dBW", modulated.link.eirp.as_f64());
-    println!("FSPL:            {:>8.2} dB", modulated.link.fspl.as_f64());
+    println!(
+        "EIRP:            {:>8.2} dBW",
+        modulated.budget.eirp.as_f64()
+    );
+    println!(
+        "FSPL:            {:>8.2} dB",
+        modulated.budget.fspl.as_f64()
+    );
     println!(
         "Env. losses:     {:>8.2} dB",
-        modulated.link.losses.total().as_f64()
+        modulated.budget.losses.total().as_f64()
     );
-    println!("G/T (clear-sky): {:>8.2} dB/K", modulated.link.gt.as_f64());
-    let gt_degraded = modulated.link.gt_degraded.expect("downlink with RX chain");
+    println!(
+        "G/T (clear-sky): {:>8.2} dB/K",
+        modulated.budget.gt.as_f64()
+    );
+    let gt_degraded = modulated
+        .budget
+        .gt_degraded
+        .expect("downlink with RX chain");
     println!(
         "G/T (rain):      {:>8.2} dB/K ({:+.2} dB)",
         gt_degraded.as_f64(),
-        gt_degraded.as_f64() - modulated.link.gt.as_f64()
+        gt_degraded.as_f64() - modulated.budget.gt.as_f64()
     );
     println!(
         "C/N0:            {:>8.2} dB·Hz",
-        modulated.link.c_n0.as_f64()
+        modulated.budget.c_n0.as_f64()
     );
-    println!("C/N:             {:>8.2} dB", modulated.link.c_n.as_f64());
+    println!("C/N:             {:>8.2} dB", modulated.c_n.as_f64());
     println!("Es/N0:           {:>8.2} dB", modulated.es_n0.as_f64());
     println!("Eb/N0:           {:>8.2} dB", modulated.eb_n0.as_f64());
     println!(
@@ -160,7 +170,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
     println!("Link margin:     {:>8.2} dB", modulated.margin.as_f64());
     assert!(
-        modulated.margin.as_f64() > 0.0,
+        modulated.closes(),
         "the downlink should close at worst-case geometry"
     );
 
@@ -182,7 +192,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Regulatory check: PFD on the ground vs. the RR Art. 21.16 mask
     // (−150 dBW/m²/4 kHz below 5° for the 8.025–8.4 GHz EESS allocation).
     // ------------------------------------------------------------------
-    let pfd = power_flux_density(modulated.link.eirp, range, channel.bandwidth(), 4.0.khz());
+    let pfd = power_flux_density(modulated.budget.eirp, range, channel.bandwidth(), 4.0.khz());
     let mask = PfdMask::art_21_16((-150.0).db());
     let limit = mask.value_at(elevation);
     println!(

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1317,6 +1317,29 @@ impl PyLinkBudget {
             .map_err(|err| PyValueError::new_err(err.to_string()))
     }
 
+    /// Selects and applies the best MODCOD from a table: the
+    /// highest-efficiency mode that closes on this channel with the given
+    /// design margin (adaptive coding and modulation). The result always
+    /// closes; ``None`` means no mode in the table closes.
+    ///
+    /// Args:
+    ///     channel: The waveform the link runs on.
+    ///     table: Candidate MODCODs, e.g. ``ModCod.dvb_s2()``.
+    ///     design_margin: Margin applied on top of the threshold (default 0 dB).
+    #[pyo3(signature = (channel, table, design_margin=None))]
+    fn modulate_best(
+        &self,
+        channel: &PyChannel,
+        table: Vec<PyModCod>,
+        design_margin: Option<PyDecibel>,
+    ) -> Option<PyModulatedLinkBudget> {
+        let margin = design_margin.map(|m| m.0).unwrap_or(Decibel::new(0.0));
+        let table: Vec<ModCod> = table.into_iter().map(|mc| mc.0).collect();
+        self.0
+            .modulate_best(&channel.0, &table, margin)
+            .map(PyModulatedLinkBudget)
+    }
+
     /// Applies a waveform and a MODCOD to this budget.
     ///
     /// Everything bandwidth-dependent derives from the channel.

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -13,7 +13,7 @@ use lox_comms::antenna::{Antenna, AntennaFrame, AntennaGain, ConstantAntenna, Pa
 use lox_comms::channel::{Channel, LinkDirection, Modulation};
 use lox_comms::link_budget::{Eirp, GOverT};
 use lox_comms::link_budget::{
-    InterferenceStats, LinkParameters, LinkStats, ModulatedLinkStats, frequency_overlap_factor,
+    InterferenceStats, LinkBudget, LinkConditions, ModulatedLinkBudget, frequency_overlap_factor,
 };
 use lox_comms::modcod::{self, ErrorMetric, ModCod};
 use lox_comms::pattern::{AntennaPattern, DipolePattern, GaussianPattern, ParabolicPattern};
@@ -1093,25 +1093,6 @@ impl PyModCod {
         PyFrequency(self.0.mode().information_rate(symbol_rate.0))
     }
 
-    /// Evaluates a link budget on a channel against this MODCOD.
-    ///
-    /// Args:
-    ///     link: The modulation-agnostic link budget.
-    ///     channel: The waveform the link runs on.
-    ///     design_margin: Margin applied on top of the threshold (default 0 dB).
-    #[pyo3(signature = (link, channel, design_margin=None))]
-    fn evaluate(
-        &self,
-        link: PyLinkStats,
-        channel: &PyChannel,
-        design_margin: Option<PyDecibel>,
-    ) -> PyResult<PyModulatedLinkStats> {
-        let margin = design_margin.map(|m| m.0).unwrap_or(Decibel::new(0.0));
-        ModulatedLinkStats::evaluate(link.0, &channel.0, &self.0, margin)
-            .map(PyModulatedLinkStats)
-            .map_err(|e| PyValueError::new_err(e.to_string()))
-    }
-
     fn __eq__(&self, other: &PyModCod) -> bool {
         self.0 == other.0
     }
@@ -1267,27 +1248,28 @@ impl PyPropagationLosses {
     }
 }
 
-// --- Link Stats ---
+// --- Link Budget ---
 
-/// Modulation-agnostic link budget statistics.
-#[pyclass(name = "LinkStats", module = "lox_space", frozen, from_py_object)]
+/// A modulation-agnostic link budget between two link terminals.
+#[pyclass(name = "LinkBudget", module = "lox_space", frozen, from_py_object)]
 #[derive(Debug, Clone)]
-pub struct PyLinkStats(pub LinkStats);
+pub struct PyLinkBudget(pub LinkBudget);
 
 #[pymethods]
-impl PyLinkStats {
+impl PyLinkBudget {
     /// Computes a modulation-agnostic link budget between two link terminals.
     ///
     /// The carrier must lie inside both terminals' frequency ranges. Each
     /// terminal's pointing is given either as an off-boresight angle or as a
     /// line-of-sight direction vector in the antenna's parent frame; omitting
-    /// both assumes ideal (boresight) pointing.
+    /// both assumes ideal (boresight) pointing. All outputs are
+    /// bandwidth-free; use ``modulate`` to apply a waveform and MODCOD, or
+    /// the ``c_n``/``noise_power`` methods for ad-hoc bandwidths.
     ///
     /// Args:
     ///     tx: The transmit terminal (TxChain or EirpModel).
     ///     rx: The receive terminal (RxChain or GtModel).
     ///     carrier: Carrier frequency.
-    ///     bandwidth: Noise bandwidth as Frequency.
     ///     range: Slant range as Distance.
     ///     tx_angle: Off-boresight angle at transmitter as Angle (optional).
     ///     rx_angle: Off-boresight angle at receiver as Angle (optional).
@@ -1297,14 +1279,13 @@ impl PyLinkStats {
     ///     link_type: "uplink", "downlink", or "crosslink" (optional). On
     ///         downlinks the budget uses the rain-degraded G/T
     ///         (ITU-R P.618 §8.2).
-    #[staticmethod]
-    #[pyo3(signature = (tx, rx, carrier, bandwidth, range, tx_angle=None, rx_angle=None, tx_direction=None, rx_direction=None, losses=None, link_type=None))]
+    #[new]
+    #[pyo3(signature = (tx, rx, carrier, range, tx_angle=None, rx_angle=None, tx_direction=None, rx_direction=None, losses=None, link_type=None))]
     #[allow(clippy::too_many_arguments)]
-    fn for_link(
+    fn new(
         tx: &Bound<'_, PyAny>,
         rx: &Bound<'_, PyAny>,
         carrier: PyFrequency,
-        bandwidth: PyFrequency,
         range: PyDistance,
         tx_angle: Option<PyAngle>,
         rx_angle: Option<PyAngle>,
@@ -1321,19 +1302,38 @@ impl PyLinkStats {
             .map(|l| l.0.clone())
             .unwrap_or_else(PropagationLosses::none);
 
-        let mut builder = LinkParameters::builder(carrier.0, bandwidth.0, range.0)
+        let mut builder = LinkConditions::builder(carrier.0, range.0)
             .losses(env_losses)
             .tx_pointing(tx_pointing)
             .rx_pointing(rx_pointing);
         if let Some(link_type) = link_type {
             builder = builder.direction(parse_link_direction(link_type)?);
         }
-        let params = builder
+        let conditions = builder
             .build()
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
-        LinkStats::for_link(&tx, &rx, &params)
+        LinkBudget::new(&tx, &rx, &conditions)
             .map(Self)
             .map_err(|err| PyValueError::new_err(err.to_string()))
+    }
+
+    /// Applies a waveform and a MODCOD to this budget.
+    ///
+    /// Everything bandwidth-dependent derives from the channel.
+    ///
+    /// Args:
+    ///     channel: The waveform the link runs on.
+    ///     modcod: The modulation and coding scheme.
+    ///     design_margin: Margin applied on top of the threshold (default 0 dB).
+    #[pyo3(signature = (channel, modcod, design_margin=None))]
+    fn modulate(
+        &self,
+        channel: &PyChannel,
+        modcod: &PyModCod,
+        design_margin: Option<PyDecibel>,
+    ) -> PyModulatedLinkBudget {
+        let margin = design_margin.map(|m| m.0).unwrap_or(Decibel::new(0.0));
+        PyModulatedLinkBudget(self.0.modulate(&channel.0, &modcod.0, margin))
     }
 
     /// Slant range.
@@ -1380,10 +1380,9 @@ impl PyLinkStats {
         PyDecibel(self.0.c_n0)
     }
 
-    /// C/N in dB.
-    #[getter]
-    fn c_n(&self) -> PyDecibel {
-        PyDecibel(self.0.c_n)
+    /// Returns C/N in dB for the given noise bandwidth.
+    fn c_n(&self, bandwidth: PyFrequency) -> PyDecibel {
+        PyDecibel(self.0.c_n(bandwidth.0))
     }
 
     /// Received carrier power in dBW. ``None`` for lumped G/T receivers.
@@ -1392,16 +1391,10 @@ impl PyLinkStats {
         self.0.carrier_rx_power.map(PyDecibel)
     }
 
-    /// Noise power in dBW. ``None`` for lumped G/T receivers.
-    #[getter]
-    fn noise_power(&self) -> Option<PyDecibel> {
-        self.0.noise_power.map(PyDecibel)
-    }
-
-    /// Channel noise bandwidth.
-    #[getter]
-    fn bandwidth(&self) -> PyFrequency {
-        PyFrequency(self.0.bandwidth)
+    /// Returns the noise power in dBW for the given bandwidth. ``None`` for
+    /// lumped G/T receivers.
+    fn noise_power(&self, bandwidth: PyFrequency) -> Option<PyDecibel> {
+        self.0.noise_power(bandwidth.0).map(PyDecibel)
     }
 
     /// Link frequency.
@@ -1412,9 +1405,8 @@ impl PyLinkStats {
 
     fn __repr__(&self) -> String {
         format!(
-            "LinkStats(c_n0={:.2} dB·Hz, c_n={:.2} dB, eirp={:.2} dBW, gt={:.2} dB/K)",
+            "LinkBudget(c_n0={:.2} dB·Hz, eirp={:.2} dBW, gt={:.2} dB/K)",
             self.0.c_n0.as_f64(),
-            self.0.c_n.as_f64(),
             self.0.eirp.as_f64(),
             self.0.gt.as_f64(),
         )
@@ -1470,24 +1462,35 @@ impl PyInterferenceStats {
     }
 }
 
-// --- Modulated Link Stats ---
+// --- Modulated Link Budget ---
 
-/// Link-budget output with modulation/coding figures applied.
+/// Link-budget output with a modulation and coding scheme applied.
 #[pyclass(
-    name = "ModulatedLinkStats",
+    name = "ModulatedLinkBudget",
     module = "lox_space",
     frozen,
     from_py_object
 )]
 #[derive(Debug, Clone)]
-pub struct PyModulatedLinkStats(pub ModulatedLinkStats);
+pub struct PyModulatedLinkBudget(pub ModulatedLinkBudget);
 
 #[pymethods]
-impl PyModulatedLinkStats {
+impl PyModulatedLinkBudget {
     /// The underlying modulation-agnostic link budget.
     #[getter]
-    fn link(&self) -> PyLinkStats {
-        PyLinkStats(self.0.link.clone())
+    fn budget(&self) -> PyLinkBudget {
+        PyLinkBudget(self.0.budget.clone())
+    }
+
+    /// C/N in dB in the channel's occupied bandwidth.
+    #[getter]
+    fn c_n(&self) -> PyDecibel {
+        PyDecibel(self.0.c_n)
+    }
+
+    /// Returns whether the link closes: margin >= 0.
+    fn closes(&self) -> bool {
+        self.0.closes()
     }
 
     /// The waveform the link was evaluated on.
@@ -1547,7 +1550,7 @@ impl PyModulatedLinkStats {
 
     fn __repr__(&self) -> String {
         format!(
-            "ModulatedLinkStats(eb_n0={:.2} dB, margin={:.2} dB)",
+            "ModulatedLinkBudget(eb_n0={:.2} dB, margin={:.2} dB)",
             self.0.eb_n0.as_f64(),
             self.0.margin.as_f64(),
         )

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -10,6 +10,7 @@ use pyo3::prelude::*;
 
 use lox_comms::antenna::{Antenna, AntennaFrame, AntennaGain, ConstantAntenna, PatternedAntenna};
 
+use lox_comms::LinkBudgetError;
 use lox_comms::channel::{Channel, LinkDirection, Modulation};
 use lox_comms::link_budget::{Eirp, GOverT};
 use lox_comms::link_budget::{
@@ -1420,10 +1421,11 @@ impl PyLinkBudget {
     /// Returns the noise power in dBW for the given bandwidth. ``None`` for
     /// lumped G/T receivers.
     fn noise_power(&self, bandwidth: PyFrequency) -> PyResult<Option<PyDecibel>> {
-        self.0
-            .noise_power(bandwidth.0)
-            .map(|p| p.map(PyDecibel))
-            .map_err(|e| PyValueError::new_err(e.to_string()))
+        match self.0.noise_power(bandwidth.0) {
+            Ok(power) => Ok(Some(PyDecibel(power))),
+            Err(LinkBudgetError::AbsolutePowerUnavailable) => Ok(None),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
     }
 
     /// Link frequency.

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -1404,8 +1404,11 @@ impl PyLinkBudget {
     }
 
     /// Returns C/N in dB for the given noise bandwidth.
-    fn c_n(&self, bandwidth: PyFrequency) -> PyDecibel {
-        PyDecibel(self.0.c_n(bandwidth.0))
+    fn c_n(&self, bandwidth: PyFrequency) -> PyResult<PyDecibel> {
+        self.0
+            .c_n(bandwidth.0)
+            .map(PyDecibel)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     /// Received carrier power in dBW. ``None`` for lumped G/T receivers.
@@ -1416,8 +1419,11 @@ impl PyLinkBudget {
 
     /// Returns the noise power in dBW for the given bandwidth. ``None`` for
     /// lumped G/T receivers.
-    fn noise_power(&self, bandwidth: PyFrequency) -> Option<PyDecibel> {
-        self.0.noise_power(bandwidth.0).map(PyDecibel)
+    fn noise_power(&self, bandwidth: PyFrequency) -> PyResult<Option<PyDecibel>> {
+        self.0
+            .noise_power(bandwidth.0)
+            .map(|p| p.map(PyDecibel))
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     /// Link frequency.

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -14,7 +14,7 @@ use crate::bodies::python::PyOrigin;
 use crate::comms::python::{
     PyAmplifierTransmitter, PyAntennaFrame, PyCascadeReceiver, PyChannel, PyConstantAntenna,
     PyDecibel, PyDipolePattern, PyEirpModel, PyFrequencyRange, PyGaussianPattern, PyGtModel,
-    PyInterferenceStats, PyLinkStats, PyModCod, PyModulatedLinkStats, PyModulation, PyNoiseStage,
+    PyInterferenceStats, PyLinkBudget, PyModCod, PyModulatedLinkBudget, PyModulation, PyNoiseStage,
     PyNoiseTempReceiver, PyParabolicPattern, PyPatternedAntenna, PyPfdMask, PyPropagationLosses,
     PyRxChain, PyTxChain, freq_overlap, fspl, power_flux_density, slant_range,
 };
@@ -73,9 +73,9 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyModCod>()?;
     m.add_class::<PyItuProvider>()?;
     m.add_class::<PyPropagationLosses>()?;
-    m.add_class::<PyLinkStats>()?;
+    m.add_class::<PyLinkBudget>()?;
     m.add_class::<PyInterferenceStats>()?;
-    m.add_class::<PyModulatedLinkStats>()?;
+    m.add_class::<PyModulatedLinkBudget>()?;
     m.add_class::<PyPfdMask>()?;
     m.add_class::<PyFrequencyRange>()?;
     m.add_class::<PyTxChain>()?;

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -922,6 +922,19 @@ def test_propagation_losses_repr_non_absorptive():
     assert "False" in r
 
 
+def test_modulate_best_acm():
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    budget = link_budget(make_tx(), make_rx())
+    table = lox.ModCod.dvb_s2()
+    m = budget.modulate_best(ch, table, design_margin=3.0 * lox.dB)
+    # Some always closes, and matches manual selection.
+    assert m.closes()
+    best = lox.ModCod.select(ch.es_n0(budget.c_n0), 3.0 * lox.dB, table)
+    assert m.modcod == best
+    # Nothing closes with an absurd margin.
+    assert budget.modulate_best(ch, table, design_margin=100.0 * lox.dB) is None
+
+
 def test_modcod_information_rate():
     # QPSK rate 1/2 at 5 Msps: 5 Mbit/s information rate.
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -35,12 +35,11 @@ def make_rx(gain=30.0, noise_temperature=500.0, feed_loss=0.0):
     )
 
 
-def link_stats(tx, rx, **kwargs):
-    """Evaluates the standard 29 GHz downlink between two terminals."""
+def link_budget(tx, rx, **kwargs):
+    """Computes the standard 29 GHz link budget between two terminals."""
     kwargs.setdefault("carrier", 29.0 * lox.GHz)
-    kwargs.setdefault("bandwidth", 5.0 * lox.MHz)
     kwargs.setdefault("range", 1000.0 * lox.km)
-    return lox.LinkStats.for_link(tx, rx, **kwargs)
+    return lox.LinkBudget(tx, rx, **kwargs)
 
 
 # --- Decibel ---
@@ -446,7 +445,7 @@ def test_transmitter_eirp():
     # 10 dBi antenna, 5 W power, 1 dB feed loss, 0 dB OBO
     # EIRP = 10 + 10*log10(5) - 1 = 15.99 dBW
     tx = make_tx(gain=10.0, power=5.0, feed_loss=1.0)
-    stats = link_stats(tx, make_rx())
+    stats = link_budget(tx, make_rx())
     assert float(stats.eirp) == pytest.approx(15.99, abs=0.01)
 
 
@@ -699,8 +698,8 @@ def test_modcod_evaluate():
     losses = lox.PropagationLosses(rain=2.0 * lox.dB)
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth(), losses=losses)
-    m = mc.evaluate(stats, ch, design_margin=3.0 * lox.dB)
+    stats = link_budget(make_tx(), make_rx(), losses=losses)
+    m = stats.modulate(ch, mc, design_margin=3.0 * lox.dB)
     # Es/N0 = C/N0 - 10*log10(5e6); Eb/N0 = Es/N0 (1 info bit/symbol)
     assert float(m.es_n0) == pytest.approx(float(stats.c_n0) - 10 * math.log10(5e6), abs=1e-9)
     assert float(m.eb_n0) == pytest.approx(float(m.es_n0), abs=1e-9)
@@ -789,23 +788,22 @@ def test_freq_overlap_partial():
 # --- Link Stats ---
 
 
-def test_link_stats_noise_power():
-    stats = link_stats(make_tx(), make_rx(), bandwidth=1.0 * lox.MHz)
-    assert float(stats.noise_power) == pytest.approx(-141.61, abs=0.01)
+def test_link_budget_noise_power():
+    budget = link_budget(make_tx(), make_rx())
+    assert float(budget.noise_power(1.0 * lox.MHz)) == pytest.approx(-141.61, abs=0.01)
 
 
 def test_link_stats_end_to_end():
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
     mc = lox.ModCod("QPSK 1/2 test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
 
-    stats = link_stats(
+    stats = link_budget(
         make_tx(),
         make_rx(),
-        bandwidth=ch.bandwidth(),
         tx_angle=0.0 * lox.deg,
         rx_angle=0.0 * lox.deg,
     )
-    modulated = mc.evaluate(stats, ch, design_margin=3.0 * lox.dB)
+    modulated = stats.modulate(ch, mc, design_margin=3.0 * lox.dB)
 
     # EIRP = 46 + 10 - 1 = 55 dBW
     assert float(stats.eirp) == pytest.approx(55.0, abs=0.01)
@@ -831,8 +829,8 @@ def test_link_stats_downlink_degrades_gt():
         rain=2.0 * lox.dB, gaseous=0.5 * lox.dB, cloud=0.2 * lox.dB,
         scintillation=0.3 * lox.dB,
     )
-    clear = link_stats(make_tx(), make_rx(), losses=losses)
-    faded = link_stats(make_tx(), make_rx(), losses=losses, link_type="downlink")
+    clear = link_budget(make_tx(), make_rx(), losses=losses)
+    faded = link_budget(make_tx(), make_rx(), losses=losses, link_type="downlink")
 
     assert clear.gt_degraded is None
     assert clear.link_type is None
@@ -847,15 +845,15 @@ def test_link_stats_downlink_degrades_gt():
 
 def test_link_stats_uplink_stays_clear_sky():
     losses = lox.PropagationLosses(rain=2.0 * lox.dB)
-    clear = link_stats(make_tx(), make_rx(), losses=losses)
-    uplink = link_stats(make_tx(), make_rx(), losses=losses, link_type="uplink")
+    clear = link_budget(make_tx(), make_rx(), losses=losses)
+    uplink = link_budget(make_tx(), make_rx(), losses=losses, link_type="uplink")
     assert uplink.gt_degraded is None
     assert float(uplink.c_n0) == pytest.approx(float(clear.c_n0), abs=1e-12)
 
 
 def test_link_stats_rejects_unknown_link_type():
     with pytest.raises(ValueError):
-        link_stats(make_tx(), make_rx(), link_type="sideways")
+        link_budget(make_tx(), make_rx(), link_type="sideways")
 
 
 def test_link_stats_with_losses():
@@ -864,14 +862,10 @@ def test_link_stats_with_losses():
 
     losses = lox.PropagationLosses(rain=2.0 * lox.dB, other=[("Atmospheric", 1.0 * lox.dB, True)])
 
-    stats_no_loss = link_stats(
-        make_tx(), make_rx(), bandwidth=ch.bandwidth()
-    )
-    stats_loss = link_stats(
-        make_tx(), make_rx(), bandwidth=ch.bandwidth(), losses=losses
-    )
-    modulated_no_loss = mc.evaluate(stats_no_loss, ch, design_margin=3.0 * lox.dB)
-    modulated_loss = mc.evaluate(stats_loss, ch, design_margin=3.0 * lox.dB)
+    stats_no_loss = link_budget(make_tx(), make_rx())
+    stats_loss = link_budget(make_tx(), make_rx(), losses=losses)
+    modulated_no_loss = stats_no_loss.modulate(ch, mc, design_margin=3.0 * lox.dB)
+    modulated_loss = stats_loss.modulate(ch, mc, design_margin=3.0 * lox.dB)
 
     # 3 dB of environmental losses should reduce margin by 3 dB
     margin_diff = float(modulated_no_loss.margin) - float(modulated_loss.margin)
@@ -893,16 +887,6 @@ def test_channel_spreading_factor_narrowband():
     ch = lox.Channel(symbol_rate=1 * lox.MHz)
     assert ch.spreading_factor() is None
     assert ch.processing_gain() is None
-
-
-def test_modcod_evaluate_rejects_bandwidth_mismatch():
-    # The link was computed with a 5 MHz noise bandwidth, not the channel's
-    # 6.75 MHz occupied bandwidth.
-    ch = lox.Channel(symbol_rate=5 * lox.MHz)
-    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    stats = link_stats(make_tx(), make_rx(), bandwidth=5 * lox.MHz)
-    with pytest.raises(ValueError, match="does not match"):
-        mc.evaluate(stats, ch)
 
 
 def test_modcod_getters_and_repr():
@@ -944,11 +928,11 @@ def test_modcod_information_rate():
     assert mc.information_rate(5 * lox.MHz).to_hertz() == pytest.approx(5e6, rel=1e-10)
 
 
-# --- LinkStats additional outputs ---
+# --- LinkBudget additional outputs ---
 
 
 def test_link_stats_carrier_power():
-    stats = link_stats(make_tx(), make_rx())
+    stats = link_budget(make_tx(), make_rx())
     # carrier_rx_power should be finite for component-tier links
     assert math.isfinite(float(stats.carrier_rx_power))
 
@@ -1040,32 +1024,35 @@ def test_noise_stage_pickle():
     assert repr(restored) == repr(ns)
 
 
-# --- LinkStats additional getters ---
+# --- LinkBudget additional getters ---
 
 
 def test_link_stats_all_getters():
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
 
-    stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
+    stats = link_budget(make_tx(), make_rx())
 
-    # Test getters not covered in test_link_stats_end_to_end
-    assert math.isfinite(float(stats.c_n))
+    # Derived views take the bandwidth explicitly.
+    assert math.isfinite(float(stats.c_n(ch.bandwidth())))
     assert stats.carrier_rx_power is not None
     assert math.isfinite(float(stats.carrier_rx_power))
-    assert stats.noise_power is not None
-    assert math.isfinite(float(stats.noise_power))
-    assert stats.bandwidth.to_hertz() == pytest.approx(5e6 * 1.35, rel=1e-6)
+    assert stats.noise_power(ch.bandwidth()) is not None
+    assert math.isfinite(float(stats.noise_power(ch.bandwidth())))
     assert math.isfinite(float(stats.gt))
+    # C/N0 consistency through the views.
+    bw = ch.bandwidth()
+    c_n0 = float(stats.carrier_rx_power) - float(stats.noise_power(bw)) + 10 * math.log10(float(bw))
+    assert float(stats.c_n0) == pytest.approx(c_n0, abs=1e-9)
 
 
 def test_link_stats_repr():
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
 
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
-    modulated = mc.evaluate(stats, ch, design_margin=3.0 * lox.dB)
+    stats = link_budget(make_tx(), make_rx())
+    modulated = stats.modulate(ch, mc, design_margin=3.0 * lox.dB)
     r = repr(stats)
-    assert "LinkStats" in r
+    assert "LinkBudget" in r
     assert "c_n0=" in r
     assert "margin=" in repr(modulated)
 
@@ -1140,7 +1127,7 @@ def test_pfd_mask_eq_and_pickle():
 def test_transmitter_eirp_complex_antenna():
     p = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
     a = lox.PatternedAntenna(pattern=p)
-    stats = link_stats(make_tx(antenna=a), make_rx())
+    stats = link_budget(make_tx(antenna=a), make_rx())
     assert math.isfinite(float(stats.eirp))
 
 
@@ -1163,24 +1150,22 @@ def test_lumped_link_interference_requires_absolute_power():
     rx = lox.GtModel(KA_BAND, 3.01 * lox.dB)
     channel = lox.Channel(symbol_rate=5.0 * lox.MHz)
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    link = link_stats(tx, rx, bandwidth=channel.bandwidth())
-    modulated = mc.evaluate(link, channel, design_margin=3.0 * lox.dB)
+    link = link_budget(tx, rx)
+    modulated = link.modulate(channel, mc, design_margin=3.0 * lox.dB)
 
     with pytest.raises(ValueError, match="absolute carrier and noise powers"):
         modulated.with_interference(1e-12 * lox.W)
 
 
-# --- ModulatedLinkStats.with_interference happy path ---
+# --- ModulatedLinkBudget.with_interference happy path ---
 
 
 def test_modulated_with_interference_component_tier():
     channel = lox.Channel(symbol_rate=5.0 * lox.MHz)
 
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    link = link_stats(
-        make_tx(), make_rx(), bandwidth=channel.bandwidth()
-    )
-    modulated = mc.evaluate(link, channel, design_margin=3.0 * lox.dB)
+    link = link_budget(make_tx(), make_rx())
+    modulated = link.modulate(channel, mc, design_margin=3.0 * lox.dB)
     interference = modulated.with_interference(1e-12 * lox.W)
 
     assert float(interference.margin_with_interference) < float(modulated.margin)
@@ -1208,19 +1193,19 @@ def test_channel_dsss_pickle():
     assert float(restored.processing_gain()) == pytest.approx(float(ch.processing_gain()), abs=1e-10)
 
 
-# --- LinkStats pattern-angle getters and pointing arguments ---
+# --- LinkBudget pattern-angle getters and pointing arguments ---
 
 
 def test_link_stats_off_boresight_angle_reduces_eirp():
     pattern = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
     tx_ant = lox.PatternedAntenna(pattern=pattern)
-    boresight = link_stats(make_tx(antenna=tx_ant), make_rx())
-    off = link_stats(make_tx(antenna=tx_ant), make_rx(), tx_angle=2.0 * lox.deg)
+    boresight = link_budget(make_tx(antenna=tx_ant), make_rx())
+    off = link_budget(make_tx(antenna=tx_ant), make_rx(), tx_angle=2.0 * lox.deg)
     assert float(off.eirp) < float(boresight.eirp)
 
 
 def test_link_stats_defaults_to_boresight():
-    stats = link_stats(make_tx(), make_rx())
+    stats = link_budget(make_tx(), make_rx())
     assert float(stats.c_n0) == pytest.approx(104.913, abs=0.1)
 
 
@@ -1230,12 +1215,12 @@ def test_link_stats_direction_pointing():
     pattern = lox.ParabolicPattern(diameter=0.98 * lox.m, efficiency=0.45)
     tx_ant = lox.PatternedAntenna(pattern=pattern, frame=frame)
 
-    on_axis = link_stats(
+    on_axis = link_budget(
         make_tx(antenna=tx_ant),
         make_rx(),
         tx_direction=[1.0, 0.0, 0.0],
     )
-    off_axis = link_stats(
+    off_axis = link_budget(
         make_tx(antenna=tx_ant),
         make_rx(),
         tx_direction=[0.0, 0.0, 1.0],
@@ -1246,7 +1231,7 @@ def test_link_stats_direction_pointing():
 
 def test_link_stats_rejects_angle_and_direction():
     with pytest.raises(ValueError, match="tx_angle or tx_direction"):
-        link_stats(
+        link_budget(
             make_tx(),
             make_rx(),
             tx_angle=1.0 * lox.deg,
@@ -1254,17 +1239,19 @@ def test_link_stats_rejects_angle_and_direction():
         )
 
 
-# --- ModulatedLinkStats link and channel getters ---
+# --- ModulatedLinkBudget budget and channel getters ---
 
 
 def test_modulated_link_stats_link_and_channel_getters():
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
-    modulated = mc.evaluate(stats, ch)
+    stats = link_budget(make_tx(), make_rx())
+    modulated = stats.modulate(ch, mc)
 
-    # link getter returns the underlying PyLinkStats
-    assert modulated.link.c_n0 == stats.c_n0
+    # budget getter returns the underlying LinkBudget
+    assert modulated.budget.c_n0 == stats.c_n0
+    assert math.isfinite(float(modulated.c_n))
+    assert modulated.closes()
     # channel and modcod getters round-trip
     assert modulated.channel == ch
     assert modulated.modcod == mc
@@ -1277,10 +1264,8 @@ def test_modulated_link_stats_link_and_channel_getters():
 def test_interference_stats_c_n0i0_and_repr():
     channel = lox.Channel(symbol_rate=5.0 * lox.MHz)
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    link = link_stats(
-        make_tx(), make_rx(), bandwidth=channel.bandwidth()
-    )
-    modulated = mc.evaluate(link, channel, design_margin=3.0 * lox.dB)
+    link = link_budget(make_tx(), make_rx())
+    modulated = link.modulate(channel, mc, design_margin=3.0 * lox.dB)
     interference = modulated.with_interference(1e-12 * lox.W)
 
     assert math.isfinite(float(interference.c_n0i0))
@@ -1289,16 +1274,16 @@ def test_interference_stats_c_n0i0_and_repr():
     assert "c_n0i0" in r
 
 
-# --- ModulatedLinkStats repr ---
+# --- ModulatedLinkBudget repr ---
 
 
 def test_modulated_link_stats_repr():
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
     mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
-    stats = link_stats(make_tx(), make_rx(), bandwidth=ch.bandwidth())
-    modulated = mc.evaluate(stats, ch)
+    stats = link_budget(make_tx(), make_rx())
+    modulated = stats.modulate(ch, mc)
     r = repr(modulated)
-    assert "ModulatedLinkStats" in r
+    assert "ModulatedLinkBudget" in r
     assert "eb_n0=" in r
     assert "margin=" in r
 
@@ -1356,7 +1341,7 @@ def test_frequency_range():
 def test_for_link_reference_values():
     # 46 dBi + 10 W \u2212 1 dB feed loss \u2192 EIRP 55 dBW;
     # 30 dBi / 500 K \u2192 G/T 3.0103 dB/K; C/N0 104.913 dB\u00b7Hz at 1000 km.
-    stats = link_stats(make_tx(), make_rx())
+    stats = link_budget(make_tx(), make_rx())
 
     assert float(stats.eirp) == pytest.approx(55.0, abs=0.01)
     assert float(stats.gt) == pytest.approx(3.0103, abs=0.01)
@@ -1365,26 +1350,24 @@ def test_for_link_reference_values():
 
 
 def test_lumped_link():
-    stats = lox.LinkStats.for_link(
+    stats = lox.LinkBudget(
         lox.EirpModel(KA_BAND, 55.0 * lox.dB),
         lox.GtModel(KA_BAND, 3.01 * lox.dB),
         carrier=29.0 * lox.GHz,
-        bandwidth=5.0 * lox.MHz,
         range=1000.0 * lox.km,
     )
     assert float(stats.c_n0) == pytest.approx(104.913, abs=0.1)
     assert stats.carrier_rx_power is None
-    assert stats.noise_power is None
+    assert stats.noise_power(5.0 * lox.MHz) is None
 
 
 def test_for_link_carrier_out_of_band():
     rx_band = lox.FrequencyRange(17.0 * lox.GHz, 21.0 * lox.GHz)
     with pytest.raises(ValueError, match="outside the supported range"):
-        lox.LinkStats.for_link(
+        lox.LinkBudget(
             lox.EirpModel(KA_BAND, 55.0 * lox.dB),
             lox.GtModel(rx_band, 3.01 * lox.dB),
             carrier=29.0 * lox.GHz,
-            bandwidth=5.0 * lox.MHz,
             range=1000.0 * lox.km,
         )
 
@@ -1438,11 +1421,10 @@ def test_shared_antenna_transceiver():
         feed_loss=0.5 * lox.dB,
     )
     assert tx.antenna == rx.antenna
-    link = lox.LinkStats.for_link(
+    link = lox.LinkBudget(
         tx,
         lox.GtModel(KA_BAND, 30.0 * lox.dB),
         carrier=29.0 * lox.GHz,
-        bandwidth=5.0 * lox.MHz,
         range=1000.0 * lox.km,
         rx_angle=0.0 * lox.deg,
     )
@@ -1616,23 +1598,20 @@ def test_for_link_error_paths():
     rx = lox.GtModel(KA_BAND, 3.01 * lox.dB)
     # Wrong terminal types
     with pytest.raises(ValueError, match="expected a TxChain or EirpModel"):
-        lox.LinkStats.for_link(
+        lox.LinkBudget(
             rx, rx,
-            carrier=29.0 * lox.GHz, bandwidth=5.0 * lox.MHz,
-            range=1000.0 * lox.km,
+            carrier=29.0 * lox.GHz, range=1000.0 * lox.km,
         )
     with pytest.raises(ValueError, match="expected an RxChain or GtModel"):
-        lox.LinkStats.for_link(
+        lox.LinkBudget(
             tx, tx,
-            carrier=29.0 * lox.GHz, bandwidth=5.0 * lox.MHz,
-            range=1000.0 * lox.km,
+            carrier=29.0 * lox.GHz, range=1000.0 * lox.km,
         )
     # Non-physical link inputs
     with pytest.raises(ValueError, match="non-physical"):
-        lox.LinkStats.for_link(
+        lox.LinkBudget(
             tx, rx,
-            carrier=29.0 * lox.GHz, bandwidth=0.0 * lox.MHz,
-            range=1000.0 * lox.km,
+            carrier=29.0 * lox.GHz, range=0.0 * lox.km,
         )
 
 

--- a/crates/lox-space/tests/test_spacelink_comms.py
+++ b/crates/lox-space/tests/test_spacelink_comms.py
@@ -18,13 +18,13 @@ spacelink function mapping:
     | lox.ParabolicPattern.peak_gain()                   | spacelink.core.antenna.dish_gain()                      |
     | lox.GaussianPattern.peak_gain()                    | spacelink.core.antenna.dish_gain()                      |
     | lox.CascadeReceiver.chain_noise_temperature()      | spacelink.core.noise.noise_factor_to_temperature()      |
-    | lox.LinkStats.for_link() noise_power               | spacelink.core.noise.noise_power()                      |
+    | lox.LinkBudget noise_power()                       | spacelink.core.noise.noise_power()                      |
     | lox.Channel.eb_n0()                                | spacelink.core.noise.cn0_to_ebn0()                      |
     | lox noise_figure round-trip                        | spacelink.core.noise.temperature_to_noise_figure()      |
     | lox noise_power_density (via k_B constant)         | spacelink.core.noise.noise_power_density()              |
     | lox G/T decomposition                              | spacelink.core.antenna.gain_from_g_over_t()             |
     | lox.DipolePattern.peak_gain()                      | (no spacelink equivalent — see internal unit tests)     |
-    | lox.LinkStats.for_link() C/N0                      | (no spacelink equivalent)                               |
+    | lox.LinkBudget C/N0                                | (no spacelink equivalent)                               |
 """
 
 import math
@@ -52,8 +52,8 @@ BOLTZMANN_CONSTANT = 1.380649e-23
 WIDE_BAND = lox.FrequencyRange(1.0 * lox.GHz, 31.0 * lox.GHz)
 
 
-def noise_temp_link_stats(t_sys_k, bandwidth_hz, rx_gain_db=30.0):
-    """Evaluates a 10 GHz link against a known-T_sys receiver and returns LinkStats."""
+def noise_temp_link_budget(t_sys_k, rx_gain_db=30.0):
+    """Computes a 10 GHz link budget against a known-T_sys receiver."""
     tx = lox.TxChain(
         lox.ConstantAntenna(gain=30.0 * lox.dB),
         lox.AmplifierTransmitter(power=10.0 * lox.W),
@@ -65,11 +65,10 @@ def noise_temp_link_stats(t_sys_k, bandwidth_hz, rx_gain_db=30.0):
         band=WIDE_BAND,
         antenna_noise_temperature=0.0 * lox.K,
     )
-    return lox.LinkStats.for_link(
+    return lox.LinkBudget(
         tx,
         rx,
         carrier=10.0 * lox.GHz,
-        bandwidth=bandwidth_hz * lox.Hz,
         range=1000.0 * lox.km,
     )
 
@@ -256,10 +255,10 @@ def test_cn0_to_ebn0(cn0_dbhz, data_rate_hz):
 
 
 # ---------------------------------------------------------------------------
-# Test 8: LinkStats.for_link() noise_power vs spacelink
+# Test 8: LinkBudget.noise_power() vs spacelink
 #
 # spacelink.core.noise.noise_power(bandwidth, temperature) computes k_B·T·BW
-# in watts. LinkStats.noise_power is the same quantity in dBW as
+# in watts. LinkBudget.noise_power(bw) is the same quantity in dBW as
 # 10·log₁₀(T_sys · k_B · BW).
 # ---------------------------------------------------------------------------
 
@@ -272,17 +271,17 @@ NOISE_POWER_CASES = [
 
 
 def t_sys_from_stats(stats, bandwidth_hz):
-    """Recovers T_sys in Kelvin from the noise power reported by LinkStats."""
-    return 10.0 ** (float(stats.noise_power) / 10.0) / (
+    """Recovers T_sys in Kelvin from the noise power reported by LinkBudget."""
+    return 10.0 ** (float(stats.noise_power(bandwidth_hz * lox.Hz)) / 10.0) / (
         BOLTZMANN_CONSTANT * bandwidth_hz
     )
 
 
 @pytest.mark.parametrize("t_sys_k,bandwidth_hz", NOISE_POWER_CASES)
 def test_noise_power(t_sys_k, bandwidth_hz):
-    """LinkStats.noise_power should agree with spacelink to 0.001 dBW."""
-    stats = noise_temp_link_stats(t_sys_k, bandwidth_hz)
-    lox_dbw = float(stats.noise_power)
+    """LinkBudget.noise_power should agree with spacelink to 0.001 dBW."""
+    stats = noise_temp_link_budget(t_sys_k)
+    lox_dbw = float(stats.noise_power(bandwidth_hz * lox.Hz))
     sl_w = float(sl_noise_power(bandwidth_hz * u.Hz, t_sys_k * u.K).to(u.W).value)
     sl_dbw = 10.0 * math.log10(sl_w)
     assert lox_dbw == pytest.approx(sl_dbw, abs=1e-3)
@@ -325,9 +324,9 @@ NPD_CASES = [150.0, 290.0, 500.0, 1000.0]
 @pytest.mark.parametrize("t_sys_k", NPD_CASES)
 def test_noise_power_density(t_sys_k):
     """k_B · T should agree between lox and spacelink to 0.001 dB."""
-    stats = noise_temp_link_stats(t_sys_k, 1.0)
+    stats = noise_temp_link_budget(t_sys_k)
     # noise_power(BW=1Hz) = 10·log₁₀(k_B · T · 1) = noise power density in dBW/Hz
-    lox_dbw_hz = float(stats.noise_power)
+    lox_dbw_hz = float(stats.noise_power(1.0 * lox.Hz))
     sl_w_hz = float(sl_npd(t_sys_k * u.K).to(u.W / u.Hz).value)
     sl_dbw_hz = 10.0 * math.log10(sl_w_hz)
     assert lox_dbw_hz == pytest.approx(sl_dbw_hz, abs=1e-3)
@@ -336,7 +335,7 @@ def test_noise_power_density(t_sys_k):
 # ---------------------------------------------------------------------------
 # Test 11: G/T decomposition
 #
-# Compute G/T in lox (via LinkStats), then use spacelink gain_from_g_over_t
+# Compute G/T in lox (via LinkBudget), then use spacelink gain_from_g_over_t
 # to recover the antenna gain from G/T and T_sys. This validates that lox's
 # G/T formula is consistent with the standard definition.
 # ---------------------------------------------------------------------------
@@ -352,7 +351,7 @@ GT_CASES = [
 @pytest.mark.parametrize("gain_db,t_sys_k", GT_CASES)
 def test_gt_decomposition(gain_db, t_sys_k):
     """G/T computed by lox should decompose correctly via spacelink."""
-    stats = noise_temp_link_stats(t_sys_k, 1e6, rx_gain_db=gain_db)
+    stats = noise_temp_link_budget(t_sys_k, rx_gain_db=gain_db)
     lox_gt = float(stats.gt)
     # Use spacelink to recover gain from G/T and T_sys
     recovered_gain = float(
@@ -407,11 +406,10 @@ def test_friis_cascade_feed_loss():
         antenna_noise_temperature=t_ant * lox.K,
         feed_loss=feed_loss_db * lox.dB,
     )
-    stats = lox.LinkStats.for_link(
+    stats = lox.LinkBudget(
         tx,
         rx,
         carrier=10.0 * lox.GHz,
-        bandwidth=bandwidth_hz * lox.Hz,
         range=1000.0 * lox.km,
     )
     lox_t_sys = t_sys_from_stats(stats, bandwidth_hz)
@@ -509,14 +507,13 @@ def test_tdrs_ka_band_return_link():
     # --- Link budget ---
     range_km = 40000.0
     bandwidth_hz = float(channel.bandwidth())
-    stats = lox.LinkStats.for_link(
+    stats = lox.LinkBudget(
         tx,
         rx,
         carrier=freq,
-        bandwidth=channel.bandwidth(),
         range=range_km * lox.km,
     )
-    modulated = modcod.evaluate(stats, channel, design_margin=3.0 * lox.dB)
+    modulated = stats.modulate(channel, modcod, design_margin=3.0 * lox.dB)
 
     # Verify T_sys via Friis: T_ant + T_LNA + T_rx/G_LNA (zero feed loss)
     g_lna = 10.0 ** (lna_gain_db / 10.0)

--- a/crates/lox-space/tests/test_stubs.py
+++ b/crates/lox-space/tests/test_stubs.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 Helge Eichhorn <git@helgeeichhorn.de>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""The type stub must cover every public runtime export."""
+
+import ast
+import pathlib
+
+import lox_space as lox
+
+
+def test_stub_covers_all_exports():
+    stub = pathlib.Path(__file__).parents[3] / "lox_space.pyi"
+    tree = ast.parse(stub.read_text())
+    stub_names = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef))
+    }
+    stub_names |= {
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    stub_names |= {
+        node.target.id
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+    }
+
+    exported = {
+        name
+        for name in dir(lox)
+        if not name.startswith("_") and name != "lox_space"
+    }
+    missing = exported - stub_names
+    assert not missing, f"exported but missing from the stub: {sorted(missing)}"

--- a/crates/lox-space/tests/test_stubs.py
+++ b/crates/lox-space/tests/test_stubs.py
@@ -12,7 +12,7 @@ import lox_space as lox
 
 def test_stub_covers_all_exports():
     stub = pathlib.Path(__file__).parents[3] / "lox_space.pyi"
-    tree = ast.parse(stub.read_text())
+    tree = ast.parse(stub.read_text(encoding="utf-8"))
     stub_names = {
         node.name
         for node in tree.body

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2706,19 +2706,6 @@ class ModCod:
     def information_rate(self, symbol_rate: Frequency) -> Frequency:
         """Returns the information bit rate at the given symbol rate."""
         ...
-    def evaluate(
-        self,
-        link: LinkStats,
-        channel: Channel,
-        design_margin: Decibel | None = None,
-    ) -> ModulatedLinkStats:
-        """Evaluates a link budget on a channel against this MODCOD.
-
-        Raises:
-            ValueError: if the link's noise bandwidth does not match the
-                channel's occupied bandwidth.
-        """
-        ...
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
@@ -2969,14 +2956,30 @@ class GtModel:
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
 
-class LinkStats:
-    """Modulation-agnostic link budget statistics."""
-    @staticmethod
-    def for_link(
+class LinkBudget:
+    """A modulation-agnostic link budget between two link terminals.
+
+    All outputs are bandwidth-free; use ``modulate`` to apply a waveform and
+    MODCOD, or the ``c_n``/``noise_power`` methods for ad-hoc bandwidths.
+
+    Args:
+        tx: The transmit terminal (TxChain or EirpModel).
+        rx: The receive terminal (RxChain or GtModel).
+        carrier: Carrier frequency.
+        range: Slant range as Distance.
+        tx_angle: Off-boresight angle at transmitter as Angle (optional).
+        rx_angle: Off-boresight angle at receiver as Angle (optional).
+        tx_direction: Line-of-sight direction at transmitter as [x, y, z] (optional).
+        rx_direction: Line-of-sight direction at receiver as [x, y, z] (optional).
+        losses: PropagationLosses (optional, defaults to none).
+        link_type: "uplink", "downlink", or "crosslink" (optional). On
+            downlinks the budget uses the rain-degraded G/T (ITU-R P.618 §8.2).
+    """
+    def __new__(
+        cls,
         tx: TxTerminal,
         rx: RxTerminal,
         carrier: Frequency,
-        bandwidth: Frequency,
         range: Distance,
         tx_angle: Angle | None = None,
         rx_angle: Angle | None = None,
@@ -2984,16 +2987,15 @@ class LinkStats:
         rx_direction: list[float] | None = None,
         losses: PropagationLosses | None = None,
         link_type: str | None = None,
-    ) -> LinkStats:
-        """Computes a modulation-agnostic link budget between two link terminals.
-
-        The carrier must lie inside both terminals' frequency ranges. Each
-        terminal's pointing is given either as an off-boresight angle or as a
-        line-of-sight direction vector in the antenna's parent frame; omitting
-        both assumes ideal (boresight) pointing. On downlinks
-        (``link_type="downlink"``) the budget uses the rain-degraded G/T
-        (ITU-R P.618 §8.2).
-        """
+    ) -> Self: ...
+    def modulate(
+        self,
+        channel: Channel,
+        modcod: ModCod,
+        design_margin: Decibel | None = None,
+    ) -> ModulatedLinkBudget:
+        """Applies a waveform and a MODCOD to this budget. Everything
+        bandwidth-dependent derives from the channel."""
         ...
     @property
     def slant_range(self) -> Distance:
@@ -3024,21 +3026,16 @@ class LinkStats:
     def c_n0(self) -> Decibel:
         """Carrier-to-noise density ratio in dB·Hz."""
         ...
-    @property
-    def c_n(self) -> Decibel:
-        """C/N in dB."""
+    def c_n(self, bandwidth: Frequency) -> Decibel:
+        """Returns C/N in dB for the given noise bandwidth."""
         ...
     @property
     def carrier_rx_power(self) -> Decibel | None:
         """Received carrier power in dBW. ``None`` for lumped G/T receivers."""
         ...
-    @property
-    def noise_power(self) -> Decibel | None:
-        """Noise power in dBW. ``None`` for lumped G/T receivers."""
-        ...
-    @property
-    def bandwidth(self) -> Frequency:
-        """Channel noise bandwidth."""
+    def noise_power(self, bandwidth: Frequency) -> Decibel | None:
+        """Returns the noise power in dBW for the given bandwidth. ``None``
+        for lumped G/T receivers."""
         ...
     @property
     def frequency(self) -> Frequency:
@@ -3046,30 +3043,10 @@ class LinkStats:
         ...
     def __repr__(self) -> str: ...
 
-class InterferenceStats:
-    """Interference statistics for a link with a given interferer power."""
-    @property
-    def interference_power(self) -> Power:
-        """Interference power."""
-        ...
-    @property
-    def c_n0i0(self) -> Decibel:
-        """Carrier-to-noise-plus-interference density ratio in dB·Hz."""
-        ...
-    @property
-    def eb_n0i0(self) -> Decibel:
-        """Eb/(N0+I0) in dB."""
-        ...
-    @property
-    def margin_with_interference(self) -> Decibel:
-        """Link margin with interference in dB."""
-        ...
-    def __repr__(self) -> str: ...
-
-class ModulatedLinkStats:
+class ModulatedLinkBudget:
     """Link-budget output with a modulation and coding scheme applied."""
     @property
-    def link(self) -> LinkStats:
+    def budget(self) -> LinkBudget:
         """The underlying modulation-agnostic link budget."""
         ...
     @property
@@ -3091,6 +3068,9 @@ class ModulatedLinkStats:
     def information_rate(self) -> Frequency:
         """Information bit rate: symbol rate × info bits per symbol."""
         ...
+    def closes(self) -> bool:
+        """Returns whether the link closes: margin >= 0."""
+        ...
     @property
     def es_n0(self) -> Decibel:
         """Es/N0 (energy per symbol to noise spectral density) in dB."""
@@ -3098,6 +3078,10 @@ class ModulatedLinkStats:
     @property
     def eb_n0(self) -> Decibel:
         """Eb/N0 (energy per information bit to noise spectral density) in dB."""
+        ...
+    @property
+    def c_n(self) -> Decibel:
+        """C/N in dB in the channel's occupied bandwidth."""
         ...
     @property
     def margin(self) -> Decibel:

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -16,6 +16,12 @@ type Unit = Literal["seconds", "days", "centuries"]
 class NonFiniteTimeDeltaError(Exception):
     """Raised when a TimeDelta operation produces a non-finite result."""
 
+class EopParserError(Exception):
+    """Raised when Earth orientation parameter data cannot be parsed."""
+
+class EopProviderError(Exception):
+    """Raised when Earth orientation parameters cannot be provided."""
+
     ...
 
 # Unit classes
@@ -3036,7 +3042,11 @@ class LinkBudget:
         """Carrier-to-noise density ratio in dB·Hz."""
         ...
     def c_n(self, bandwidth: Frequency) -> Decibel:
-        """Returns C/N in dB for the given noise bandwidth."""
+        """Returns C/N in dB for the given noise bandwidth.
+
+        Raises:
+            ValueError: if the bandwidth is not finite and positive.
+        """
         ...
     @property
     def carrier_rx_power(self) -> Decibel | None:
@@ -3044,11 +3054,35 @@ class LinkBudget:
         ...
     def noise_power(self, bandwidth: Frequency) -> Decibel | None:
         """Returns the noise power in dBW for the given bandwidth. ``None``
-        for lumped G/T receivers."""
+        for lumped G/T receivers.
+
+        Raises:
+            ValueError: if the bandwidth is not finite and positive.
+        """
         ...
     @property
     def frequency(self) -> Frequency:
         """Link frequency."""
+        ...
+    def __repr__(self) -> str: ...
+
+class InterferenceStats:
+    """Interference statistics for a link with a given interferer power."""
+    @property
+    def interference_power(self) -> Power:
+        """Interference power."""
+        ...
+    @property
+    def c_n0i0(self) -> Decibel:
+        """Carrier-to-noise-plus-interference density ratio in dB·Hz."""
+        ...
+    @property
+    def eb_n0i0(self) -> Decibel:
+        """Eb/(N0+I0) in dB."""
+        ...
+    @property
+    def margin_with_interference(self) -> Decibel:
+        """Link margin with interference in dB."""
         ...
     def __repr__(self) -> str: ...
 

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2988,6 +2988,15 @@ class LinkBudget:
         losses: PropagationLosses | None = None,
         link_type: str | None = None,
     ) -> Self: ...
+    def modulate_best(
+        self,
+        channel: Channel,
+        table: list[ModCod],
+        design_margin: Decibel | None = None,
+    ) -> ModulatedLinkBudget | None:
+        """Selects and applies the best MODCOD from a table (ACM). The
+        result always closes; ``None`` means no mode in the table closes."""
+        ...
     def modulate(
         self,
         channel: Channel,


### PR DESCRIPTION
LinkBudget::new(tx, rx, &LinkConditions) -> budget.modulate(channel,
modcod, design_margin) -> ModulatedLinkBudget { closes(), ... }. The
agnostic stage is bandwidth-free (C/N and noise power take an explicit
bandwidth); the modulated stage derives everything from the channel, so
modulate is infallible and BandwidthMismatch is gone structurally.
