### PR TITLE
Root finder hardening and cleanup

### DIFF
--- a/crates/lox-core/src/math/optim.rs
+++ b/crates/lox-core/src/math/optim.rs
@@ -5,9 +5,30 @@
 //! Bracketed optimization algorithms.
 
 use lox_approx::approx_eq;
+use thiserror::Error;
 
-use super::roots::{Callback, RootFinderError};
+use super::roots::{Callback, CallbackError};
 use crate::math::float::abs;
+
+/// Error returned by bracketed minimization algorithms.
+#[derive(Debug, Error)]
+pub enum MinimizerError {
+    /// The algorithm did not converge within the maximum number of iterations.
+    #[error(
+        "minimization did not converge after {iterations} iterations at x = {x}, f(x) = {value}"
+    )]
+    NotConverged {
+        /// Number of iterations performed before giving up.
+        iterations: u32,
+        /// The best minimizer estimate reached.
+        x: f64,
+        /// The objective value `f(x)` at the best estimate.
+        value: f64,
+    },
+    /// The objective function returned an error.
+    #[error(transparent)]
+    Callback(#[from] CallbackError),
+}
 
 /// Finds the minimum of a function within a bracket.
 pub trait FindBracketedMinimum<F>
@@ -15,7 +36,7 @@ where
     F: Callback,
 {
     /// Finds the x value that minimizes `f` within the given `bracket`.
-    fn find_minimum_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, RootFinderError>;
+    fn find_minimum_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, MinimizerError>;
 }
 
 /// Brent's method for finding the minimum of a unimodal function in a bracket.
@@ -45,7 +66,7 @@ impl<F> FindBracketedMinimum<F> for BrentMinimizer
 where
     F: Callback,
 {
-    fn find_minimum_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, RootFinderError> {
+    fn find_minimum_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, MinimizerError> {
         let (mut a, mut b) = bracket;
         if a > b {
             core::mem::swap(&mut a, &mut b);
@@ -151,10 +172,10 @@ where
             }
         }
 
-        Err(RootFinderError::NotConverged {
+        Err(MinimizerError::NotConverged {
             iterations: self.max_iter,
             x,
-            residual: fx,
+            value: fx,
         })
     }
 }

--- a/crates/lox-core/src/math/optim.rs
+++ b/crates/lox-core/src/math/optim.rs
@@ -151,7 +151,11 @@ where
             }
         }
 
-        Err(RootFinderError::NotConverged(self.max_iter, fx))
+        Err(RootFinderError::NotConverged {
+            iterations: self.max_iter,
+            x,
+            residual: fx,
+        })
     }
 }
 

--- a/crates/lox-core/src/math/roots.rs
+++ b/crates/lox-core/src/math/roots.rs
@@ -14,8 +14,15 @@ use crate::math::float::{abs, powi, sqrt};
 #[derive(Debug, Error)]
 pub enum RootFinderError {
     /// The algorithm did not converge within the maximum number of iterations.
-    #[error("not converged after {0} iterations, residual {1}")]
-    NotConverged(u32, f64),
+    #[error("not converged after {iterations} iterations at x = {x}, residual {residual}")]
+    NotConverged {
+        /// Number of iterations performed before giving up.
+        iterations: u32,
+        /// The best root estimate reached.
+        x: f64,
+        /// The residual `f(x)` at the best estimate.
+        residual: f64,
+    },
     /// The root is not within the given bracket.
     #[error("root not in bracket")]
     NotInBracket,
@@ -158,14 +165,18 @@ impl core::fmt::Display for ZeroCrossing {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Steffensen {
     max_iter: u32,
-    tolerance: f64,
+    /// Absolute tolerance on the root location.
+    abs_tol: f64,
+    /// Relative tolerance on the root location.
+    rel_tol: f64,
 }
 
 impl Default for Steffensen {
     fn default() -> Self {
         Self {
             max_iter: 1000,
-            tolerance: sqrt(f64::EPSILON),
+            abs_tol: sqrt(f64::EPSILON),
+            rel_tol: sqrt(f64::EPSILON),
         }
     }
 }
@@ -177,15 +188,36 @@ where
     fn find(&self, f: F, initial_guess: f64) -> Result<f64, RootFinderError> {
         let mut p0 = initial_guess;
         for _ in 0..self.max_iter {
-            let f1 = p0 + f.call(p0).map_err(RootFinderError::Callback)?;
-            let f2 = f1 + f.call(f1).map_err(RootFinderError::Callback)?;
+            let fp0 = f.call(p0).map_err(RootFinderError::Callback)?;
+            if !fp0.is_finite() {
+                return Err(RootFinderError::NonFinite(fp0));
+            }
+            // An initial guess that is already a root is returned directly,
+            // avoiding a 0/0 update.
+            if fp0 == 0.0 {
+                return Ok(p0);
+            }
+            let f1 = p0 + fp0;
+            let ff1 = f.call(f1).map_err(RootFinderError::Callback)?;
+            if !ff1.is_finite() {
+                return Err(RootFinderError::NonFinite(ff1));
+            }
+            let f2 = f1 + ff1;
             let p = p0 - powi(f1 - p0, 2) / (f2 - 2.0 * f1 + p0);
-            if approx_eq!(p, p0, atol <= self.tolerance) {
+            if !p.is_finite() {
+                return Err(RootFinderError::NonFinite(p));
+            }
+            if approx_eq!(p, p0, rtol <= self.rel_tol, atol <= self.abs_tol) {
                 return Ok(p);
             }
             p0 = p;
         }
-        Err(RootFinderError::NotConverged(self.max_iter, p0))
+        let residual = f.call(p0).map_err(RootFinderError::Callback)?;
+        Err(RootFinderError::NotConverged {
+            iterations: self.max_iter,
+            x: p0,
+            residual,
+        })
     }
 }
 
@@ -193,14 +225,18 @@ where
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Newton {
     max_iter: u32,
-    tolerance: f64,
+    /// Absolute tolerance on the root location.
+    abs_tol: f64,
+    /// Relative tolerance on the root location.
+    rel_tol: f64,
 }
 
 impl Default for Newton {
     fn default() -> Self {
         Self {
             max_iter: 50,
-            tolerance: sqrt(f64::EPSILON),
+            abs_tol: sqrt(f64::EPSILON),
+            rel_tol: sqrt(f64::EPSILON),
         }
     }
 }
@@ -218,15 +254,34 @@ where
     ) -> Result<f64, RootFinderError> {
         let mut p0 = initial_guess;
         for _ in 0..self.max_iter {
-            let p = p0
-                - f.call(p0).map_err(RootFinderError::Callback)?
-                    / derivative.call(p0).map_err(RootFinderError::Callback)?;
-            if approx_eq!(p, p0, atol <= self.tolerance) {
+            let fx = f.call(p0).map_err(RootFinderError::Callback)?;
+            if !fx.is_finite() {
+                return Err(RootFinderError::NonFinite(fx));
+            }
+            // An initial guess that is already a root is returned directly,
+            // avoiding a 0/0 update at a stationary point.
+            if fx == 0.0 {
+                return Ok(p0);
+            }
+            let dfx = derivative.call(p0).map_err(RootFinderError::Callback)?;
+            if !dfx.is_finite() {
+                return Err(RootFinderError::NonFinite(dfx));
+            }
+            let p = p0 - fx / dfx;
+            if !p.is_finite() {
+                return Err(RootFinderError::NonFinite(p));
+            }
+            if approx_eq!(p, p0, rtol <= self.rel_tol, atol <= self.abs_tol) {
                 return Ok(p);
             }
             p0 = p;
         }
-        Err(RootFinderError::NotConverged(self.max_iter, p0))
+        let residual = f.call(p0).map_err(RootFinderError::Callback)?;
+        Err(RootFinderError::NotConverged {
+            iterations: self.max_iter,
+            x: p0,
+            residual,
+        })
     }
 }
 
@@ -356,7 +411,11 @@ where
             fcur = f.call(xcur).map_err(RootFinderError::Callback)?;
         }
 
