### PR TITLE
feat(lox-comms): line-item budget report and C/N combining (Track F.1/F.2)

### DIFF
--- a/crates/lox-comms/src/link_budget.rs
+++ b/crates/lox-comms/src/link_budget.rs
@@ -197,6 +197,62 @@ pub struct InterferenceStats {
     pub margin_with_interference: Decibel,
 }
 
+/// The role a line plays in a budget table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum LineKind {
+    /// A contribution that increases the link quality (EIRP, G/T, ...).
+    Gain,
+    /// A contribution that decreases the link quality (FSPL, rain, ...).
+    Loss,
+    /// An intermediate result (C/N, Es/N0, Eb/N0).
+    Subtotal,
+    /// A final result (C/N0, link margin).
+    Total,
+}
+
+/// One line of a link-budget report.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BudgetLine {
+    /// Human-readable label, e.g. `"Free-space path loss"`.
+    pub label: String,
+    /// Value in decibels (gains and losses are both positive).
+    pub value: Decibel,
+    /// The role of this line.
+    pub kind: LineKind,
+}
+
+impl BudgetLine {
+    fn new(label: impl Into<String>, value: Decibel, kind: LineKind) -> Self {
+        Self {
+            label: label.into(),
+            value,
+            kind,
+        }
+    }
+}
+
+/// Renders budget lines as an aligned table.
+fn render_budget(f: &mut core::fmt::Formatter<'_>, lines: &[BudgetLine]) -> core::fmt::Result {
+    let width = lines.iter().map(|l| l.label.len()).max().unwrap_or(0);
+    for line in lines {
+        let sign = match line.kind {
+            LineKind::Gain => "+",
+            LineKind::Loss => "-",
+            LineKind::Subtotal | LineKind::Total => "=",
+        };
+        writeln!(
+            f,
+            "{sign} {:width$}  {:>10.2} dB",
+            line.label,
+            line.value.as_f64(),
+        )?;
+    }
+    Ok(())
+}
+
 /// The conditions a link budget is evaluated under: carrier, slant range,
 /// environmental losses, link direction, and the pointing at each end.
 ///
@@ -493,6 +549,41 @@ impl LinkBudget {
         ))
     }
 
+    /// Returns the budget as ordered report lines:
+    /// EIRP → FSPL → propagation losses (itemized) → G/T (+ rain
+    /// degradation) → Boltzmann constant → C/N₀.
+    ///
+    /// Gains minus losses equal the C/N₀ total exactly; the Boltzmann line
+    /// carries the +228.6 dB(Hz·K/W) term that makes the column sum.
+    pub fn budget_lines(&self) -> Vec<BudgetLine> {
+        let mut lines = vec![
+            BudgetLine::new("EIRP", self.eirp, LineKind::Gain),
+            BudgetLine::new("Free-space path loss", self.fspl, LineKind::Loss),
+        ];
+        for loss in self.losses.lines() {
+            lines.push(BudgetLine::new(
+                loss.kind().label(),
+                loss.value(),
+                LineKind::Loss,
+            ));
+        }
+        lines.push(BudgetLine::new("G/T", self.gt, LineKind::Gain));
+        if let Some(gt_degraded) = self.gt_degraded {
+            lines.push(BudgetLine::new(
+                "G/T degradation due to rain",
+                self.gt - gt_degraded,
+                LineKind::Loss,
+            ));
+        }
+        lines.push(BudgetLine::new(
+            "Boltzmann constant",
+            -BOLTZMANN_CONSTANT_DB,
+            LineKind::Gain,
+        ));
+        lines.push(BudgetLine::new("C/N0", self.c_n0, LineKind::Total));
+        lines
+    }
+
     /// Selects and applies the best MODCOD from a table: the
     /// highest-efficiency mode that closes on this channel with the given
     /// design margin (adaptive coding and modulation).
@@ -540,6 +631,12 @@ impl LinkBudget {
     }
 }
 
+impl core::fmt::Display for LinkBudget {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        render_budget(f, &self.budget_lines())
+    }
+}
+
 /// Link-budget output with a modulation and coding scheme applied.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -580,6 +677,32 @@ impl ModulatedLinkBudget {
             .information_rate(self.channel.symbol_rate())
     }
 