-        Err(RootFinderError::NotConverged(self.max_iter, fcur))
+        Err(RootFinderError::NotConverged {
+            iterations: self.max_iter,
+            x: xcur,
+            residual: fcur,
+        })
     }
 }
 
@@ -395,6 +454,72 @@ mod tests {
             )
             .expect("should converge");
         assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-8);
+    }
+
+    #[test]
+    fn test_newton_exact_root_initial_guess() {
+        // f(x) = x^2, f'(x) = 2x. At x = 0 both are zero; the guess is already
+        // the root and must be returned rather than producing 0/0 = NaN.
+        let newton = Newton::default();
+        let act = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(powi(x, 2)) },
+                |x: f64| -> Result { Ok(2.0 * x) },
+                0.0,
+            )
+            .expect("guess is already the root");
+        assert_eq!(act, 0.0);
+    }
+
+    #[test]
+    fn test_newton_zero_derivative_is_non_finite() {
+        // f(x) = x^2 + 1 has no real root; at x = 0 the derivative is zero, so
+        // the step diverges and must be reported as a non-finite error.
+        let newton = Newton::default();
+        let err = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(powi(x, 2) + 1.0) },
+                |x: f64| -> Result { Ok(2.0 * x) },
+                0.0,
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_newton_large_root_relative_tolerance() {
+        // A root at 1e8 is unreachable by an absolute step tolerance of
+        // sqrt(EPSILON); the relative tolerance lets it converge.
+        let newton = Newton::default();
+        let act = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(powi(x, 2) - 1e16) },
+                |x: f64| -> Result { Ok(2.0 * x) },
+                9e7,
+            )
+            .expect("should converge");
+        assert_approx_eq!(act, 1e8, rtol <= 1e-9);
+    }
+
+    #[test]
+    fn test_steffensen_exact_root_initial_guess() {
+        // f(x) = x^2 - 4 has a root at 2; the guess is already the root.
+        let steffensen = Steffensen::default();
+        let act = steffensen
+            .find(|x: f64| -> Result { Ok(powi(x, 2) - 4.0) }, 2.0)
+            .expect("guess is already the root");
+        assert_eq!(act, 2.0);
+    }
+
+    #[test]
+    fn test_steffensen_zero_denominator_is_non_finite() {
+        // A constant non-zero residual makes the Aitken denominator vanish; the
+        // update diverges and must be reported as a non-finite error.
+        let steffensen = Steffensen::default();
+        let err = steffensen
+            .find(|_x: f64| -> Result { Ok(1.0) }, 0.0)
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
     }
 
     #[test]

--- a/crates/lox-core/src/math/roots.rs
+++ b/crates/lox-core/src/math/roots.rs
@@ -88,8 +88,67 @@ pub trait FindBracketedRoot<F>
 where
     F: Callback,
 {
+    /// Finds a root of `f` within `bracket`, reusing the function values at the
+    /// bracket endpoints instead of evaluating them again.
+    ///
+    /// `values` must equal `(f(bracket.0), f(bracket.1))`.
+    fn find_in_bracket_with_values(
+        &self,
+        f: F,
+        bracket: (f64, f64),
+        values: (f64, f64),
+    ) -> Result<f64, RootFinderError>;
+
     /// Finds a root of `f` within the given `bracket`.
-    fn find_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, RootFinderError>;
+    fn find_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, RootFinderError> {
+        let fa = f.call(bracket.0).map_err(RootFinderError::Callback)?;
+        let fb = f.call(bracket.1).map_err(RootFinderError::Callback)?;
+        self.find_in_bracket_with_values(f, bracket, (fa, fb))
+    }
+}
+
+/// Direction of a zero-crossing of a scalar function between two samples.
+///
+/// Classification uses a half-open convention: a sample of `0.0` belongs to the
+/// non-negative ("active") side, so a crossing is a transition between a
+/// negative sample and a non-negative one. This matches the `value >= 0`
+/// convention used by interval/event detection. `NaN` samples do not define a
+/// direction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ZeroCrossing {
+    /// The signal crosses from negative to non-negative.
+    Up,
+    /// The signal crosses from non-negative to negative.
+    Down,
+}
+
+impl ZeroCrossing {
+    /// Classifies the crossing direction between two consecutive samples `s0`
+    /// and `s1`, returning `None` when there is no crossing or either sample is
+    /// `NaN`.
+    ///
+    /// A value of `0.0` counts as the non-negative side, so brackets are
+    /// half-open.
+    pub fn new(s0: f64, s1: f64) -> Option<ZeroCrossing> {
+        if s0.is_nan() || s1.is_nan() {
+            return None;
+        }
+        match (s0 < 0.0, s1 < 0.0) {
+            (true, false) => Some(ZeroCrossing::Up),
+            (false, true) => Some(ZeroCrossing::Down),
+            _ => None,
+        }
+    }
+}
+
+impl core::fmt::Display for ZeroCrossing {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ZeroCrossing::Up => write!(f, "up"),
+            ZeroCrossing::Down => write!(f, "down"),
+        }
+    }
 }
 
 /// Steffensen's method for root-finding (derivative-free).