+    /// Returns the budget as ordered report lines: the underlying link
+    /// budget extended with C/N, Es/N0, Eb/N0, the MODCOD threshold, the
+    /// design margin, and the link margin.
+    pub fn budget_lines(&self) -> Vec<BudgetLine> {
+        let mut lines = self.budget.budget_lines();
+        lines.push(BudgetLine::new(
+            "C/N (occupied bandwidth)",
+            self.c_n,
+            LineKind::Subtotal,
+        ));
+        lines.push(BudgetLine::new("Es/N0", self.es_n0, LineKind::Subtotal));
+        lines.push(BudgetLine::new("Eb/N0", self.eb_n0, LineKind::Subtotal));
+        lines.push(BudgetLine::new(
+            format!("Required Eb/N0 ({})", self.modcod.mode().name()),
+            self.modcod.required_eb_n0(),
+            LineKind::Loss,
+        ));
+        lines.push(BudgetLine::new(
+            "Design margin",
+            self.design_margin,
+            LineKind::Loss,
+        ));
+        lines.push(BudgetLine::new("Link margin", self.margin, LineKind::Total));
+        lines
+    }
+
     /// Returns interference statistics for the given interferer power.
     ///
     /// Returns an error when absolute carrier or noise power is unavailable
@@ -615,6 +738,30 @@ impl ModulatedLinkBudget {
             margin_with_interference,
         })
     }
+}
+
+impl core::fmt::Display for ModulatedLinkBudget {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        render_budget(f, &self.budget_lines())
+    }
+}
+
+/// Combines carrier-to-noise contributions in the linear domain:
+/// 1/(C/N)_total = Σ 1/(C/N)_i.
+///
+/// The standard composition for bent-pipe/relay budgets (uplink + downlink
+/// transponder) and C/(N+I+IM) pooling. An empty slice yields +∞ dB — no
+/// contribution degrades the link.
+pub fn combine_c_n(contributions: &[Decibel]) -> Decibel {
+    if contributions.is_empty() {
+        return Decibel::new(f64::INFINITY);
+    }
+    Decibel::from_linear(
+        1.0 / contributions
+            .iter()
+            .map(|c| 1.0 / c.to_linear())
+            .sum::<f64>(),
+    )
 }
 
 /// Computes the frequency overlap factor between a receiver and an interfering transmitter.
@@ -1188,6 +1335,95 @@ mod tests {
             .with_interference(Power::watts(1e-12))
             .unwrap_err();
         assert_eq!(err, LinkBudgetError::AbsolutePowerUnavailable);
+    }
+
+    #[test]
+    fn test_budget_lines_sum_to_c_n0() {
+        let budget = LinkBudget::new(
+            &tx_chain(),
+            &rx_chain(),
+            &faded_params(Some(LinkDirection::Downlink)),
+        )
+        .unwrap();
+        let lines = budget.budget_lines();
+        // Gains minus losses must reproduce the C/N0 total exactly.
+        let sum: f64 = lines
+            .iter()
+            .map(|l| match l.kind {
+                LineKind::Gain => l.value.as_f64(),
+                LineKind::Loss => -l.value.as_f64(),
+                LineKind::Subtotal | LineKind::Total => 0.0,
+            })
+            .sum();
+        let total = lines.last().unwrap();
+        assert_eq!(total.label, "C/N0");
+        assert_eq!(total.kind, LineKind::Total);
+        assert_approx_eq!(sum, total.value.as_f64(), atol <= 1e-10);
+        // The rain degradation appears as its own line on downlinks.
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.label == "G/T degradation due to rain")
+        );
+        // Itemized propagation losses are present.
+        assert!(lines.iter().any(|l| l.label == "Rain attenuation"));
+    }
+
+    #[test]
+    fn test_budget_lines_clear_sky_has_no_degradation_line() {
+        let lines = component_stats().budget_lines();
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.label == "G/T degradation due to rain")
+        );
+    }
+
+    #[test]
+    fn test_modulated_budget_lines_extend_to_margin() {
+        let m = component_stats().modulate(&channel(), &modcod(), 3.0.db());
+        let lines = m.budget_lines();
+        let total = lines.last().unwrap();
+        assert_eq!(total.label, "Link margin");
+        assert_approx_eq!(total.value.as_f64(), m.margin.as_f64(), atol <= 1e-12);
+        // Margin = Eb/N0 − required − design margin, reconstructable from lines.
+        let get = |label: &str| {
+            lines
+                .iter()
+                .find(|l| l.label.starts_with(label))
+                .unwrap()
+                .value
+                .as_f64()
+        };
+        assert_approx_eq!(
+            get("Eb/N0") - get("Required Eb/N0") - get("Design margin"),
+            total.value.as_f64(),
+            atol <= 1e-10
+        );
+    }
+
+    #[test]
+    fn test_budget_display_renders_table() {
+        let m = component_stats().modulate(&channel(), &modcod(), 3.0.db());
+        let table = m.to_string();
+        assert!(table.contains("+ EIRP"));
+        assert!(table.contains("- Free-space path loss"));
+        assert!(table.contains("= Link margin"));
+    }
+
+    #[test]
+    fn test_combine_c_n() {
+        // Two equal contributions halve the linear C/N: −3.01 dB.
+        let combined = combine_c_n(&[10.0.db(), 10.0.db()]);
+        assert_approx_eq!(combined.as_f64(), 10.0 - 3.0103, atol <= 1e-3);
+        // A single contribution passes through.
+        assert_approx_eq!(combine_c_n(&[7.5.db()]).as_f64(), 7.5, atol <= 1e-12);
+        // A dominant weak link controls the total.
+        let combined = combine_c_n(&[30.0.db(), 3.0.db()]);
+        assert!(combined.as_f64() < 3.0);
+        assert!(combined.as_f64() > 2.9);
+        // No contributions: nothing degrades the link.
+        assert!(combine_c_n(&[]).as_f64().is_infinite());
     }
 
     #[test]