@@ -190,15 +249,19 @@ impl<F> FindBracketedRoot<F> for Brent
 where
     F: Callback,
 {
-    fn find_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, RootFinderError> {
+    fn find_in_bracket_with_values(
+        &self,
+        f: F,
+        bracket: (f64, f64),
+        values: (f64, f64),
+    ) -> Result<f64, RootFinderError> {
         let mut fblk = 0.0;
         let mut xblk = 0.0;
         let (mut xpre, mut xcur) = bracket;
         let mut spre = 0.0;
         let mut scur = 0.0;
 
-        let mut fpre = f.call(xpre).map_err(RootFinderError::Callback)?;
-        let mut fcur = f.call(xcur).map_err(RootFinderError::Callback)?;
+        let (mut fpre, mut fcur) = values;
 
         if fpre * fcur > 0.0 {
             return Err(RootFinderError::NotInBracket);
@@ -299,12 +362,16 @@ impl<F> FindBracketedRoot<F> for Secant
 where
     F: Callback,
 {
-    fn find_in_bracket(&self, f: F, bracket: (f64, f64)) -> Result<f64, RootFinderError> {
+    fn find_in_bracket_with_values(
+        &self,
+        f: F,
+        bracket: (f64, f64),
+        values: (f64, f64),
+    ) -> Result<f64, RootFinderError> {
         let (x0, x1) = bracket;
         let mut p0 = x0;
         let mut p1 = x1;
-        let mut q0 = f.call(p0).map_err(RootFinderError::Callback)?;
-        let mut q1 = f.call(p1).map_err(RootFinderError::Callback)?;
+        let (mut q0, mut q1) = values;
         if abs(q1) < abs(q0) {
             core::mem::swap(&mut p0, &mut p1);
             core::mem::swap(&mut q0, &mut q1);
@@ -467,5 +534,63 @@ mod tests {
                 (-1.0, 2.0),
             )
             .unwrap();
+    }
+
+    #[test]
+    fn test_zero_crossing() {
+        // Negative -> positive is Up; positive -> negative is Down.
+        assert_eq!(ZeroCrossing::new(-1.0, 1.0), Some(ZeroCrossing::Up));
+        assert_eq!(ZeroCrossing::new(1.0, -1.0), Some(ZeroCrossing::Down));
+        // Same side -> no crossing.
+        assert_eq!(ZeroCrossing::new(-1.0, -2.0), None);
+        assert_eq!(ZeroCrossing::new(1.0, 2.0), None);
+        // Half-open: zero counts as the non-negative side.
+        assert_eq!(ZeroCrossing::new(-1.0, 0.0), Some(ZeroCrossing::Up));
+        assert_eq!(ZeroCrossing::new(0.0, -1.0), Some(ZeroCrossing::Down));
+        assert_eq!(ZeroCrossing::new(0.0, 1.0), None);
+        assert_eq!(ZeroCrossing::new(1.0, 0.0), None);
+        // The sign of zero does not affect classification.
+        assert_eq!(ZeroCrossing::new(-1.0, -0.0), Some(ZeroCrossing::Up));
+        assert_eq!(ZeroCrossing::new(-0.0, -1.0), Some(ZeroCrossing::Down));
+        // NaN never defines a direction.
+        assert_eq!(ZeroCrossing::new(f64::NAN, 1.0), None);
+        assert_eq!(ZeroCrossing::new(-1.0, f64::NAN), None);
+    }
+
+    #[test]
+    fn test_find_in_bracket_with_values_reuses_endpoints() {
+        use core::cell::Cell;
+
+        let f = |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) };
+        let (a, b) = (1.0, 1.5);
+        let fa = powi(a, 3) + 4.0 * powi(a, 2) - 10.0;
+        let fb = powi(b, 3) + 4.0 * powi(b, 2) - 10.0;
+
+        // The value-reuse entry point agrees with the recomputing one.
+        let brent = Brent::default();
+        let via_values = brent
+            .find_in_bracket_with_values(f, (a, b), (fa, fb))
+            .expect("should converge");
+        let via_recompute = brent.find_in_bracket(f, (a, b)).expect("should converge");
+        assert_approx_eq!(via_values, via_recompute, rtol <= 1e-12);
+
+        let secant = Secant::default();
+        let via_values = secant
+            .find_in_bracket_with_values(f, (a, b), (fa, fb))
+            .expect("should converge");
+        assert_approx_eq!(via_values, 1.3652300134140969, rtol <= 1e-8);
+
+        // The supplied endpoints are not re-evaluated.
+        let count = Cell::new(0usize);
+        let counting = |x: f64| -> Result {
+            if x == a || x == b {
+                count.set(count.get() + 1);
+            }
+            Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0)
+        };
+        Brent::default()
+            .find_in_bracket_with_values(counting, (a, b), (fa, fb))
+            .expect("should converge");
+        assert_eq!(count.get(), 0, "endpoints must not be re-evaluated");
     }
 }

--- a/crates/lox-core/src/math/roots.rs
+++ b/crates/lox-core/src/math/roots.rs
@@ -181,6 +181,26 @@ impl Default for Steffensen {
     }
 }
 
+impl Steffensen {
+    /// Sets the maximum number of iterations.
+    pub fn with_max_iter(mut self, max_iter: u32) -> Self {
+        self.max_iter = max_iter;
+        self
+    }
+
+    /// Sets the absolute tolerance on the root location.
+    pub fn with_abs_tol(mut self, abs_tol: f64) -> Self {
+        self.abs_tol = abs_tol;
+        self
+    }
+
+    /// Sets the relative tolerance on the root location.
+    pub fn with_rel_tol(mut self, rel_tol: f64) -> Self {
+        self.rel_tol = rel_tol;
+        self
+    }
+}
+
 impl<F> FindRoot<F> for Steffensen
 where
     F: Callback,
@@ -238,6 +258,26 @@ impl Default for Newton {
             abs_tol: sqrt(f64::EPSILON),
             rel_tol: sqrt(f64::EPSILON),
         }
+    }
+}
+
+impl Newton {
+    /// Sets the maximum number of iterations.
+    pub fn with_max_iter(mut self, max_iter: u32) -> Self {
+        self.max_iter = max_iter;
+        self
+    }
+
+    /// Sets the absolute tolerance on the root location.
+    pub fn with_abs_tol(mut self, abs_tol: f64) -> Self {
+        self.abs_tol = abs_tol;
+        self
+    }
+
+    /// Sets the relative tolerance on the root location.
+    pub fn with_rel_tol(mut self, rel_tol: f64) -> Self {
+        self.rel_tol = rel_tol;
+        self
     }
 }
 
@@ -307,6 +347,26 @@ impl Default for Brent {
             abs_tol: 1e-6,
             rel_tol: sqrt(f64::EPSILON),
         }
+    }
+}
+
+impl Brent {
+    /// Sets the maximum number of iterations.
+    pub fn with_max_iter(mut self, max_iter: u32) -> Self {
+        self.max_iter = max_iter;
+        self
+    }
+
+    /// Sets the absolute tolerance on the root location.
+    pub fn with_abs_tol(mut self, abs_tol: f64) -> Self {
+        self.abs_tol = abs_tol;
+        self
+    }
+
+    /// Sets the relative tolerance on the root location.
+    pub fn with_rel_tol(mut self, rel_tol: f64) -> Self {
+        self.rel_tol = rel_tol;
+        self
     }
 }
 
@@ -673,5 +733,39 @@ mod tests {
             .find_in_bracket(|x: f64| -> Result { Ok(1e-12 * (x - 1e6)) }, (0.0, 2e6))
             .expect("should converge");
         assert_approx_eq!(act, 1e6, rtol <= 1e-5);
+    }
+
+    #[test]
+    fn test_brent_builder_tolerances() {
+        // Custom tolerances set via the builder still locate the root.
+        let brent = Brent::default()
+            .with_abs_tol(1e-2)
+            .with_rel_tol(1e-8)
+            .with_max_iter(50);
+        let act = brent
+            .find_in_bracket(
+                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
+                (1.0, 1.5),
+            )
+            .expect("should converge");
+        assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-2);
+    }
+
+    #[test]
+    fn test_newton_builder_max_iter() {
+        // A single iteration is not enough to converge on the cubic root, and
+        // the configured cap is reported back in the error.
+        let newton = Newton::default().with_max_iter(1);
+        let err = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
+                |x: f64| -> Result { Ok(2.0 * powi(x, 2) + 8.0 * x) },
+                1.5,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RootFinderError::NotConverged { iterations: 1, .. }
+        ));
     }
 }

--- a/crates/lox-core/src/math/roots.rs
+++ b/crates/lox-core/src/math/roots.rs
@@ -515,6 +515,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
     use core::f64::consts::PI;
     use lox_approx::assert_approx_eq;
 