--- a/crates/lox-space/docs/comms.md
+++ b/crates/lox-space/docs/comms.md
@@ -193,6 +193,37 @@ best = link.modulate_best(channel, table, design_margin=3.0 * lox.dB)
 print(f"{best.modcod.name}: {float(best.information_rate()) / 1e6:.1f} Mbit/s")
 ```
 
+### Budget Report
+
+Both budget stages render as the line-item table engineers exchange —
+`budget_lines()` returns the data as `(label, value, kind)` tuples and
+`str()` renders it, with gains minus losses reproducing the C/N₀ total
+exactly:
+
+```python
+print(modulated)
+# + EIRP                            55.00 dB
+# - Free-space path loss           181.70 dB
+# - Rain attenuation                 2.00 dB
+# + G/T                              3.01 dB
+# - G/T degradation due to rain      0.99 dB
+# + Boltzmann constant             228.60 dB
+# = C/N0                           101.93 dB
+# = C/N (occupied bandwidth)        93.64 dB
+# = Es/N0                           34.94 dB
+# = Eb/N0                           34.94 dB
+# - Required Eb/N0 (QPSK 1/2)       10.00 dB
+# - Design margin                    3.00 dB
+# = Link margin                     21.94 dB
+```
+
+For bent-pipe/relay budgets, combine per-hop C/N contributions in the
+linear domain with `combine_carrier_to_noise`:
+
+```python
+total = lox.combine_carrier_to_noise([uplink_c_n, downlink_c_n])
+```
+
 Use the component tier (configure antennas, amplifiers, receiver noise) when
 you need the full breakdown — for example for noise-budget allocation or
 detailed component trade studies.

--- a/crates/lox-space/examples/x_band_downlink.rs
+++ b/crates/lox-space/examples/x_band_downlink.rs
@@ -132,43 +132,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let modulated = budget.modulate(&channel, modcod, design_margin);
 
     println!("\n--- Link budget at {} GHz ---", carrier.to_gigahertz());
-    println!(
-        "EIRP:            {:>8.2} dBW",
-        modulated.budget.eirp.as_f64()
-    );
-    println!(
-        "FSPL:            {:>8.2} dB",
-        modulated.budget.fspl.as_f64()
-    );
-    println!(
-        "Env. losses:     {:>8.2} dB",
-        modulated.budget.losses.total().as_f64()
-    );
-    println!(
-        "G/T (clear-sky): {:>8.2} dB/K",
-        modulated.budget.gt.as_f64()
-    );
-    let gt_degraded = modulated
-        .budget
-        .gt_degraded
-        .expect("downlink with RX chain");
-    println!(
-        "G/T (rain):      {:>8.2} dB/K ({:+.2} dB)",
-        gt_degraded.as_f64(),
-        gt_degraded.as_f64() - modulated.budget.gt.as_f64()
-    );
-    println!(
-        "C/N0:            {:>8.2} dB·Hz",
-        modulated.budget.c_n0.as_f64()
-    );
-    println!("C/N:             {:>8.2} dB", modulated.c_n.as_f64());
-    println!("Es/N0:           {:>8.2} dB", modulated.es_n0.as_f64());
-    println!("Eb/N0:           {:>8.2} dB", modulated.eb_n0.as_f64());
+    print!("{modulated}");
     println!(
         "Data rate:       {:>8.1} Mbit/s",
         modulated.information_rate().to_megahertz()
     );
-    println!("Link margin:     {:>8.2} dB", modulated.margin.as_f64());
     assert!(
         modulated.closes(),
         "the downlink should close at worst-case geometry"

--- a/crates/lox-space/src/comms/python.rs
+++ b/crates/lox-space/src/comms/python.rs
@@ -14,7 +14,8 @@ use lox_comms::LinkBudgetError;
 use lox_comms::channel::{Channel, LinkDirection, Modulation};
 use lox_comms::link_budget::{Eirp, GOverT};
 use lox_comms::link_budget::{
-    InterferenceStats, LinkBudget, LinkConditions, ModulatedLinkBudget, frequency_overlap_factor,
+    InterferenceStats, LineKind, LinkBudget, LinkConditions, ModulatedLinkBudget, combine_c_n,
+    frequency_overlap_factor,
 };
 use lox_comms::modcod::{self, ErrorMetric, ModCod};
 use lox_comms::pattern::{AntennaPattern, DipolePattern, GaussianPattern, ParabolicPattern};
@@ -1249,6 +1250,31 @@ impl PyPropagationLosses {
     }
 }
 
+fn line_kind_name(kind: LineKind) -> &'static str {
+    match kind {
+        LineKind::Gain => "gain",
+        LineKind::Loss => "loss",
+        LineKind::Subtotal => "subtotal",
+        LineKind::Total => "total",
+        _ => "unknown",
+    }
+}
+
+fn budget_lines_py(
+    lines: Vec<lox_comms::link_budget::BudgetLine>,
+) -> Vec<(String, PyDecibel, String)> {
+    lines
+        .into_iter()
+        .map(|l| {
+            (
+                l.label,
+                PyDecibel(l.value),
+                line_kind_name(l.kind).to_owned(),
+            )
+        })
+        .collect()
+}
+
 // --- Link Budget ---
 
 /// A modulation-agnostic link budget between two link terminals.
@@ -1404,6 +1430,17 @@ impl PyLinkBudget {
         PyDecibel(self.0.c_n0)
     }
 
+    /// Returns the budget as ordered (label, value, kind) report lines,
+    /// where kind is "gain", "loss", "subtotal", or "total". Gains minus
+    /// losses equal the C/N0 total exactly.
+    fn budget_lines(&self) -> Vec<(String, PyDecibel, String)> {
+        budget_lines_py(self.0.budget_lines())
+    }
+
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
     /// Returns C/N in dB for the given noise bandwidth.
     fn c_n(&self, bandwidth: PyFrequency) -> PyResult<PyDecibel> {
         self.0
@@ -1524,6 +1561,17 @@ impl PyModulatedLinkBudget {
         self.0.closes()
     }
 
+    /// Returns the budget as ordered (label, value, kind) report lines,
+    /// extended with C/N, Es/N0, Eb/N0, the MODCOD threshold, the design
+    /// margin, and the link margin.
+    fn budget_lines(&self) -> Vec<(String, PyDecibel, String)> {
+        budget_lines_py(self.0.budget_lines())
+    }
+
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
     /// The waveform the link was evaluated on.
     #[getter]
     fn channel(&self) -> PyChannel {
@@ -1589,6 +1637,17 @@ impl PyModulatedLinkBudget {
 }
 
 // --- Free functions ---
+
+/// Combines carrier-to-noise contributions in the linear domain:
+/// 1/(C/N)_total = sum(1/(C/N)_i).
+///
+/// Args:
+///     contributions: C/N values as Decibel.
+#[pyfunction]
+pub fn combine_carrier_to_noise(contributions: Vec<PyDecibel>) -> PyDecibel {
+    let contributions: Vec<Decibel> = contributions.into_iter().map(|c| c.0).collect();
+    PyDecibel(combine_c_n(&contributions))
+}
 
 /// Computes the free-space path loss in dB.
 ///

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -16,7 +16,8 @@ use crate::comms::python::{
     PyDecibel, PyDipolePattern, PyEirpModel, PyFrequencyRange, PyGaussianPattern, PyGtModel,
     PyInterferenceStats, PyLinkBudget, PyModCod, PyModulatedLinkBudget, PyModulation, PyNoiseStage,
     PyNoiseTempReceiver, PyParabolicPattern, PyPatternedAntenna, PyPfdMask, PyPropagationLosses,
-    PyRxChain, PyTxChain, freq_overlap, fspl, power_flux_density, slant_range,
+    PyRxChain, PyTxChain, combine_carrier_to_noise, freq_overlap, fspl, power_flux_density,
+    slant_range,
 };
 use crate::constellations::python::{PyConstellation, PyConstellationSatellite};
 use crate::earth::python::ut1::{EopParserError, EopProviderError, PyEopProvider};
@@ -83,6 +84,7 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyEirpModel>()?;
     m.add_class::<PyGtModel>()?;
     m.add_function(wrap_pyfunction!(fspl, m)?)?;
+    m.add_function(wrap_pyfunction!(combine_carrier_to_noise, m)?)?;
     m.add_function(wrap_pyfunction!(freq_overlap, m)?)?;
     m.add_function(wrap_pyfunction!(power_flux_density, m)?)?;
     m.add_function(wrap_pyfunction!(slant_range, m)?)?;

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -922,6 +922,39 @@ def test_propagation_losses_repr_non_absorptive():
     assert "False" in r
 
 
+def test_budget_lines_and_table():
+    ch = lox.Channel(symbol_rate=5 * lox.MHz)
+    mc = lox.ModCod("test", lox.Modulation("QPSK"), 0.5, 10.0 * lox.dB)
+    losses = lox.PropagationLosses(rain=2.0 * lox.dB)
+    budget = link_budget(make_tx(), make_rx(), losses=losses, link_type="downlink")
+    m = budget.modulate(ch, mc, design_margin=3.0 * lox.dB)
+
+    lines = m.budget_lines()
+    labels = [label for label, _, _ in lines]
+    assert labels[0] == "EIRP"
+    assert "Rain attenuation" in labels
+    assert "G/T degradation due to rain" in labels
+    assert labels[-1] == "Link margin"
+    # Gains minus losses reproduce the C/N0 total on the agnostic stage.
+    link_lines = budget.budget_lines()
+    total = sum(
+        float(v) if kind == "gain" else -float(v) if kind == "loss" else 0.0
+        for _, v, kind in link_lines
+    )
+    c_n0 = next(float(v) for label, v, _ in link_lines if label == "C/N0")
+    assert total == pytest.approx(c_n0, abs=1e-9)
+    # The rendered table is the same data.
+    table = str(m)
+    assert "+ EIRP" in table
+    assert "= Link margin" in table
+
+
+def test_combine_carrier_to_noise():
+    combined = lox.combine_carrier_to_noise([10.0 * lox.dB, 10.0 * lox.dB])
+    assert float(combined) == pytest.approx(10.0 - 3.0103, abs=1e-3)
+    assert float(lox.combine_carrier_to_noise([])) == math.inf
+
+
 def test_modulate_best_acm():
     ch = lox.Channel(symbol_rate=5 * lox.MHz)
     budget = link_budget(make_tx(), make_rx())

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -2994,6 +2994,11 @@ class LinkBudget:
         losses: PropagationLosses | None = None,
         link_type: str | None = None,
     ) -> Self: ...
+    def budget_lines(self) -> list[tuple[str, Decibel, str]]:
+        """Returns the budget as ordered (label, value, kind) report lines,
+        where kind is "gain", "loss", "subtotal", or "total"."""
+        ...
+    def __str__(self) -> str: ...
     def modulate_best(
         self,
         channel: Channel,
@@ -3114,6 +3119,11 @@ class ModulatedLinkBudget:
     def closes(self) -> bool:
         """Returns whether the link closes: margin >= 0."""
         ...
+    def budget_lines(self) -> list[tuple[str, Decibel, str]]:
+        """Returns the budget as ordered (label, value, kind) report lines,
+        extended with C/N, Es/N0, Eb/N0, threshold, and margins."""
+        ...
+    def __str__(self) -> str: ...
     @property
     def es_n0(self) -> Decibel:
         """Es/N0 (energy per symbol to noise spectral density) in dB."""
@@ -3134,6 +3144,11 @@ class ModulatedLinkBudget:
         """Computes interference statistics for a given interferer power."""
         ...
     def __repr__(self) -> str: ...
+
+def combine_carrier_to_noise(contributions: list[Decibel]) -> Decibel:
+    """Combines carrier-to-noise contributions in the linear domain:
+    1/(C/N)_total = sum(1/(C/N)_i)."""
+    ...
 
 def fspl(distance: Distance, frequency: Frequency) -> Decibel:
     """Computes the free-space path loss in dB.


### PR DESCRIPTION
budget_lines() on both budget stages with itemized losses, the rain G/T
degradation line, and a Boltzmann line so gains - losses equals C/N0
exactly; Display/__str__ render the table; combine_c_n pools linear
C/N contributions for bent-pipe budgets.