@@ -891,5 +892,240 @@ mod tests {
             }
             other => panic!("expected NotConverged, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_callback_error_conversions() {
+        // Both `From` constructors wrap the message transparently.
+        let from_str: CallbackError = "boom".into();
+        assert_eq!(from_str.to_string(), "boom");
+
+        let boxed: BoxedError = "kaboom".into();
+        let from_boxed: CallbackError = boxed.into();
+        assert_eq!(from_boxed.to_string(), "kaboom");
+    }
+
+    #[test]
+    fn test_root_finder_error_display() {
+        let not_converged = RootFinderError::NotConverged {
+            iterations: 7,
+            x: 1.5,
+            residual: -0.25,
+        };
+        assert_eq!(
+            not_converged.to_string(),
+            "not converged after 7 iterations at x = 1.5, residual -0.25"
+        );
+        assert_eq!(
+            RootFinderError::NotInBracket.to_string(),
+            "root not in bracket"
+        );
+        assert_eq!(
+            RootFinderError::NonFinite(f64::INFINITY).to_string(),
+            "function returned a non-finite value: inf"
+        );
+    }
+
+    #[test]
+    fn test_zero_crossing_display() {
+        assert_eq!(ZeroCrossing::Up.to_string(), "up");
+        assert_eq!(ZeroCrossing::Down.to_string(), "down");
+    }
+
+    #[test]
+    fn test_steffensen_builder_tolerances() {
+        // Custom tolerances set via the builder still locate the root.
+        let steffensen = Steffensen::default()
+            .with_abs_tol(1e-4)
+            .with_rel_tol(1e-8)
+            .with_max_iter(100);
+        let act = steffensen
+            .find(
+                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
+                1.5,
+            )
+            .expect("should converge");
+        assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-3);
+    }
+
+    #[test]
+    fn test_newton_builder_tolerances() {
+        let newton = Newton::default().with_abs_tol(1e-4).with_rel_tol(1e-8);
+        let act = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
+                |x: f64| -> Result { Ok(2.0 * powi(x, 2) + 8.0 * x) },
+                1.5,
+            )
+            .expect("should converge");
+        assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-3);
+    }
+
+    #[test]
+    fn test_steffensen_non_finite_function_value() {
+        // A non-finite value at the initial guess is reported immediately.
+        let steffensen = Steffensen::default();
+        let err = steffensen
+            .find(|_x: f64| -> Result { Ok(f64::INFINITY) }, 1.0)
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_steffensen_non_finite_aitken_probe() {
+        // The first sample is finite, but the displaced Aitken probe f(p0 + f(p0))
+        // is non-finite and must be reported.
+        let steffensen = Steffensen::default();
+        let err = steffensen
+            .find(
+                |x: f64| -> Result { if x >= 2.0 { Ok(f64::INFINITY) } else { Ok(x) } },
+                1.5,
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_steffensen_not_converged_reports_last_evaluation() {
+        // One iteration cannot converge; the error reports the point that was
+        // actually evaluated (the initial guess) and its residual.
+        let steffensen = Steffensen::default().with_max_iter(1);
+        let err = steffensen
+            .find(
+                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
+                1.5,
+            )
+            .unwrap_err();
+        match err {
+            RootFinderError::NotConverged {
+                iterations: 1,
+                x,
+                residual,
+            } => {
+                assert_eq!(x, 1.5);
+                assert_approx_eq!(residual, 2.375, atol <= 1e-9);
+            }
+            other => panic!("expected NotConverged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_newton_non_finite_function_value() {
+        let newton = Newton::default();
+        let err = newton
+            .find_with_derivative(
+                |_x: f64| -> Result { Ok(f64::INFINITY) },
+                |_x: f64| -> Result { Ok(1.0) },
+                1.0,
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_newton_non_finite_derivative_value() {
+        // A finite function value but a non-finite derivative is reported.
+        let newton = Newton::default();
+        let err = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(x) },
+                |_x: f64| -> Result { Ok(f64::INFINITY) },
+                1.0,
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_brent_rejects_non_finite_second_endpoint() {
+        // The first endpoint is finite; the second is not.
+        let brent = Brent::default();
+        let err = brent
+            .find_in_bracket_with_values(
+                |_x: f64| -> Result { Ok(1.0) },
+                (0.0, 1.0),
+                (1.0, f64::NAN),
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_brent_endpoint_is_root() {
+        let brent = Brent::default();
+        // The lower endpoint is exactly the root.
+        let lo = brent
+            .find_in_bracket_with_values(|x: f64| -> Result { Ok(x) }, (0.0, 1.0), (0.0, 1.0))
+            .expect("lower endpoint is the root");
+        assert_eq!(lo, 0.0);
+        // The upper endpoint is exactly the root.
+        let hi = brent
+            .find_in_bracket_with_values(
+                |x: f64| -> Result { Ok(x - 1.0) },
+                (0.0, 1.0),
+                (-1.0, 0.0),
+            )
+            .expect("upper endpoint is the root");
+        assert_eq!(hi, 1.0);
+    }
+
+    #[test]
+    fn test_brent_not_converged() {
+        // A single iteration cannot narrow a wide bracket below the tolerance.
+        let brent = Brent::default().with_max_iter(1);
+        let err = brent
+            .find_in_bracket(|x: f64| -> Result { Ok(powi(x, 3) - 0.5) }, (-1e6, 1e6))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RootFinderError::NotConverged { iterations: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn test_zero_max_iter_non_finite_initial_guess() {
+        // With no iterations the initial guess is still evaluated; a non-finite
+        // value there is reported as NonFinite, not NotConverged.
+        let newton = Newton::default().with_max_iter(0);
+        let err = newton
+            .find_with_derivative(
+                |_x: f64| -> Result { Ok(f64::INFINITY) },
+                |_x: f64| -> Result { Ok(1.0) },
+                1.0,
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_brent_converges_on_stiff_function() {
+        // A high-degree monomial has extreme curvature near its root, which
+        // exercises Brent's switching between interpolation and bisection.
+        let brent = Brent::default();
+        let root = brent
+            .find_in_bracket(|x: f64| -> Result { Ok(powi(x, 15) - 0.5) }, (0.0, 1.0))
+            .expect("should converge");
+        assert!(abs(powi(root, 15) - 0.5) < 1e-3);
+    }
+
+    #[test]
+    fn test_brent_in_loop_callback_error() {
+        // Endpoints evaluate cleanly, but an interior evaluation fails; the
+        // callback error must propagate.
+        let brent = Brent::default();
+        let err = brent
+            .find_in_bracket_with_values(
+                |x: f64| -> Result {
+                    if x == -1.0 || x == 2.0 {
+                        Ok(x * x - 2.0)
+                    } else {
+                        Err("interior failure".into())
+                    }
+                },
+                (-1.0, 2.0),
+                (-1.0, 2.0),
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::Callback(_)));
     }
 }

--- a/crates/lox-core/src/math/roots.rs
+++ b/crates/lox-core/src/math/roots.rs
@@ -201,12 +201,23 @@ impl Steffensen {
     }
 }
 
+/// Evaluates `f` at `x`, mapping a callback failure or non-finite result to the
+/// corresponding [`RootFinderError`].
+fn eval_finite<F: Callback>(f: &F, x: f64) -> Result<f64, RootFinderError> {
+    let value = f.call(x).map_err(RootFinderError::Callback)?;
+    if !value.is_finite() {
+        return Err(RootFinderError::NonFinite(value));
+    }
+    Ok(value)
+}
+
 impl<F> FindRoot<F> for Steffensen
 where
     F: Callback,
 {
     fn find(&self, f: F, initial_guess: f64) -> Result<f64, RootFinderError> {
         let mut p0 = initial_guess;
+        let mut last: Option<(f64, f64)> = None;
         for _ in 0..self.max_iter {
             let fp0 = f.call(p0).map_err(RootFinderError::Callback)?;
             if !fp0.is_finite() {
@@ -217,6 +228,7 @@ where
             if fp0 == 0.0 {
                 return Ok(p0);
             }
+            last = Some((p0, fp0));
             let f1 = p0 + fp0;
             let ff1 = f.call(f1).map_err(RootFinderError::Callback)?;
             if !ff1.is_finite() {
@@ -232,10 +244,18 @@ where
             }
             p0 = p;
         }
-        let residual = f.call(p0).map_err(RootFinderError::Callback)?;
+        // Report the last point where `f` was actually evaluated rather than
+        // re-evaluating a stepped final iterate, which may lie outside the
+        // callback's valid domain and turn non-convergence into a callback error
+        // or panic. When `max_iter == 0` the loop never runs, so fall back to the
+        // still-in-domain initial guess.
+        let (x, residual) = match last {
+            Some(pair) => pair,
+            None => (p0, eval_finite(&f, p0)?),
+        };
         Err(RootFinderError::NotConverged {
             iterations: self.max_iter,
-            x: p0,
+            x,
             residual,
         })
     }
@@ -293,6 +313,7 @@ where
         initial_guess: f64,
     ) -> Result<f64, RootFinderError> {
         let mut p0 = initial_guess;
+        let mut last: Option<(f64, f64)> = None;
         for _ in 0..self.max_iter {
             let fx = f.call(p0).map_err(RootFinderError::Callback)?;
             if !fx.is_finite() {
@@ -303,6 +324,7 @@ where
             if fx == 0.0 {
                 return Ok(p0);
             }
+            last = Some((p0, fx));
             let dfx = derivative.call(p0).map_err(RootFinderError::Callback)?;
             if !dfx.is_finite() {
                 return Err(RootFinderError::NonFinite(dfx));
@@ -316,10 +338,18 @@ where
             }
             p0 = p;
         }
-        let residual = f.call(p0).map_err(RootFinderError::Callback)?;
+        // Report the last point where `f` was actually evaluated rather than
+        // re-evaluating a stepped final iterate, which may lie outside the
+        // callback's valid domain and turn non-convergence into a callback error
+        // or panic. When `max_iter == 0` the loop never runs, so fall back to the
+        // still-in-domain initial guess.
+        let (x, residual) = match last {
+            Some(pair) => pair,
+            None => (p0, eval_finite(&f, p0)?),
+        };
         Err(RootFinderError::NotConverged {
             iterations: self.max_iter,
-            x: p0,
+            x,
             residual,
         })
     }
@@ -327,10 +357,9 @@ where
 
 /// Brent's method for bracketed root-finding.
 ///
-/// Convergence is governed by the width of the bracket: iteration stops once it
-/// is narrower than `abs_tol + rel_tol * |x|`. Both tolerances are on the root
-/// location `x`, not on the residual `f(x)`, so the result is independent of how
-/// the objective is scaled.
+/// The tolerances bound the root location `x`, not the residual `f(x)`: the
+/// returned root is accurate to within `abs_tol + rel_tol * |x|`, independent of
+/// how the objective is scaled.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Brent {
     max_iter: u32,
@@ -411,7 +440,9 @@ where
         }
 
         for _ in 0..self.max_iter {
-            if fpre * fcur < 0.0 {
+            // Compare sign bits rather than the product to avoid the underflow
+            // that loses the sign of very small opposite-sign residuals.
+            if fpre.is_sign_negative() != fcur.is_sign_negative() {
                 xblk = xpre;
                 fblk = fpre;
                 spre = xcur - xpre;
@@ -469,6 +500,9 @@ where
             }
 
             fcur = f.call(xcur).map_err(RootFinderError::Callback)?;
+            if !fcur.is_finite() {
+                return Err(RootFinderError::NonFinite(fcur));
+            }
         }
 
         Err(RootFinderError::NotConverged {
@@ -767,5 +801,95 @@ mod tests {
             err,
             RootFinderError::NotConverged { iterations: 1, .. }
         ));
+    }
+
+    #[test]
+    fn test_brent_tiny_opposite_sign_residuals() {
+        // Residuals so small their product underflows to a signed zero; the
+        // in-loop bracketing must recognise the sign change from the sign bits
+        // rather than the product, which would otherwise return the endpoint.
+        let brent = Brent::default();
+        let act = brent
+            .find_in_bracket(|x: f64| -> Result { Ok(1e-200 * (x - 0.5)) }, (0.0, 1.0))
+            .expect("should converge");
+        assert_approx_eq!(act, 0.5, rtol <= 1e-8);
+    }
+
+    #[test]
+    fn test_brent_interior_non_finite() {
+        // Finite, opposite-sign endpoints but a non-finite value at an interior
+        // point must be reported rather than silently accepted as a root.
+        let calls = core::cell::Cell::new(0u32);
+        let brent = Brent::default();
+        let err = brent
+            .find_in_bracket(
+                |x: f64| -> Result {
+                    let n = calls.get();
+                    calls.set(n + 1);
+                    // The first two calls evaluate the bracket endpoints.
+                    if n >= 2 { Ok(f64::NAN) } else { Ok(x - 0.5) }
+                },
+                (0.0, 1.0),
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_newton_not_converged_does_not_re_evaluate() {
+        // The final iterate steps outside the callback's valid domain. Reaching
+        // the iteration cap must still yield NotConverged, not a callback error
+        // from re-evaluating the un-checked final iterate.
+        let newton = Newton::default().with_max_iter(1);
+        let err = newton
+            .find_with_derivative(
+                |x: f64| -> Result {
+                    if x > 5.0 {
+                        Err("out of domain".into())
+                    } else {
+                        Ok(x * x - 2.0)
+                    }
+                },
+                |_x: f64| -> Result { Ok(0.1) },
+                1.0,
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NotConverged { .. }));
+    }
+
+    #[test]
+    fn test_newton_zero_max_iter_reports_real_residual() {
+        // With no iterations the solver still reports a finite residual measured
+        // at the initial guess, not NaN.
+        let newton = Newton::default().with_max_iter(0);
+        let err = newton
+            .find_with_derivative(
+                |x: f64| -> Result { Ok(x * x - 2.0) },
+                |x: f64| -> Result { Ok(2.0 * x) },
+                1.0,
+            )
+            .unwrap_err();
+        match err {
+            RootFinderError::NotConverged { x, residual, .. } => {
+                assert_eq!(x, 1.0);
+                assert_approx_eq!(residual, -1.0, atol <= 1e-12);
+            }
+            other => panic!("expected NotConverged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_steffensen_zero_max_iter_reports_real_residual() {
+        let steffensen = Steffensen::default().with_max_iter(0);
+        let err = steffensen
+            .find(|x: f64| -> Result { Ok(x * x - 2.0) }, 1.0)
+            .unwrap_err();
+        match err {
+            RootFinderError::NotConverged { x, residual, .. } => {
+                assert_eq!(x, 1.0);
+                assert_approx_eq!(residual, -1.0, atol <= 1e-12);
+            }
+            other => panic!("expected NotConverged, got {other:?}"),
+        }
     }
 }

--- a/crates/lox-core/src/math/roots.rs
+++ b/crates/lox-core/src/math/roots.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-//! Root-finding algorithms: Steffensen, Newton, Brent, and Secant methods.
+//! Root-finding algorithms: Steffensen, Newton, and Brent methods.
 
 use alloc::boxed::Box;
 use lox_approx::approx_eq;
@@ -19,6 +19,9 @@ pub enum RootFinderError {
     /// The root is not within the given bracket.
     #[error("root not in bracket")]
     NotInBracket,
+    /// The objective function returned a non-finite value.
+    #[error("function returned a non-finite value: {0}")]
+    NonFinite(f64),
     /// The objective function returned an error.
     #[error(transparent)]
     Callback(#[from] CallbackError),
@@ -228,10 +231,17 @@ where
 }
 
 /// Brent's method for bracketed root-finding.
+///
+/// Convergence is governed by the width of the bracket: iteration stops once it
+/// is narrower than `abs_tol + rel_tol * |x|`. Both tolerances are on the root
+/// location `x`, not on the residual `f(x)`, so the result is independent of how
+/// the objective is scaled.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Brent {
     max_iter: u32,
+    /// Absolute tolerance on the root location.
     abs_tol: f64,
+    /// Relative tolerance on the root location.
     rel_tol: f64,
 }
 
@@ -263,16 +273,26 @@ where
 
         let (mut fpre, mut fcur) = values;
 
-        if fpre * fcur > 0.0 {
-            return Err(RootFinderError::NotInBracket);
+        if !fpre.is_finite() {
+            return Err(RootFinderError::NonFinite(fpre));
+        }
+        if !fcur.is_finite() {
+            return Err(RootFinderError::NonFinite(fcur));
         }
 
-        if approx_eq!(fpre, 0.0, atol <= self.abs_tol) {
+        // An endpoint that is exactly a root is returned directly.
+        if fpre == 0.0 {
             return Ok(xpre);
         }
-
-        if approx_eq!(fcur, 0.0, atol <= self.abs_tol) {
+        if fcur == 0.0 {
             return Ok(xcur);
+        }
+
+        // The endpoints must straddle the root. Comparing the sign bits of the
+        // two finite, non-zero values avoids the underflow and NaN hazards of
+        // testing the sign of their product.
+        if fpre.is_sign_negative() == fcur.is_sign_negative() {
+            return Err(RootFinderError::NotInBracket);
         }
 
         for _ in 0..self.max_iter {
@@ -295,7 +315,7 @@ where
             let delta = (self.abs_tol + self.rel_tol * abs(xcur)) / 2.0;
             let sbis = (xblk - xcur) / 2.0;
 
-            if approx_eq!(fcur, 0.0, atol <= self.abs_tol) || abs(sbis) < delta {
+            if fcur == 0.0 || abs(sbis) < delta {
                 return Ok(xcur);
             }
 
@@ -337,79 +357,6 @@ where
         }
 
         Err(RootFinderError::NotConverged(self.max_iter, fcur))
-    }
-}
-
-/// Secant method for root-finding.
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Secant {
-    max_iter: u32,
-    rel_tol: f64,
-    abs_tol: f64,
-}
-
-impl Default for Secant {
-    fn default() -> Self {
-        Self {
-            max_iter: 100,
-            rel_tol: sqrt(f64::EPSILON),
-            abs_tol: 1e-6,
-        }
-    }
-}
-
-impl<F> FindBracketedRoot<F> for Secant
-where
-    F: Callback,
-{
-    fn find_in_bracket_with_values(
-        &self,
-        f: F,
-        bracket: (f64, f64),
-        values: (f64, f64),
-    ) -> Result<f64, RootFinderError> {
-        let (x0, x1) = bracket;
-        let mut p0 = x0;
-        let mut p1 = x1;
-        let (mut q0, mut q1) = values;
-        if abs(q1) < abs(q0) {
-            core::mem::swap(&mut p0, &mut p1);
-            core::mem::swap(&mut q0, &mut q1);
-        }
-        for i in 0..self.max_iter {
-            if q1 == q0 {
-                if p1 != p0 {
-                    return Err(RootFinderError::NotConverged(i, q0));
-                }
-                return Ok((p1 + p0) / 2.0);
-            }
-            let p = if abs(q1) > abs(q0) {
-                (-q0 / q1 * p1 + p0) / (1.0 - q0 / q1)
-            } else {
-                (-q1 / q0 * p0 + p1) / (1.0 - q1 / q0)
-            };
-            if approx_eq!(p, p1, rtol <= self.rel_tol, atol <= self.abs_tol) {
-                return Ok(p);
-            }
-            p0 = p1;
-            q0 = q1;
-            p1 = p;
-            q1 = f.call(p).map_err(RootFinderError::Callback)?;
-        }
-        Err(RootFinderError::NotConverged(self.max_iter, p0))
-    }
-}
-
-impl<F> FindRoot<F> for Secant
-where
-    F: Callback,
-{
-    fn find(&self, f: F, initial_guess: f64) -> Result<f64, RootFinderError> {
-        let x0 = initial_guess;
-        let eps = 1e-4;
-        let mut x1 = x0 * (1.0 + eps);
-        x1 += if x1 > x0 { eps } else { -eps };
-        self.find_in_bracket(f, (x0, x1))
     }
 }
 
@@ -469,26 +416,6 @@ mod tests {
             .find_in_bracket(
                 |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
                 (1.0, 1.5),
-            )
-            .expect("should converge");
-        assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-8);
-    }
-
-    #[test]
-    fn test_secant_cubic() {
-        let secant = Secant::default();
-        let act = secant
-            .find_in_bracket(
-                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
-                (1.0, 1.5),
-            )
-            .expect("should converge");
-        assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-8);
-
-        let act = secant
-            .find(
-                |x: f64| -> Result { Ok(powi(x, 3) + 4.0 * powi(x, 2) - 10.0) },
-                1.0,
             )
             .expect("should converge");
         assert_approx_eq!(act, 1.3652300134140969, rtol <= 1e-8);
@@ -574,12 +501,6 @@ mod tests {
         let via_recompute = brent.find_in_bracket(f, (a, b)).expect("should converge");
         assert_approx_eq!(via_values, via_recompute, rtol <= 1e-12);
 
-        let secant = Secant::default();
-        let via_values = secant
-            .find_in_bracket_with_values(f, (a, b), (fa, fb))
-            .expect("should converge");
-        assert_approx_eq!(via_values, 1.3652300134140969, rtol <= 1e-8);
-
         // The supplied endpoints are not re-evaluated.
         let count = Cell::new(0usize);
         let counting = |x: f64| -> Result {
@@ -592,5 +513,40 @@ mod tests {
             .find_in_bracket_with_values(counting, (a, b), (fa, fb))
             .expect("should converge");
         assert_eq!(count.get(), 0, "endpoints must not be re-evaluated");
+    }
+
+    #[test]
+    fn test_brent_rejects_non_finite_endpoint() {
+        let brent = Brent::default();
+        let err = brent
+            .find_in_bracket_with_values(
+                |_x: f64| -> Result { Ok(1.0) },
+                (0.0, 1.0),
+                (f64::NAN, 1.0),
+            )
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NonFinite(_)));
+    }
+
+    #[test]
+    fn test_brent_rejects_same_sign_underflowing_bracket() {
+        // Same-sign endpoints whose product underflows to 0.0 must still be
+        // rejected rather than accepted as a bracket (and returned as a root).
+        let brent = Brent::default();
+        let err = brent
+            .find_in_bracket(|x: f64| -> Result { Ok(1e-200 * (x + 1.0)) }, (0.0, 1.0))
+            .unwrap_err();
+        assert!(matches!(err, RootFinderError::NotInBracket));
+    }
+
+    #[test]
+    fn test_brent_scale_independent() {
+        // A heavily down-scaled objective: f(0) = -1e-6 must not be mistaken for
+        // a root by a residual tolerance. The true root is at x = 1e6.
+        let brent = Brent::default();
+        let act = brent
+            .find_in_bracket(|x: f64| -> Result { Ok(1e-12 * (x - 1e6)) }, (0.0, 2e6))
+            .expect("should converge");
+        assert_approx_eq!(act, 1e6, rtol <= 1e-5);
     }
 }

--- a/crates/lox-orbits/src/events.rs
+++ b/crates/lox-orbits/src/events.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::VecDeque;
-use std::fmt::Display;
 
 use itertools::Itertools;
+pub use lox_math::roots::ZeroCrossing;
 use lox_math::roots::{BoxedError, Callback, CallbackError, FindBracketedRoot, RootFinderError};
 use lox_time::Time;
 use lox_time::deltas::TimeDelta;
@@ -16,37 +16,6 @@ use thiserror::Error;
 // ---------------------------------------------------------------------------
 // Core event types
 // ---------------------------------------------------------------------------
-
-/// Direction of a zero-crossing event.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum ZeroCrossing {
-    /// Signal crosses from negative to positive.
-    Up,
-    /// Signal crosses from positive to negative.
-    Down,
-}
-
-impl ZeroCrossing {
-    fn new(s0: f64, s1: f64) -> Option<ZeroCrossing> {
-        if s0 < 0.0 && s1 > 0.0 {
-            Some(ZeroCrossing::Up)
-        } else if s0 > 0.0 && s1 < 0.0 {
-            Some(ZeroCrossing::Down)
-        } else {
-            None
-        }
-    }
-}
-
-impl Display for ZeroCrossing {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ZeroCrossing::Up => write!(f, "up"),
-            ZeroCrossing::Down => write!(f, "down"),
-        }
-    }
-}
 
 /// A zero-crossing event at a specific time.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -209,12 +178,13 @@ fn build_time_grid(total: f64, step: f64) -> Vec<f64> {
 }
 
 impl<F, R> RootFindingDetector<F, R> {
-    /// Core detection returning events and the sign at the interval start.
+    /// Core detection returning events and the function value at the interval
+    /// start.
     ///
-    /// The start sign is needed by [`EventsToIntervals`] to determine whether
+    /// The start value is needed by [`EventsToIntervals`] to determine whether
     /// the condition holds throughout when no zero-crossings are found.
     /// Returning it here avoids a redundant function evaluation.
-    pub(crate) fn detect_with_start_sign<T>(
+    pub(crate) fn detect_with_start_value<T>(
         &self,
         interval: TimeInterval<T>,
     ) -> Result<(Vec<Event<T>>, f64), DetectError>
@@ -253,33 +223,36 @@ impl<F, R> RootFindingDetector<F, R> {
     {
         let steps = build_time_grid(total_seconds, step_seconds);
 
-        let mut signs = Vec::with_capacity(steps.len());
+        let mut values = Vec::with_capacity(steps.len());
         for &t in &steps {
             let v = callback
                 .call(t)
                 .map_err(|e| DetectError::RootFinder(RootFinderError::Callback(e)))?;
-            signs.push(v.signum());
+            values.push(v);
         }
 
-        let start_sign = signs[0];
+        let start_value = values[0];
 
-        if signs.iter().all(|&s| s < 0.0) || signs.iter().all(|&s| s > 0.0) {
-            return Ok((vec![], start_sign));
+        // Half-open convention: a value of 0.0 is on the non-negative side, so
+        // a crossing requires a transition across zero.
+        if values.iter().all(|&v| v < 0.0) || values.iter().all(|&v| v >= 0.0) {
+            return Ok((vec![], start_value));
         }
 
         let mut events = Vec::new();
-        for ((&t0, &s0), (&t1, &s1)) in std::iter::zip(&steps, &signs).tuple_windows() {
-            if let Some(crossing) = ZeroCrossing::new(s0, s1) {
+        for ((&t0, &v0), (&t1, &v1)) in std::iter::zip(&steps, &values).tuple_windows() {
+            if let Some(crossing) = ZeroCrossing::new(v0, v1) {
+                // The endpoint values are already known, so reuse them.
                 let t = self
                     .root_finder
-                    .find_in_bracket(callback, (t0, t1))
+                    .find_in_bracket_with_values(callback, (t0, t1), (v0, v1))
                     .map_err(DetectError::RootFinder)?;
                 let time = start + TimeDelta::from_seconds_f64(t);
                 events.push(Event { crossing, time });
             }
         }
 
-        Ok((events, start_sign))
+        Ok((events, start_value))
     }
 
     /// Two-level detection: coarse grid to find sign-change brackets, then
@@ -297,38 +270,38 @@ impl<F, R> RootFindingDetector<F, R> {
         F: DetectFn<T>,
         for<'a> R: FindBracketedRoot<DetectCallback<'a, T, F>>,
     {
-        // 1. Build coarse grid and evaluate signs.
+        // 1. Build coarse grid and evaluate function values.
         let coarse_grid = build_time_grid(total_seconds, coarse_seconds);
-        let mut coarse_signs = Vec::with_capacity(coarse_grid.len());
+        let mut coarse_values = Vec::with_capacity(coarse_grid.len());
         for &t in &coarse_grid {
             let v = callback
                 .call(t)
                 .map_err(|e| DetectError::RootFinder(RootFinderError::Callback(e)))?;
-            coarse_signs.push(v.signum());
+            coarse_values.push(v);
         }
 
-        let start_sign = coarse_signs[0];
+        let start_value = coarse_values[0];
 
         // 2. For each coarse bracket with a sign change, subdivide with fine steps.
         let mut events = Vec::new();
-        for ((&tc0, &sc0), (&tc1, &sc1)) in
-            std::iter::zip(&coarse_grid, &coarse_signs).tuple_windows()
+        for ((&tc0, &vc0), (&tc1, &vc1)) in
+            std::iter::zip(&coarse_grid, &coarse_values).tuple_windows()
         {
-            if ZeroCrossing::new(sc0, sc1).is_none() {
+            if ZeroCrossing::new(vc0, vc1).is_none() {
                 continue;
             }
 
             // Build fine grid within this coarse bracket.
-            // Reuse the known sign at tc0 to avoid a redundant evaluation.
+            // Reuse the known value at tc0 to avoid a redundant evaluation.
             let bracket_len = tc1 - tc0;
             let fine_grid = build_time_grid(bracket_len, step_seconds);
 
             let mut fine_times = Vec::with_capacity(fine_grid.len());
-            let mut fine_signs = Vec::with_capacity(fine_grid.len());
+            let mut fine_values = Vec::with_capacity(fine_grid.len());
 
-            // First point: reuse coarse sign.
+            // First point: reuse the coarse value.
             fine_times.push(tc0);
-            fine_signs.push(sc0);
+            fine_values.push(vc0);
 
             // Interior and last points: evaluate.
             for &ft in &fine_grid[1..] {
@@ -337,16 +310,17 @@ impl<F, R> RootFindingDetector<F, R> {
                 let v = callback
                     .call(abs_t)
                     .map_err(|e| DetectError::RootFinder(RootFinderError::Callback(e)))?;
-                fine_signs.push(v.signum());
+                fine_values.push(v);
             }
 
-            // Root-find on fine-level sign changes.
-            for ((&t0, &s0), (&t1, &s1)) in std::iter::zip(&fine_times, &fine_signs).tuple_windows()
+            // Root-find on fine-level sign changes, reusing the bracket values.
+            for ((&t0, &v0), (&t1, &v1)) in
+                std::iter::zip(&fine_times, &fine_values).tuple_windows()
             {
-                if let Some(crossing) = ZeroCrossing::new(s0, s1) {
+                if let Some(crossing) = ZeroCrossing::new(v0, v1) {
                     let t = self
                         .root_finder
-                        .find_in_bracket(callback, (t0, t1))
+                        .find_in_bracket_with_values(callback, (t0, t1), (v0, v1))
                         .map_err(DetectError::RootFinder)?;
                     let time = start + TimeDelta::from_seconds_f64(t);
                     events.push(Event { crossing, time });
@@ -354,7 +328,7 @@ impl<F, R> RootFindingDetector<F, R> {
             }
         }
 
-        Ok((events, start_sign))
+        Ok((events, start_value))
     }
 }
 
@@ -365,7 +339,7 @@ where
     for<'a> R: FindBracketedRoot<DetectCallback<'a, T, F>>,
 {
     fn detect(&self, interval: TimeInterval<T>) -> Result<Vec<Event<T>>, DetectError> {
-        self.detect_with_start_sign(interval)
+        self.detect_with_start_value(interval)
             .map(|(events, _)| events)
     }
 }
@@ -408,12 +382,12 @@ where
         let start = interval.start();
         let end = interval.end();
 
-        let (events, start_sign) = self.detector.detect_with_start_sign(interval)?;
+        let (events, start_value) = self.detector.detect_with_start_value(interval)?;
         if events.is_empty() {
             // No zero crossings — use the sign at the start (already computed
             // during step evaluation) to determine if the condition holds
             // throughout or not at all.
-            return if start_sign >= 0.0 {
+            return if start_value >= 0.0 {
                 Ok(vec![interval])
             } else {
                 Ok(vec![])
@@ -832,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_two_level_no_events() {
-        // Constant negative function — no events, correct start_sign.
+        // Constant negative function — no events, correct start_value.
         let start = time!(Tai, 2000, 1, 1, 12).unwrap();
         let end = start + TimeDelta::from_seconds(10);
         let interval = TimeInterval::new(start, end);
@@ -841,9 +815,9 @@ mod tests {
             RootFindingDetector::new(FnDetect(|_t: Time<Tai>| -1.0), TimeDelta::from_seconds(1))
                 .with_coarse_step(TimeDelta::from_seconds(3));
 
-        let (events, start_sign) = det.detect_with_start_sign(interval).unwrap();
+        let (events, start_value) = det.detect_with_start_value(interval).unwrap();
         assert!(events.is_empty());
-        assert!(start_sign < 0.0);
+        assert!(start_value < 0.0);
     }
 
     #[test]


### PR DESCRIPTION
- **refactor(lox-core/lox-orbits): move ZeroCrossing into roots and reuse bracket endpoint values**
- **fix(lox-core): harden Brent and remove unused Secant root-finder**
- **fix(lox-core): harden Brent and remove unused Secant root-finder**
- **feat(lox-core): add tolerance and iteration builders to root finders**
