### PR TITLE
refactor(lox-orbits)!: key ground locations on body-fixed frames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Key details:
 - `Distance` stores meters internally, even when created via `kilometers()`.
 - `GravitationalParameter` stores m³/s² internally, even when created via `km3_per_s2()`.
 - `Angle` stores **radians** internally.
-- `GroundLocation` altitude is in **km** (converted to m internally in `body_fixed_position()`).
+- `EllipsoidLocation` and `Observables` accessors return **unitful** types (`Angle`, `Distance`, `Velocity`), not raw `f64` — prefer this for new scalar accessors. Bulk numeric arrays feeding interpolation series (e.g. `ElevationMask::new`) stay `Vec<f64>` in radians.
 
 **Getting this wrong will produce silently incorrect results. Always verify units.**
 

--- a/crates/lox-analysis/benches/visibility.rs
+++ b/crates/lox-analysis/benches/visibility.rs
@@ -11,8 +11,9 @@ use lox_analysis::assets::{AssetId, GroundStation, Scenario, Spacecraft};
 use lox_analysis::visibility::{ElevationMask, VisibilityAnalysis};
 use lox_bodies::Origin;
 use lox_core::coords::LonLatAlt;
+use lox_core::units::Angle;
 use lox_frames::Frame;
-use lox_orbits::ground::GroundLocation;
+use lox_orbits::ground::EllipsoidLocation;
 use lox_orbits::orbits::{Ensemble, Trajectory};
 use lox_orbits::propagators::OrbitSource;
 use lox_test_utils::read_data_file;
@@ -30,8 +31,8 @@ static FIXTURE: LazyLock<Fixture> = LazyLock::new(|| {
     )
     .unwrap();
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-    let gs_loc = GroundLocation::try_new(coords, Origin::Earth).unwrap();
-    let mask = ElevationMask::with_fixed_elevation(0.0);
+    let gs_loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+    let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
     let gs = GroundStation::new("cebreros", gs_loc, mask);
     let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
 

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -28,7 +28,7 @@ use lox_comms::terminal::{RxTerminal, TxTerminal};
 
 use crate::visibility::ElevationMask;
 use lox_orbits::constellations::{Constellation, ConstellationPropagator};
-use lox_orbits::ground::GroundLocation;
+use lox_orbits::ground::EllipsoidLocation;
 use lox_orbits::orbits::{Ensemble, KeplerianOrbit};
 use lox_orbits::propagators::j2::J2Propagator;
 use lox_orbits::propagators::j4::J4Propagator;
@@ -110,9 +110,8 @@ impl fmt::Display for NetworkId {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroundStation {
     id: AssetId,
-    location: GroundLocation,
+    location: EllipsoidLocation,
     mask: ElevationMask,
-    body_fixed_frame: Frame,
     network: Option<NetworkId>,
     #[cfg(feature = "comms")]
     tx_terminals: BTreeMap<String, TxTerminal>,
@@ -122,25 +121,17 @@ pub struct GroundStation {
 
 impl GroundStation {
     /// Creates a new ground station with the given location and elevation mask.
-    pub fn new(id: impl Into<String>, location: GroundLocation, mask: ElevationMask) -> Self {
-        let body_fixed_frame = Frame::Iau(location.origin());
+    pub fn new(id: impl Into<String>, location: EllipsoidLocation, mask: ElevationMask) -> Self {
         Self {
             id: AssetId::new(id),
             location,
             mask,
-            body_fixed_frame,
             network: None,
             #[cfg(feature = "comms")]
             tx_terminals: BTreeMap::new(),
             #[cfg(feature = "comms")]
             rx_terminals: BTreeMap::new(),
         }
-    }
-
-    /// Overrides the body-fixed frame (defaults to IAU frame of the location's origin).
-    pub fn with_body_fixed_frame(mut self, frame: impl Into<Frame>) -> Self {
-        self.body_fixed_frame = frame.into();
-        self
     }
 
     /// Assigns this ground station to a network.
@@ -181,7 +172,7 @@ impl GroundStation {
     }
 
     /// Returns the ground location.
-    pub fn location(&self) -> &GroundLocation {
+    pub fn location(&self) -> &EllipsoidLocation {
         &self.location
     }
 
@@ -193,11 +184,6 @@ impl GroundStation {
     /// Returns the network identifier, if assigned.
     pub fn network_id(&self) -> Option<&NetworkId> {
         self.network.as_ref()
-    }
-
-    /// Returns the body-fixed reference frame.
-    pub fn body_fixed_frame(&self) -> Frame {
-        self.body_fixed_frame
     }
 
     /// Returns the named transmit terminals of this ground station.
@@ -644,19 +630,20 @@ mod tests {
     #[cfg(feature = "comms")]
     use lox_core::comms::FrequencyBand;
     use lox_core::coords::LonLatAlt;
+    use lox_core::units::Angle;
     #[cfg(feature = "comms")]
     use lox_core::units::DecibelUnits;
     use lox_frames::Frame;
-    use lox_orbits::ground::GroundLocation;
+    use lox_orbits::ground::EllipsoidLocation;
     use lox_time::deltas::TimeDelta;
 
-    fn dummy_location() -> GroundLocation {
+    fn dummy_location() -> EllipsoidLocation {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        GroundLocation::try_new(coords, Origin::Earth).unwrap()
+        EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap()
     }
 
     fn dummy_mask() -> ElevationMask {
-        ElevationMask::with_fixed_elevation(0.0)
+        ElevationMask::with_fixed_elevation(Angle::ZERO)
     }
 
     #[cfg(feature = "comms")]
@@ -764,14 +751,6 @@ mod tests {
         let mask = dummy_mask();
         let gs = GroundStation::new("gs1", loc, mask);
         assert_eq!(gs.id().as_str(), "gs1");
-        assert_eq!(gs.body_fixed_frame(), Frame::Iau(Origin::Earth));
-    }
-
-    #[test]
-    fn test_ground_station_with_body_fixed_frame() {
-        let gs = GroundStation::new("gs1", dummy_location(), dummy_mask())
-            .with_body_fixed_frame(Frame::Itrf);
-        assert_eq!(gs.body_fixed_frame(), Frame::Itrf);
     }
 
     #[test]
@@ -803,9 +782,9 @@ mod tests {
 
     #[test]
     fn test_ground_station_mask_getter() {
-        let mask = ElevationMask::with_fixed_elevation(0.1);
+        let mask = ElevationMask::with_fixed_elevation(Angle::radians(0.1));
         let gs = GroundStation::new("gs1", dummy_location(), mask.clone());
-        assert_eq!(gs.mask().min_elevation(0.0), 0.1);
+        assert_eq!(gs.mask().min_elevation(Angle::ZERO), Angle::radians(0.1));
     }
 
     // --- Spacecraft ---

--- a/crates/lox-analysis/src/visibility.rs
+++ b/crates/lox-analysis/src/visibility.rs
@@ -22,7 +22,7 @@ use rayon::prelude::*;
 use std::f64::consts::PI;
 use thiserror::Error;
 
-use lox_core::units::{AngularRate, Distance};
+use lox_core::units::{Angle, AngularRate, Distance, Velocity};
 
 use lox_core::error::LoxError;
 
@@ -31,7 +31,7 @@ use crate::events::{
     AdaptiveSampler, DetectError, DetectFn, DetectFnExt as _, Differentiable, IntervalIterExt as _,
     RateBounded, UniformSampler,
 };
-use lox_orbits::ground::{GroundLocation, Observables};
+use lox_orbits::ground::{EllipsoidLocation, Observables};
 use lox_orbits::orbits::{Ensemble, Trajectory};
 
 // ---------------------------------------------------------------------------
@@ -115,14 +115,18 @@ pub enum ElevationMaskError {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ElevationMask {
-    /// Constant minimum elevation angle (radians).
-    Fixed(f64),
+    /// Constant minimum elevation angle.
+    Fixed(Angle),
     /// Azimuth-dependent minimum elevation angle (interpolated series).
     Variable(Series),
 }
 
 impl ElevationMask {
-    /// Creates a variable elevation mask from paired azimuth/elevation vectors (radians).
+    /// Creates a variable elevation mask from paired azimuth/elevation vectors
+    /// in radians.
+    ///
+    /// The vectors feed a numeric interpolation series and so are taken as raw
+    /// radians; scalar angles elsewhere on this type are [`Angle`]s.
     pub fn new(azimuth: Vec<f64>, elevation: Vec<f64>) -> Result<Self, ElevationMaskError> {
         if !azimuth.is_empty() {
             let az_min = *azimuth.iter().min_by(|a, b| a.total_cmp(b)).unwrap();
@@ -138,16 +142,18 @@ impl ElevationMask {
         )?))
     }
 
-    /// Creates a fixed elevation mask with a constant minimum elevation (radians).
-    pub fn with_fixed_elevation(elevation: f64) -> Self {
+    /// Creates a fixed elevation mask with a constant minimum elevation.
+    pub fn with_fixed_elevation(elevation: Angle) -> Self {
         Self::Fixed(elevation)
     }
 
-    /// Returns the minimum elevation angle (radians) at the given azimuth.
-    pub fn min_elevation(&self, azimuth: f64) -> f64 {
+    /// Returns the minimum elevation angle at the given azimuth.
+    pub fn min_elevation(&self, azimuth: Angle) -> Angle {
         match self {
             ElevationMask::Fixed(min_elevation) => *min_elevation,
-            ElevationMask::Variable(series) => series.interpolate(azimuth),
+            ElevationMask::Variable(series) => {
+                Angle::radians(series.interpolate(azimuth.to_radians()))
+            }
         }
     }
 }
@@ -205,10 +211,9 @@ impl Pass {
     pub fn from_interval(
         interval: TimeInterval<TimeScale>,
         time_resolution: TimeDelta,
-        gs: &GroundLocation,
+        gs: &EllipsoidLocation,
         mask: &ElevationMask,
         sc: &lox_orbits::orbits::Trajectory,
-        body_fixed_frame: Frame,
     ) -> Option<Pass> {
         let mut pass_times = Vec::new();
         let mut pass_observables = Vec::new();
@@ -216,9 +221,9 @@ impl Pass {
         for current_time in interval.step_by(time_resolution) {
             let state = sc.at(current_time);
             let state_bf = state
-                .try_to_frame(body_fixed_frame, &DefaultRotationProvider)
+                .try_to_frame(gs.frame(), &DefaultRotationProvider)
                 .unwrap();
-            let obs = gs.observables_dynamic(state_bf);
+            let obs = gs.observables(state_bf);
 
             let min_elev = mask.min_elevation(obs.azimuth());
             if obs.elevation() >= min_elev {
@@ -255,10 +260,19 @@ where {
             .iter()
             .map(|t| (*t - epoch).to_seconds().to_f64())
             .collect();
-        let azimuths: Vec<f64> = observables.iter().map(|o| o.azimuth()).collect();
-        let elevations: Vec<f64> = observables.iter().map(|o| o.elevation()).collect();
-        let ranges: Vec<f64> = observables.iter().map(|o| o.range()).collect();
-        let range_rates: Vec<f64> = observables.iter().map(|o| o.range_rate()).collect();
+        let azimuths: Vec<f64> = observables
+            .iter()
+            .map(|o| o.azimuth().to_radians())
+            .collect();
+        let elevations: Vec<f64> = observables
+            .iter()
+            .map(|o| o.elevation().to_radians())
+            .collect();
+        let ranges: Vec<f64> = observables.iter().map(|o| o.range().to_meters()).collect();
+        let range_rates: Vec<f64> = observables
+            .iter()
+            .map(|o| o.range_rate().to_meters_per_second())
+            .collect();
 
         let azimuth_series = TimeSeries::try_new(
             epoch,
@@ -318,10 +332,10 @@ where {
             return None;
         }
 
-        let azimuth = self.azimuth_series.interpolate(time);
-        let elevation = self.elevation_series.interpolate(time);
-        let range = self.range_series.interpolate(time);
-        let range_rate = self.range_rate_series.interpolate(time);
+        let azimuth = Angle::radians(self.azimuth_series.interpolate(time));
+        let elevation = Angle::radians(self.elevation_series.interpolate(time));
+        let range = Distance::meters(self.range_series.interpolate(time));
+        let range_rate = Velocity::meters_per_second(self.range_rate_series.interpolate(time));
 
         Some(Observables::new(azimuth, elevation, range, range_rate))
     }
@@ -371,10 +385,9 @@ impl From<RotationError> for EvalError {
 /// 3. Computes observables (azimuth, elevation, range, range rate)
 /// 4. Returns elevation minus minimum elevation from the mask
 struct ElevationDetectFn<'a, O: CoordinateOrigin, R: ReferenceFrame> {
-    gs: &'a GroundLocation,
+    gs: &'a EllipsoidLocation,
     mask: &'a ElevationMask,
     sc: &'a Trajectory<O, R>,
-    body_fixed_frame: Frame,
 }
 
 impl<O, R> DetectFn for ElevationDetectFn<'_, O, R>
@@ -390,10 +403,10 @@ where
     fn eval(&self, time: Time) -> Result<f64, Self::Error> {
         let sc = self.sc.at(time.into_dynamic());
         let sc = sc
-            .try_to_frame(self.body_fixed_frame, &DefaultRotationProvider)
+            .try_to_frame(self.gs.frame(), &DefaultRotationProvider)
             .map_err(|e| EvalError::Rotation(Box::new(e)))?;
-        let obs = self.gs.compute_observables(sc.position(), sc.velocity());
-        Ok(obs.elevation() - self.mask.min_elevation(obs.azimuth()))
+        let obs = self.gs.observables(sc);
+        Ok((obs.elevation() - self.mask.min_elevation(obs.azimuth())).to_radians())
     }
 }
 
@@ -408,10 +421,10 @@ where
     fn eval_bounded(&self, time: Time) -> Result<(f64, f64), Self::Error> {
         let sc = self.sc.at(time);
         let sc = sc
-            .try_to_frame(self.body_fixed_frame, &DefaultRotationProvider)
+            .try_to_frame(self.gs.frame(), &DefaultRotationProvider)
             .map_err(|e| EvalError::Rotation(Box::new(e)))?;
-        let obs = self.gs.compute_observables(sc.position(), sc.velocity());
-        let value = obs.elevation() - self.mask.min_elevation(obs.azimuth());
+        let obs = self.gs.observables(sc);
+        let value = (obs.elevation() - self.mask.min_elevation(obs.azimuth())).to_radians();
 
         // The topocentric elevation-angle rate is bounded by the transverse
         // angular rate of the line-of-sight vector, |v_bf| / range (the
@@ -422,7 +435,7 @@ where
         // an unbounded rate, which degrades adaptive stepping to the fixed step.
         let bound = match self.mask {
             ElevationMask::Fixed(_) => {
-                let range = obs.range();
+                let range = obs.range().to_meters();
                 if range > 0.0 {
                     sc.velocity().length() / range
                 } else {
@@ -444,11 +457,10 @@ where
 /// Line-of-sight between a ground station and spacecraft, relative to an
 /// occulting body.
 struct LineOfSightDetectFn<'a, O: CoordinateOrigin, R: ReferenceFrame, E> {
-    gs: &'a GroundLocation,
+    gs: &'a EllipsoidLocation,
     sc: &'a Trajectory<O, R>,
     body: Origin,
     ephemeris: &'a E,
-    body_fixed_frame: Frame,
 }
 
 impl<O, R, E: Ephemeris> DetectFn for LineOfSightDetectFn<'_, O, R, E>
@@ -473,7 +485,7 @@ where
         // Compute ground station position in the scenario frame R by rotating
         // from body-fixed → R.
         let rot = DefaultRotationProvider
-            .try_rotation(self.body_fixed_frame, self.sc.reference_frame(), time)
+            .try_rotation(self.gs.frame(), self.sc.reference_frame(), time)
             .map_err(|e| EvalError::Rotation(Box::new(e)))?;
         let (r_gs_frame, _) = rot.rotate_state(self.gs.body_fixed_position(), DVec3::ZERO);
         let r_gs = r_gs_frame - r_body;
@@ -709,14 +721,12 @@ where
         sc_traj: &Trajectory<O, R>,
         interval: TimeInterval,
     ) -> Result<Vec<TimeInterval>, VisibilityError> {
-        let body_fixed_frame = gs.body_fixed_frame();
         let step = self.scan_step();
 
         let elev = ElevationDetectFn {
             gs: gs.location(),
             mask: gs.mask(),
             sc: sc_traj,
-            body_fixed_frame,
         };
 
         // Elevation is the cheap constraint and always runs over the whole
@@ -747,7 +757,6 @@ where
                     sc: sc_traj,
                     body,
                     ephemeris,
-                    body_fixed_frame,
                 }
                 .into_intervals(UniformSampler::new(step), window)
             };
@@ -938,11 +947,10 @@ impl VisibilityResults {
         &self,
         ground_id: &AssetId,
         space_id: &AssetId,
-        gs: &GroundLocation,
+        gs: &EllipsoidLocation,
         mask: &ElevationMask,
         sc: &lox_orbits::orbits::Trajectory,
         time_resolution: TimeDelta,
-        body_fixed_frame: Frame,
     ) -> Result<Vec<Pass>, PassError> {
         let key = (ground_id.clone(), space_id.clone());
         if self.pair_types.get(&key) == Some(&PairType::InterSatellite) {
@@ -962,14 +970,7 @@ impl VisibilityResults {
                             interval.start().into_dynamic(),
                             interval.end().into_dynamic(),
                         );
-                        Pass::from_interval(
-                            dynamic_interval,
-                            time_resolution,
-                            gs,
-                            mask,
-                            sc,
-                            body_fixed_frame,
-                        )
+                        Pass::from_interval(dynamic_interval, time_resolution, gs, mask, sc)
                     })
                     .collect()
             })
@@ -1131,7 +1132,6 @@ where
                             gs.location(),
                             gs.mask(),
                             &dynamic_traj,
-                            gs.body_fixed_frame(),
                         )
                     })
                     .collect();
@@ -1269,7 +1269,6 @@ where
             let sc_traj = ensemble.get(sc.id()).expect(
                 "trajectory not found in ensemble; did you forget to propagate this spacecraft?",
             );
-            let body_fixed_frame = gs.body_fixed_frame();
             let step = match min_pass_duration {
                 Some(d) if 0.5 * d > step => 0.5 * d,
                 _ => step,
@@ -1278,7 +1277,6 @@ where
                 gs: gs.location(),
                 mask: gs.mask(),
                 sc: sc_traj,
-                body_fixed_frame,
             };
             let windows = if adaptive {
                 elev.intervals(
@@ -1625,7 +1623,7 @@ mod tests {
 
     use super::*;
     use lox_frames::Icrf;
-    use lox_orbits::ground::GroundLocation;
+    use lox_orbits::ground::EllipsoidLocation;
     use lox_orbits::orbits::Trajectory;
 
     /// Build a Scenario + Ensemble from ground/space assets and a TimeScale interval.
@@ -1696,7 +1694,7 @@ mod tests {
         let sc = spacecraft_trajectory_dynamic();
         let gs_traj = ground_station_trajectory();
         let gs = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let expected: Vec<f64> = read_data_file("elevation.csv")
             .lines()
             .map(|line| line.parse::<f64>().unwrap().to_radians())
@@ -1708,7 +1706,6 @@ mod tests {
             gs: &gs,
             mask: &mask,
             sc: &typed_sc,
-            body_fixed_frame: Frame::Iau(Origin::Earth),
         };
         // Use the ground station trajectory times
         let actual: Vec<f64> = gs_traj
@@ -1727,7 +1724,7 @@ mod tests {
         let azimuth = vec![-PI, 0.0, PI];
         let elevation = vec![-2.0, 0.0, 2.0];
         let mask = ElevationMask::new(azimuth, elevation).unwrap();
-        assert_eq!(mask.min_elevation(0.0), 0.0);
+        assert_eq!(mask.min_elevation(Angle::ZERO), Angle::ZERO);
     }
 
     #[test]
@@ -1744,7 +1741,7 @@ mod tests {
     #[test]
     fn test_visibility() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
@@ -1768,7 +1765,7 @@ mod tests {
     #[test]
     fn test_visibility_no_ephemeris() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
@@ -1793,7 +1790,7 @@ mod tests {
     #[test]
     fn test_visibility_combined() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
@@ -1820,7 +1817,7 @@ mod tests {
     #[test]
     fn test_pass_observables_above_mask() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(10.0_f64.to_radians());
+        let mask = ElevationMask::with_fixed_elevation(Angle::degrees(10.0));
         let sc_traj = spacecraft_trajectory_dynamic();
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
@@ -1863,9 +1860,9 @@ mod tests {
         .unwrap()
     }
 
-    fn location_dynamic() -> GroundLocation<Origin> {
+    fn location_dynamic() -> EllipsoidLocation {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        GroundLocation::try_new(coords, Origin::Earth).unwrap()
+        EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap()
     }
 
     fn contacts_tai() -> Vec<TimeInterval> {
@@ -1901,7 +1898,7 @@ mod tests {
     #[test]
     fn test_visibility_adaptive_matches_uniform() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
@@ -2227,7 +2224,7 @@ mod tests {
     #[test]
     fn test_ground_space_filter() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let gs1 = GroundStation::new("cebreros", gs_loc.clone(), mask.clone());
         let gs2 = GroundStation::new("malargue", gs_loc, mask);
         let sc_traj = spacecraft_trajectory_dynamic();
@@ -2278,7 +2275,7 @@ mod tests {
     #[test]
     fn test_both_filters_combined_with_ground_space() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let gs1 = GroundStation::new("cebreros", gs_loc.clone(), mask.clone());
         let gs2 = GroundStation::new("malargue", gs_loc, mask);
         let sc_traj = spacecraft_trajectory_dynamic();
@@ -2312,7 +2309,7 @@ mod tests {
     #[test]
     fn test_min_pass_duration_filters_short_passes() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
@@ -2366,7 +2363,7 @@ mod tests {
             .unwrap();
 
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let dummy_traj = Trajectory::from_csv_dynamic(
             &read_data_file("trajectory_lunar.csv"),
             Origin::Earth,
@@ -2382,7 +2379,6 @@ mod tests {
                 &mask,
                 &dummy_traj,
                 TimeDelta::from_seconds(60),
-                Frame::Iau(Origin::Earth),
             )
             .unwrap_err();
         assert!(matches!(err, PassError::InterSatellitePair(_, _)));
@@ -2391,7 +2387,7 @@ mod tests {
     #[test]
     fn test_to_passes_unknown_pair_returns_empty() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let gs = GroundStation::new("cebreros", gs_loc.clone(), mask.clone());
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
@@ -2418,7 +2414,6 @@ mod tests {
                 &mask,
                 &dummy_traj,
                 TimeDelta::from_seconds(60),
-                Frame::Iau(Origin::Earth),
             )
             .unwrap();
         assert!(passes.is_empty());
@@ -2427,7 +2422,7 @@ mod tests {
     #[test]
     fn test_combined_ground_and_inter_satellite() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(0.0);
+        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let gs = GroundStation::new("cebreros", gs_loc, mask);
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());

--- a/crates/lox-frames/src/frames.rs
+++ b/crates/lox-frames/src/frames.rs
@@ -6,16 +6,18 @@
 use std::str::FromStr;
 
 use lox_bodies::{
-    CoordinateOrigin, Origin, RotationalElements, TryRotationalElements,
-    UndefinedOriginPropertyError,
+    CoordinateOrigin, Earth, Origin, RotationalElements, Spheroid, TryRotationalElements,
+    TrySpheroid, UndefinedOriginPropertyError,
 };
+use lox_core::coords::Ellipsoid;
 use thiserror::Error;
 
 use crate::{
     iers::{Iau2000Model, IersSystem, ReferenceSystem},
     traits::{
         BodyFixed, FrameKey, NonBodyFixedFrameError, NonQuasiInertialFrameError, QuasiInertial,
-        ReferenceFrame, TryBodyFixed, TryQuasiInertial, frame_key,
+        ReferenceEllipsoid, ReferenceFrame, TryBodyFixed, TryQuasiInertial, TryReferenceEllipsoid,
+        UndefinedReferenceEllipsoidError, frame_key,
     },
 };
 
@@ -83,6 +85,8 @@ impl ReferenceFrame for Cirf {
     }
 }
 
+impl QuasiInertial for Cirf {}
+
 /// Terrestrial Intermediate Reference Frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -103,6 +107,21 @@ impl ReferenceFrame for Tirf {
     }
 }
 
+impl BodyFixed for Tirf {
+    type Origin = Earth;
+
+    fn origin(&self) -> Self::Origin {
+        Earth
+    }
+}
+
+// TIRF differs from ITRF only by polar motion, so it shares ITRF's datum.
+impl ReferenceEllipsoid for Tirf {
+    fn reference_ellipsoid(&self) -> Ellipsoid {
+        Ellipsoid::GRS80
+    }
+}
+
 /// International Terrestrial Reference Frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -120,6 +139,20 @@ impl ReferenceFrame for Itrf {
 
     fn frame_key(&self, _: crate::traits::private::Internal) -> Option<FrameKey> {
         Some(FrameKey::Itrf)
+    }
+}
+
+impl BodyFixed for Itrf {
+    type Origin = Earth;
+
+    fn origin(&self) -> Self::Origin {
+        Earth
+    }
+}
+
+impl ReferenceEllipsoid for Itrf {
+    fn reference_ellipsoid(&self) -> Ellipsoid {
+        Ellipsoid::GRS80
     }
 }
 
@@ -145,6 +178,8 @@ where
     }
 }
 
+impl<T> QuasiInertial for Mod<T> where T: IersSystem + Into<ReferenceSystem> + Copy {}
+
 /// True of Date frame, parameterised by IERS convention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -166,6 +201,8 @@ where
         Some(FrameKey::Tod(self.0.into()))
     }
 }
+
+impl<T> QuasiInertial for Tod<T> where T: IersSystem + Into<ReferenceSystem> + Copy {}
 
 /// Pseudo-Earth Fixed frame, parameterised by IERS convention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -189,6 +226,27 @@ where
     }
 }
 
+impl<T> BodyFixed for Pef<T>
+where
+    T: IersSystem + Into<ReferenceSystem> + Copy,
+{
+    type Origin = Earth;
+
+    fn origin(&self) -> Self::Origin {
+        Earth
+    }
+}
+
+// PEF differs from ITRF only by polar motion, so it shares ITRF's datum.
+impl<T> ReferenceEllipsoid for Pef<T>
+where
+    T: IersSystem + Into<ReferenceSystem> + Copy,
+{
+    fn reference_ellipsoid(&self) -> Ellipsoid {
+        Ellipsoid::GRS80
+    }
+}
+
 /// True Equator Mean Equinox frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -209,7 +267,7 @@ impl ReferenceFrame for Teme {
     }
 }
 
-impl BodyFixed for Itrf {}
+impl QuasiInertial for Teme {}
 
 // -- serde: serialize frame ZSTs as their abbreviation --
 
@@ -310,7 +368,19 @@ where
     }
 }
 
-impl<T: TryRotationalElements> BodyFixed for Iau<T> {}
+impl<T: TryRotationalElements + Copy> BodyFixed for Iau<T> {
+    type Origin = T;
+
+    fn origin(&self) -> Self::Origin {
+        self.0
+    }
+}
+
+impl<T: RotationalElements + Spheroid + Copy> ReferenceEllipsoid for Iau<T> {
+    fn reference_ellipsoid(&self) -> Ellipsoid {
+        self.0.ellipsoid()
+    }
+}
 
 /// Full name of the IAU body-fixed frame for a body named `body`.
 pub(crate) fn iau_name(body: &str) -> String {
@@ -448,17 +518,48 @@ impl ReferenceFrame for Frame {
 impl TryQuasiInertial for Frame {
     fn try_quasi_inertial(&self) -> Result<(), NonQuasiInertialFrameError> {
         match self {
-            Frame::Icrf | Frame::J2000 | Frame::Cirf | Frame::Mod(_) | Frame::Tod(_) => Ok(()),
+            Frame::Icrf
+            | Frame::J2000
+            | Frame::Cirf
+            | Frame::Mod(_)
+            | Frame::Tod(_)
+            | Frame::Teme => Ok(()),
             _ => Err(NonQuasiInertialFrameError(self.abbreviation())),
         }
     }
 }
 
 impl TryBodyFixed for Frame {
+    type Origin = Origin;
+
     fn try_body_fixed(&self) -> Result<(), NonBodyFixedFrameError> {
         match self {
             Frame::Iau(_) | Frame::Itrf | Frame::Tirf | Frame::Pef(_) => Ok(()),
             _ => Err(NonBodyFixedFrameError(self.abbreviation())),
+        }
+    }
+
+    fn try_origin(&self) -> Result<Self::Origin, NonBodyFixedFrameError> {
+        match self {
+            Frame::Iau(origin) => Ok(*origin),
+            Frame::Itrf => Ok(Itrf.origin().into()),
+            Frame::Tirf => Ok(Tirf.origin().into()),
+            Frame::Pef(sys) => Ok(Pef(*sys).origin().into()),
+            _ => Err(NonBodyFixedFrameError(self.abbreviation())),
+        }
+    }
+}
+
+impl TryReferenceEllipsoid for Frame {
+    fn try_reference_ellipsoid(&self) -> Result<Ellipsoid, UndefinedReferenceEllipsoidError> {
+        match self {
+            Frame::Iau(origin) => Ok(origin.try_ellipsoid()?),
+            Frame::Itrf => Ok(Itrf.reference_ellipsoid()),
+            Frame::Tirf => Ok(Tirf.reference_ellipsoid()),
+            Frame::Pef(sys) => Ok(Pef(*sys).reference_ellipsoid()),
+            _ => Err(UndefinedReferenceEllipsoidError::NotBodyFixed(
+                NonBodyFixedFrameError(self.abbreviation()),
+            )),
         }
     }
 }
@@ -598,6 +699,7 @@ impl FromStr for Frame {
 mod tests {
     use super::*;
 
+    use crate::iers::{Iers1996, Iers2003, Iers2010};
     use crate::rotations::TryRotation;
     use crate::traits::frame_key;
     use crate::{Iau, providers::DefaultRotationProvider};
@@ -765,6 +867,124 @@ mod tests {
         assert!(Frame::J2000.try_quasi_inertial().is_ok());
     }
 
+    /// Quasi-inertial frames do not rotate with a central body; body-fixed
+    /// frames do. Every variant is listed so adding one forces a decision.
+    #[rstest]
+    #[case(Frame::Icrf, true)]
+    #[case(Frame::J2000, true)]
+    #[case(Frame::Cirf, true)]
+    #[case(Frame::Teme, true)]
+    #[case(Frame::Mod(ReferenceSystem::Iers1996), true)]
+    #[case(Frame::Mod(ReferenceSystem::Iers2010), true)]
+    #[case(Frame::Tod(ReferenceSystem::Iers1996), true)]
+    #[case(Frame::Tod(ReferenceSystem::Iers2010), true)]
+    #[case(Frame::Tirf, false)]
+    #[case(Frame::Itrf, false)]
+    #[case(Frame::Pef(ReferenceSystem::Iers1996), false)]
+    #[case(Frame::Pef(ReferenceSystem::Iers2010), false)]
+    #[case(Frame::Iau(Origin::Earth), false)]
+    fn test_quasi_inertial_classification(#[case] frame: Frame, #[case] exp: bool) {
+        assert_eq!(frame.try_quasi_inertial().is_ok(), exp);
+        // The two classifications are mutually exclusive.
+        assert!(!(frame.try_quasi_inertial().is_ok() && frame.try_body_fixed().is_ok()));
+    }
+
+    #[rstest]
+    #[case(Frame::Tirf, true)]
+    #[case(Frame::Itrf, true)]
+    #[case(Frame::Pef(ReferenceSystem::Iers1996), true)]
+    #[case(Frame::Pef(ReferenceSystem::Iers2010), true)]
+    #[case(Frame::Iau(Origin::Earth), true)]
+    #[case(Frame::Iau(Origin::Moon), true)]
+    #[case(Frame::Icrf, false)]
+    #[case(Frame::J2000, false)]
+    #[case(Frame::Cirf, false)]
+    #[case(Frame::Teme, false)]
+    #[case(Frame::Mod(ReferenceSystem::Iers1996), false)]
+    #[case(Frame::Tod(ReferenceSystem::Iers1996), false)]
+    fn test_body_fixed_classification(#[case] frame: Frame, #[case] exp: bool) {
+        assert_eq!(frame.try_body_fixed().is_ok(), exp);
+        assert_eq!(frame.try_origin().is_ok(), exp);
+    }
+
+    /// The terrestrial frames are all realizations of the same rotating Earth.
+    #[rstest]
+    #[case(Frame::Itrf)]
+    #[case(Frame::Tirf)]
+    #[case(Frame::Pef(ReferenceSystem::Iers2010))]
+    fn test_terrestrial_frames_share_origin_and_datum(#[case] frame: Frame) {
+        assert_eq!(frame.try_origin().unwrap(), Origin::Earth);
+        assert_eq!(frame.try_reference_ellipsoid().unwrap(), Ellipsoid::GRS80);
+    }
+
+    // The zero-sized types carry their capabilities as compile-time markers and
+    // `Frame` as runtime checks. The two must not drift apart: passing a ZST to
+    // these helpers requires the marker, and the assertion covers the enum.
+
+    fn assert_quasi_inertial_agrees(frame: impl QuasiInertial + Copy + Into<Frame>) {
+        let dynamic: Frame = frame.into();
+        assert!(
+            dynamic.try_quasi_inertial().is_ok(),
+            "{} is quasi-inertial as a ZST but not as a Frame",
+            dynamic.abbreviation()
+        );
+    }
+
+    fn assert_body_fixed_agrees<F>(frame: F)
+    where
+        F: BodyFixed + Copy + Into<Frame>,
+        F::Origin: Into<Origin>,
+    {
+        let dynamic: Frame = frame.into();
+        assert!(
+            dynamic.try_body_fixed().is_ok(),
+            "{} is body-fixed as a ZST but not as a Frame",
+            dynamic.abbreviation()
+        );
+        assert_eq!(dynamic.try_origin().unwrap(), frame.origin().into());
+    }
+
+    fn assert_reference_ellipsoid_agrees(frame: impl ReferenceEllipsoid + Copy + Into<Frame>) {
+        let dynamic: Frame = frame.into();
+        assert_eq!(
+            dynamic.try_reference_ellipsoid().unwrap(),
+            frame.reference_ellipsoid()
+        );
+    }
+
+    #[test]
+    fn test_quasi_inertial_zsts_agree_with_frame() {
+        assert_quasi_inertial_agrees(Icrf);
+        assert_quasi_inertial_agrees(J2000);
+        assert_quasi_inertial_agrees(Cirf);
+        assert_quasi_inertial_agrees(Teme);
+        assert_quasi_inertial_agrees(Mod(Iers1996));
+        assert_quasi_inertial_agrees(Mod(Iers2003::default()));
+        assert_quasi_inertial_agrees(Mod(Iers2010));
+        assert_quasi_inertial_agrees(Tod(Iers1996));
+        assert_quasi_inertial_agrees(Tod(Iers2003::default()));
+        assert_quasi_inertial_agrees(Tod(Iers2010));
+    }
+
+    #[test]
+    fn test_body_fixed_zsts_agree_with_frame() {
+        assert_body_fixed_agrees(Itrf);
+        assert_body_fixed_agrees(Tirf);
+        assert_body_fixed_agrees(Pef(Iers1996));
+        assert_body_fixed_agrees(Pef(Iers2003::default()));
+        assert_body_fixed_agrees(Pef(Iers2010));
+        assert_body_fixed_agrees(Iau::new(Earth));
+    }
+
+    #[test]
+    fn test_reference_ellipsoid_zsts_agree_with_frame() {
+        assert_reference_ellipsoid_agrees(Itrf);
+        assert_reference_ellipsoid_agrees(Tirf);
+        assert_reference_ellipsoid_agrees(Pef(Iers1996));
+        assert_reference_ellipsoid_agrees(Pef(Iers2010));
+        assert_reference_ellipsoid_agrees(Iau::new(Earth));
+    }
+
     #[test]
     fn test_from_simple_frames() {
         assert_eq!(Frame::from(Icrf), Frame::Icrf);
@@ -777,8 +997,6 @@ mod tests {
 
     #[test]
     fn test_from_parameterized_frames() {
-        use crate::iers::{Iers1996, Iers2003, Iers2010};
-
         assert_eq!(
             Frame::from(Mod(Iers1996)),
             Frame::Mod(ReferenceSystem::Iers1996)

--- a/crates/lox-frames/src/traits.rs
+++ b/crates/lox-frames/src/traits.rs
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use lox_bodies::NaifId;
+use lox_bodies::{CoordinateOrigin, NaifId, UndefinedOriginPropertyError};
+use lox_core::coords::Ellipsoid;
 use thiserror::Error;
 
 use crate::iers::ReferenceSystem;
@@ -77,7 +78,13 @@ impl<T: QuasiInertial> TryQuasiInertial for T {
 }
 
 /// Marker trait for body-fixed reference frames.
-pub trait BodyFixed: ReferenceFrame {}
+pub trait BodyFixed: ReferenceFrame {
+    /// The coordinate origin (central body) of the body-fixed frame.
+    type Origin: CoordinateOrigin + Copy;
+
+    /// Returns the coordinate origin (central body) of the body-fixed frame.
+    fn origin(&self) -> Self::Origin;
+}
 
 /// The frame is not body-fixed.
 #[derive(Clone, Debug, Error)]
@@ -86,12 +93,63 @@ pub struct NonBodyFixedFrameError(pub String);
 
 /// Fallible check for body-fixed frames (used by dynamic dispatch).
 pub trait TryBodyFixed: ReferenceFrame {
+    /// The coordinate origin (central body) of the body-fixed frame.
+    type Origin: CoordinateOrigin + Copy;
+
     /// Returns `Ok(())` if the frame is body-fixed.
     fn try_body_fixed(&self) -> Result<(), NonBodyFixedFrameError>;
+
+    /// Returns the coordinate origin (central body) of the body-fixed frame.
+    fn try_origin(&self) -> Result<Self::Origin, NonBodyFixedFrameError>;
 }
 
 impl<T: BodyFixed> TryBodyFixed for T {
+    type Origin = T::Origin;
+
     fn try_body_fixed(&self) -> Result<(), NonBodyFixedFrameError> {
         Ok(())
     }
+
+    fn try_origin(&self) -> Result<Self::Origin, NonBodyFixedFrameError> {
+        Ok(self.origin())
+    }
+}
+
+/// A body-fixed frame with a conventional reference ellipsoid.
+///
+/// The ellipsoid is the one conventionally paired with the frame rather than an
+/// intrinsic property of its origin: the terrestrial frames
+/// ([`Itrf`](crate::Itrf), [`Tirf`](crate::Tirf) and [`Pef`](crate::Pef)) are
+/// paired with GRS80, while [`Iau`](crate::Iau) frames use their body's own
+/// spheroid. Callers needing a different datum supply the ellipsoid explicitly.
+pub trait ReferenceEllipsoid: BodyFixed {
+    /// Returns the reference ellipsoid conventionally paired with this frame.
+    fn reference_ellipsoid(&self) -> Ellipsoid;
+}
+
+/// Fallible accessor for a frame's reference ellipsoid (used by dynamic dispatch).
+pub trait TryReferenceEllipsoid: TryBodyFixed {
+    /// Returns the reference ellipsoid conventionally paired with this frame,
+    /// or an error if the frame is not body-fixed or its origin is not a spheroid.
+    fn try_reference_ellipsoid(&self) -> Result<Ellipsoid, UndefinedReferenceEllipsoidError>;
+}
+
+impl<T> TryReferenceEllipsoid for T
+where
+    T: ReferenceEllipsoid,
+{
+    fn try_reference_ellipsoid(&self) -> Result<Ellipsoid, UndefinedReferenceEllipsoidError> {
+        Ok(self.reference_ellipsoid())
+    }
+}
+
+/// Error returned when a frame has no reference ellipsoid.
+#[derive(Debug, thiserror::Error)]
+pub enum UndefinedReferenceEllipsoidError {
+    /// The frame is not body-fixed, so no datum is associated with it.
+    #[error(transparent)]
+    NotBodyFixed(#[from] NonBodyFixedFrameError),
+    /// The frame's origin has no spheroid, as for a triaxial body.
+    #[error(transparent)]
+    UndefinedSpheroid(#[from] UndefinedOriginPropertyError),
 }

--- a/crates/lox-orbits/src/ground.rs
+++ b/crates/lox-orbits/src/ground.rs
@@ -4,11 +4,14 @@
 
 use crate::orbits::{CartesianOrbit, Trajectory, TrajectoryError};
 use crate::propagators::Propagator;
-use lox_bodies::{Origin, RotationalElements, Spheroid, TrySpheroid, UndefinedOriginPropertyError};
+use lox_bodies::CoordinateOrigin;
 use lox_core::coords::{Cartesian, Ellipsoid, LonLatAlt};
 use lox_core::glam::{DMat3, DVec3};
-use lox_core::types::units::Radians;
-use lox_frames::{Frame, Iau, ReferenceFrame};
+use lox_core::units::{Angle, Distance, Velocity};
+use lox_frames::traits::{
+    ReferenceEllipsoid, TryReferenceEllipsoid, UndefinedReferenceEllipsoidError, frame_key,
+};
+use lox_frames::{BodyFixed, Frame, NonBodyFixedFrameError, TryBodyFixed};
 use lox_time::Time;
 use lox_time::deltas::TimeDelta;
 use lox_time::intervals::TimeInterval;
@@ -18,15 +21,15 @@ use thiserror::Error;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Observables {
-    azimuth: Radians,
-    elevation: Radians,
-    range: f64,
-    range_rate: f64,
+    azimuth: Angle,
+    elevation: Angle,
+    range: Distance,
+    range_rate: Velocity,
 }
 
 impl Observables {
     /// Creates a new set of observables.
-    pub fn new(azimuth: Radians, elevation: Radians, range: f64, range_rate: f64) -> Self {
+    pub fn new(azimuth: Angle, elevation: Angle, range: Distance, range_rate: Velocity) -> Self {
         Observables {
             azimuth,
             elevation,
@@ -34,71 +37,172 @@ impl Observables {
             range_rate,
         }
     }
-    /// Returns the azimuth angle in radians.
-    pub fn azimuth(&self) -> Radians {
+    /// Returns the azimuth angle.
+    pub fn azimuth(&self) -> Angle {
         self.azimuth
     }
 
-    /// Returns the elevation angle in radians.
-    pub fn elevation(&self) -> Radians {
+    /// Returns the elevation angle.
+    pub fn elevation(&self) -> Angle {
         self.elevation
     }
 
-    /// Returns the slant range in meters.
-    pub fn range(&self) -> f64 {
+    /// Returns the slant range.
+    pub fn range(&self) -> Distance {
         self.range
     }
 
-    /// Returns the range rate in meters per second.
-    pub fn range_rate(&self) -> f64 {
+    /// Returns the range rate.
+    pub fn range_rate(&self) -> Velocity {
         self.range_rate
     }
 }
 
 /// A location on the surface of a celestial body.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GroundLocation<B: TrySpheroid = Origin> {
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(
+        try_from = "EllipsoidLocationDe<R>",
+        bound(deserialize = "R: serde::Deserialize<'de> + TryBodyFixed")
+    )
+)]
+pub struct EllipsoidLocation<R = Frame> {
     coordinates: LonLatAlt,
-    body: B,
+    ellipsoid: Ellipsoid,
+    frame: R,
 }
 
-/// Infallible constructor — requires compile-time `Spheroid` guarantee.
-impl<B: Spheroid> GroundLocation<B> {
-    /// Creates a new ground location on a body that is guaranteed to be a spheroid.
-    pub fn new(coordinates: LonLatAlt, body: B) -> Self {
-        GroundLocation { coordinates, body }
+/// Deserialization shadow for [`EllipsoidLocation`].
+///
+/// Deserializing into the public type directly would bypass the body-fixed
+/// check that [`EllipsoidLocation::origin`] relies on.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+#[serde(rename = "EllipsoidLocation")]
+struct EllipsoidLocationDe<R> {
+    coordinates: LonLatAlt,
+    ellipsoid: Ellipsoid,
+    frame: R,
+}
+
+#[cfg(feature = "serde")]
+impl<R: TryBodyFixed> TryFrom<EllipsoidLocationDe<R>> for EllipsoidLocation<R> {
+    type Error = NonBodyFixedFrameError;
+
+    fn try_from(de: EllipsoidLocationDe<R>) -> Result<Self, Self::Error> {
+        de.frame.try_body_fixed()?;
+        Ok(EllipsoidLocation {
+            coordinates: de.coordinates,
+            ellipsoid: de.ellipsoid,
+            frame: de.frame,
+        })
     }
 }
 
-/// Fallible constructor — for `Origin` and other `TrySpheroid` types.
-impl<B: TrySpheroid> GroundLocation<B> {
-    /// Creates a new ground location, returning an error if the body has no spheroid.
-    pub fn try_new(coordinates: LonLatAlt, body: B) -> Result<Self, UndefinedOriginPropertyError> {
-        // Validate the body has a valid ellipsoid at construction time.
-        // This is the invariant that `ellipsoid()` relies on.
-        body.try_ellipsoid()?;
-        Ok(GroundLocation { coordinates, body })
+impl<R> EllipsoidLocation<R> {
+    /// Creates a location on the frame's conventional reference ellipsoid.
+    pub fn new(coordinates: LonLatAlt, frame: R) -> Self
+    where
+        R: ReferenceEllipsoid,
+    {
+        EllipsoidLocation {
+            coordinates,
+            ellipsoid: frame.reference_ellipsoid(),
+            frame,
+        }
     }
-}
 
-impl<B: TrySpheroid + Into<Origin>> GroundLocation<B> {
-    /// Converts the ground location into a dynamic representation.
-    pub fn into_dynamic(self) -> GroundLocation {
-        GroundLocation {
-            coordinates: self.coordinates,
-            body: self.body.into(),
+    /// Creates a location on an explicitly chosen reference ellipsoid.
+    ///
+    /// Use this to reference coordinates to a different datum, such as a historical
+    /// ellipsoid or one whose values differ from the body's.
+    pub fn with_ellipsoid(coordinates: LonLatAlt, ellipsoid: Ellipsoid, frame: R) -> Self
+    where
+        R: BodyFixed,
+    {
+        EllipsoidLocation {
+            coordinates,
+            ellipsoid,
+            frame,
         }
     }
 }
 
-impl<B: TrySpheroid> GroundLocation<B> {
-    /// Returns the central body.
-    pub fn origin(&self) -> B
+impl<R> EllipsoidLocation<R>
+where
+    R: TryReferenceEllipsoid,
+{
+    /// Creates a location on the frame's conventional reference ellipsoid,
+    /// returning an error if the frame has none.
+    pub fn try_new(
+        coordinates: LonLatAlt,
+        frame: R,
+    ) -> Result<Self, UndefinedReferenceEllipsoidError> {
+        let ellipsoid = frame.try_reference_ellipsoid()?;
+        Ok(EllipsoidLocation {
+            coordinates,
+            ellipsoid,
+            frame,
+        })
+    }
+}
+
+impl<R> EllipsoidLocation<R>
+where
+    R: TryBodyFixed,
+{
+    /// Creates a location on an explicitly chosen reference ellipsoid,
+    /// returning an error if the frame is not body-fixed.
+    ///
+    /// See [`EllipsoidLocation::with_ellipsoid`] for when to override the
+    /// frame's conventional ellipsoid.
+    pub fn try_with_ellipsoid(
+        coordinates: LonLatAlt,
+        ellipsoid: Ellipsoid,
+        frame: R,
+    ) -> Result<Self, NonBodyFixedFrameError> {
+        frame.try_body_fixed()?;
+        Ok(EllipsoidLocation {
+            coordinates,
+            ellipsoid,
+            frame,
+        })
+    }
+}
+
+impl<R> EllipsoidLocation<R>
+where
+    R: Into<Frame>,
+{
+    /// Converts the ground location into a dynamic representation.
+    pub fn into_dynamic(self) -> EllipsoidLocation {
+        EllipsoidLocation {
+            coordinates: self.coordinates,
+            ellipsoid: self.ellipsoid,
+            frame: self.frame.into(),
+        }
+    }
+}
+
+impl<R> EllipsoidLocation<R> {
+    /// Returns the reference frame for this location.
+    pub fn frame(&self) -> R
     where
-        B: Clone,
+        R: Clone,
     {
-        self.body.clone()
+        self.frame.clone()
+    }
+
+    /// Returns the central body of the location's frame.
+    pub fn origin(&self) -> R::Origin
+    where
+        R: TryBodyFixed,
+    {
+        self.frame
+            .try_origin()
+            .expect("validated at EllipsoidLocation construction")
     }
 
     /// Returns the geodetic coordinates.
@@ -106,29 +210,24 @@ impl<B: TrySpheroid> GroundLocation<B> {
         self.coordinates
     }
 
-    /// Returns the longitude in radians.
-    pub fn longitude(&self) -> f64 {
-        self.coordinates.lon().to_radians()
+    /// Returns the geodetic longitude.
+    pub fn longitude(&self) -> Angle {
+        self.coordinates.lon()
     }
 
-    /// Returns the latitude in radians.
-    pub fn latitude(&self) -> f64 {
-        self.coordinates.lat().to_radians()
+    /// Returns the geodetic latitude.
+    pub fn latitude(&self) -> Angle {
+        self.coordinates.lat()
     }
 
-    /// Returns altitude in km (for backward compatibility).
-    pub fn altitude(&self) -> f64 {
-        self.coordinates.alt().to_kilometers()
+    /// Returns the altitude above the reference ellipsoid.
+    pub fn altitude(&self) -> Distance {
+        self.coordinates.alt()
     }
 
-    /// Returns the ellipsoid for this location's body.
-    ///
-    /// Infallible: the body's spheroid validity is checked at construction
-    /// (in [`GroundLocation::new`] or [`GroundLocation::try_new`]).
+    /// Returns the ellipsoid for this location.
     pub fn ellipsoid(&self) -> Ellipsoid {
-        self.body
-            .try_ellipsoid()
-            .expect("validated at GroundLocation construction")
+        self.ellipsoid
     }
 
     /// Returns the body-fixed Cartesian position in meters.
@@ -141,34 +240,44 @@ impl<B: TrySpheroid> GroundLocation<B> {
         self.coordinates.rotation_to_topocentric()
     }
 
-    /// Computes topocentric observables from raw body-fixed position and velocity vectors.
-    pub fn compute_observables(&self, state_position: DVec3, state_velocity: DVec3) -> Observables {
+    /// Computes topocentric observables from a Cartesian state.
+    ///
+    /// The state must be centred on this location's body and expressed in its
+    /// frame. Neither is enforced by the signature — a mismatch yields silently
+    /// wrong observables rather than an error — so both are asserted in debug
+    /// builds.
+    pub fn observables<O>(&self, state: CartesianOrbit<O, R>) -> Observables
+    where
+        O: CoordinateOrigin + Copy,
+        R: TryBodyFixed + Copy,
+    {
+        debug_assert_eq!(
+            state.origin().id(),
+            self.origin().id(),
+            "state origin `{}` is not the location's body `{}`",
+            state.origin().name(),
+            self.origin().name(),
+        );
+        debug_assert_eq!(
+            frame_key(&state.reference_frame()),
+            frame_key(&self.frame),
+            "state frame `{}` is not the location's frame `{}`",
+            state.reference_frame().abbreviation(),
+            self.frame.abbreviation(),
+        );
         let rot = self.rotation_to_topocentric();
-        let position = rot * (state_position - self.body_fixed_position());
-        let velocity = rot * state_velocity;
+        let position = rot * (state.position() - self.body_fixed_position());
+        let velocity = rot * state.velocity();
         let range = position.length();
         let range_rate = position.dot(velocity) / range;
         let elevation = (position.z / range).asin();
         let azimuth = position.y.atan2(-position.x);
         Observables {
-            azimuth,
-            elevation,
-            range,
-            range_rate,
+            azimuth: Angle::radians(azimuth),
+            elevation: Angle::radians(elevation),
+            range: Distance::meters(range),
+            range_rate: Velocity::meters_per_second(range_rate),
         }
-    }
-
-    /// Computes topocentric observables from a Cartesian orbit in the body-fixed frame.
-    pub fn observables(&self, state: CartesianOrbit<B, Iau<B>>) -> Observables
-    where
-        B: RotationalElements + Copy,
-    {
-        self.compute_observables(state.position(), state.velocity())
-    }
-
-    /// Computes topocentric observables from a dynamic Cartesian orbit.
-    pub fn observables_dynamic(&self, state: crate::orbits::CartesianOrbit) -> Observables {
-        self.compute_observables(state.position(), state.velocity())
     }
 }
 
@@ -184,46 +293,20 @@ pub enum GroundPropagatorError {
 }
 
 /// Propagator that produces a stationary body-fixed trajectory for a ground location.
-pub struct GroundPropagator<B: TrySpheroid = Origin, R: ReferenceFrame = Frame> {
-    location: GroundLocation<B>,
-    frame: R,
+pub struct GroundPropagator<R = Frame> {
+    location: EllipsoidLocation<R>,
     step: Option<TimeDelta>,
 }
 
-/// Typed constructor -- for static bodies with `Spheroid + RotationalElements`.
-impl<B: Spheroid + RotationalElements> GroundPropagator<B, Iau<B>> {
-    /// Creates a new ground propagator in the body's IAU frame.
-    pub fn new(location: GroundLocation<B>) -> Self
-    where
-        B: Copy,
-    {
-        let frame = Iau::new(location.body);
+impl<R> GroundPropagator<R> {
+    /// Creates a new ground propagator.
+    pub fn new(location: EllipsoidLocation<R>) -> Self {
         GroundPropagator {
             location,
-            frame,
             step: None,
         }
     }
-}
 
-/// Infallible constructor for `Origin`.
-///
-/// Unlike `GroundLocation::try_new`, this constructor cannot fail: the location
-/// already holds a valid ellipsoid, and building the IAU frame from a `Origin`
-/// is always possible.
-impl GroundPropagator<Origin, Frame> {
-    /// Creates a new ground propagator for a dynamic-origin ground location.
-    pub fn new_dynamic(location: GroundLocation<Origin>) -> Self {
-        let frame = Frame::Iau(location.body);
-        GroundPropagator {
-            location,
-            frame,
-            step: None,
-        }
-    }
-}
-
-impl<B: TrySpheroid, R: ReferenceFrame> GroundPropagator<B, R> {
     /// Sets the propagation time step.
     pub fn with_step(mut self, step: TimeDelta) -> Self {
         self.step = Some(step);
@@ -231,40 +314,38 @@ impl<B: TrySpheroid, R: ReferenceFrame> GroundPropagator<B, R> {
     }
 
     /// Returns a reference to the underlying ground location.
-    pub fn location(&self) -> &GroundLocation<B> {
+    pub fn location(&self) -> &EllipsoidLocation<R> {
         &self.location
     }
 
     /// Compute the body-fixed state at a single time.
-    pub fn state_at(&self, time: Time) -> CartesianOrbit<B, R>
+    pub fn state_at(&self, time: Time) -> CartesianOrbit<R::Origin, R>
     where
-        B: Copy,
-        R: Copy,
+        R: TryBodyFixed + Copy,
     {
         let pos = self.location.body_fixed_position();
         CartesianOrbit::new(
             Cartesian::from_vecs(pos, DVec3::ZERO),
             time,
-            self.location.body,
-            self.frame,
+            self.location.origin(),
+            self.location.frame,
         )
     }
 }
 
 /// Single `Propagator` impl covers both typed and Dyn paths.
-impl<B, R> Propagator<B> for GroundPropagator<B, R>
+impl<R> Propagator<R::Origin> for GroundPropagator<R>
 where
-    B: TrySpheroid + lox_bodies::CoordinateOrigin + Copy,
-    R: ReferenceFrame + Copy,
+    R: TryBodyFixed + Copy,
 {
     type Frame = R;
     type Error = GroundPropagatorError;
 
-    fn state_at(&self, time: Time) -> Result<CartesianOrbit<B, R>, GroundPropagatorError> {
+    fn state_at(&self, time: Time) -> Result<CartesianOrbit<R::Origin, R>, GroundPropagatorError> {
         Ok(self.state_at(time))
     }
 
-    fn propagate(&self, interval: TimeInterval) -> Result<Trajectory<B, R>, Self::Error> {
+    fn propagate(&self, interval: TimeInterval) -> Result<Trajectory<R::Origin, R>, Self::Error> {
         let pos = self.location.body_fixed_position();
         let step = self.step.unwrap_or(TimeDelta::from_seconds(60));
         let states: Vec<_> = interval
@@ -273,8 +354,8 @@ where
                 CartesianOrbit::new(
                     Cartesian::from_vecs(pos, DVec3::ZERO),
                     t,
-                    self.location.body,
-                    self.frame,
+                    self.location.origin(),
+                    self.location.frame,
                 )
             })
             .collect();
@@ -285,10 +366,10 @@ where
 #[cfg(test)]
 mod tests {
     use lox_approx::assert_approx_eq;
-    use lox_bodies::Earth;
+    use lox_bodies::{Earth, Origin};
     use lox_core::coords::Cartesian;
-    use lox_frames::Icrf;
     use lox_frames::providers::DefaultRotationProvider;
+    use lox_frames::{Iau, Icrf};
     use lox_time::intervals::Interval;
     use lox_time::time_scales::Tdb;
     use lox_time::{time, utc};
@@ -298,7 +379,7 @@ mod tests {
     #[test]
     fn test_ground_location_to_body_fixed() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::new(coords, Earth);
+        let location = EllipsoidLocation::new(coords, Iau::new(Earth));
         let expected = DVec3::new(4846130.017870638, -370132.8551351891, 4116364.272747229);
         assert_approx_eq!(location.body_fixed_position(), expected);
     }
@@ -306,7 +387,7 @@ mod tests {
     #[test]
     fn test_ground_location_rotation_to_topocentric() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::new(coords, Earth);
+        let location = EllipsoidLocation::new(coords, Iau::new(Earth));
         let act = location.rotation_to_topocentric();
         let exp = DMat3::from_cols(
             DVec3::new(0.6469358921661584, 0.07615519584215287, 0.7587320591443464),
@@ -323,7 +404,7 @@ mod tests {
     #[test]
     fn test_ground_location_observables() {
         let coords = LonLatAlt::from_degrees(-4.0, 41.0, 0.0).unwrap();
-        let location = GroundLocation::new(coords, Earth);
+        let location = EllipsoidLocation::new(coords, Iau::new(Earth));
         let position = DVec3::new(3359927.0, -2398072.0, 5153000.0);
         let velocity = DVec3::new(5065.7, 5485.0, -744.0);
         let time = time!(Tdb, 2012, 7, 1).unwrap();
@@ -334,20 +415,53 @@ mod tests {
             Iau::new(Earth),
         );
         let observables = location.observables(state);
-        let expected_range = 2707700.0;
-        let expected_range_rate = -7160.0;
-        let expected_azimuth = -53.418f64.to_radians();
-        let expected_elevation = -7.077f64.to_radians();
+        let expected_range = Distance::kilometers(2707.7);
+        let expected_range_rate = Velocity::kilometers_per_second(-7.16);
+        let expected_azimuth = Angle::degrees(-53.418);
+        let expected_elevation = Angle::degrees(-7.077);
         assert_approx_eq!(observables.range, expected_range, rtol <= 1e-2);
         assert_approx_eq!(observables.range_rate, expected_range_rate, rtol <= 1e-2);
         assert_approx_eq!(observables.azimuth, expected_azimuth, rtol <= 1e-2);
         assert_approx_eq!(observables.elevation, expected_elevation, rtol <= 1e-2);
     }
 
+    /// `observables` is generic over the state's origin, so a state centred on
+    /// the wrong body type-checks. The debug assertion is the only thing
+    /// standing between that and silently offset observables.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "is not the location's body")]
+    fn test_observables_rejects_mismatched_origin() {
+        let coords = LonLatAlt::from_degrees(-4.0, 41.0, 0.0).unwrap();
+        let location = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+        let state = CartesianOrbit::new(
+            Cartesian::from_vecs(DVec3::new(3359927.0, -2398072.0, 5153000.0), DVec3::ZERO),
+            time!(Tdb, 2012, 7, 1).unwrap().into_dynamic(),
+            Origin::Moon,
+            Frame::Iau(Origin::Earth),
+        );
+        location.observables(state);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "is not the location's frame")]
+    fn test_observables_rejects_mismatched_frame() {
+        let coords = LonLatAlt::from_degrees(-4.0, 41.0, 0.0).unwrap();
+        let location = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+        let state = CartesianOrbit::new(
+            Cartesian::from_vecs(DVec3::new(3359927.0, -2398072.0, 5153000.0), DVec3::ZERO),
+            time!(Tdb, 2012, 7, 1).unwrap().into_dynamic(),
+            Origin::Earth,
+            Frame::Icrf,
+        );
+        location.observables(state);
+    }
+
     #[test]
     fn test_ground_propagator_body_fixed() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::new(coords, Earth);
+        let location = EllipsoidLocation::new(coords, Iau::new(Earth));
         let propagator = GroundPropagator::new(location.clone());
         let time = utc!(2022, 1, 31, 23).unwrap().to_dynamic_time();
         let t1 = time + TimeDelta::from_minutes(5);
@@ -364,7 +478,7 @@ mod tests {
     #[test]
     fn test_ground_propagator_in_icrf() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::new(coords, Earth);
+        let location = EllipsoidLocation::new(coords, Iau::new(Earth));
         let propagator = GroundPropagator::new(location);
         let time = utc!(2022, 1, 31, 23).unwrap().to_dynamic_time();
         let t1 = time + TimeDelta::from_minutes(5);
@@ -382,41 +496,74 @@ mod tests {
     #[test]
     fn test_try_new_with_static_body() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::try_new(coords, Earth).unwrap();
-        assert_approx_eq!(location.longitude(), -4.3676f64.to_radians());
-        assert_approx_eq!(location.latitude(), 40.4527f64.to_radians());
-        assert_approx_eq!(location.altitude(), 0.0);
+        let location = EllipsoidLocation::try_new(coords, Iau::new(Earth)).unwrap();
+        assert_approx_eq!(location.longitude(), Angle::degrees(-4.3676));
+        assert_approx_eq!(location.latitude(), Angle::degrees(40.4527));
+        assert_approx_eq!(location.altitude(), Distance::meters(0.0));
+    }
+
+    #[test]
+    fn test_accessors_are_in_si_units() {
+        // `LonLatAlt::from_degrees` takes metres, and the accessors return the
+        // same: radians and metres, matching `body_fixed_position`.
+        let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 450.0).unwrap();
+        let location = EllipsoidLocation::try_new(coords, Iau::new(Earth)).unwrap();
+        assert_approx_eq!(location.altitude(), Distance::meters(450.0));
+        assert_approx_eq!(
+            location.body_fixed_position().length(),
+            location
+                .coordinates()
+                .to_body_fixed(&location.ellipsoid())
+                .length()
+        );
     }
 
     #[test]
     fn test_try_new_with_dynamic_origin() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::try_new(coords, Origin::Earth).unwrap();
+        let location = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
         assert_eq!(location.origin(), Origin::Earth);
     }
 
     #[test]
     fn test_try_new_rejects_non_spheroid() {
         let coords = LonLatAlt::from_degrees(0.0, 0.0, 0.0).unwrap();
-        let result = GroundLocation::try_new(coords, Origin::SolarSystemBarycenter);
+        let result = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Phobos));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_with_ellipsoid_overrides_the_frame_default() {
+        let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
+        let default = EllipsoidLocation::new(coords, Iau::new(Earth));
+        let overridden =
+            EllipsoidLocation::with_ellipsoid(coords, Ellipsoid::WGS84, Iau::new(Earth));
+        assert_eq!(overridden.ellipsoid(), Ellipsoid::WGS84);
+        assert_ne!(overridden.ellipsoid(), default.ellipsoid());
+    }
+
+    #[test]
+    fn test_try_with_ellipsoid_rejects_non_body_fixed_frame() {
+        let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
+        let result = EllipsoidLocation::try_with_ellipsoid(coords, Ellipsoid::WGS84, Frame::Icrf);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_into_dynamic_ground_location() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::new(coords, Earth);
+        let location = EllipsoidLocation::new(coords, Iau::new(Earth));
         let dynamic_location = location.into_dynamic();
         assert_eq!(dynamic_location.origin(), Origin::Earth);
-        assert_approx_eq!(dynamic_location.longitude(), -4.3676f64.to_radians());
-        assert_approx_eq!(dynamic_location.latitude(), 40.4527f64.to_radians());
+        assert_approx_eq!(dynamic_location.longitude(), Angle::degrees(-4.3676));
+        assert_approx_eq!(dynamic_location.latitude(), Angle::degrees(40.4527));
     }
 
     #[test]
     fn test_ground_propagator_try_new_with_dynamic_origin() {
         let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-        let location = GroundLocation::try_new(coords, Origin::Earth).unwrap();
-        let propagator = GroundPropagator::new_dynamic(location);
+        let location = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+        let propagator = GroundPropagator::new(location);
         let time = utc!(2022, 1, 31, 23).unwrap().to_dynamic_time();
         let t1 = time + TimeDelta::from_minutes(5);
         let interval = Interval::new(time, t1);

--- a/crates/lox-orbits/src/orbits/cartesian.rs
+++ b/crates/lox-orbits/src/orbits/cartesian.rs
@@ -4,23 +4,22 @@
 
 use std::ops::Sub;
 
-use lox_bodies::{
-    CoordinateOrigin, Origin, PointMass, RotationalElements, Spheroid, TryPointMass, TrySpheroid,
-    UndefinedOriginPropertyError,
-};
+use lox_bodies::{CoordinateOrigin, Origin, PointMass, TryPointMass, UndefinedOriginPropertyError};
 use lox_core::coords::Cartesian;
 use lox_core::coords::FromBodyFixedError;
 use lox_core::coords::LonLatAlt;
 use lox_core::glam::{DMat3, DVec3};
 use lox_ephem::Ephemeris;
-use lox_frames::{
-    Frame, Iau, Icrf, ReferenceFrame, TryBodyFixed, rotations::TryRotation, traits::frame_key,
-};
+use lox_frames::BodyFixed;
+use lox_frames::traits::ReferenceEllipsoid;
+use lox_frames::traits::TryReferenceEllipsoid;
+use lox_frames::traits::UndefinedReferenceEllipsoidError;
+use lox_frames::{Frame, Icrf, ReferenceFrame, rotations::TryRotation, traits::frame_key};
 use lox_time::offsets::DefaultOffsetProvider;
 use lox_time::time_scales::{Tdb, TimeScale};
 use thiserror::Error;
 
-use crate::ground::GroundLocation;
+use crate::ground::EllipsoidLocation;
 
 use super::{CartesianOrbit, KeplerianOrbit, Orbit};
 
@@ -106,30 +105,27 @@ where
     }
 }
 
-impl<O> CartesianOrbit<O, Iau<O>>
+impl<R> CartesianOrbit<R::Origin, R>
 where
-    O: CoordinateOrigin + RotationalElements + Spheroid + Copy,
+    R: BodyFixed + ReferenceEllipsoid + Copy,
 {
     /// Converts this body-fixed Cartesian orbit to a ground location.
-    pub fn to_ground_location(&self) -> Result<GroundLocation<O>, FromBodyFixedError> {
-        let origin = self.origin();
-        let coords = LonLatAlt::from_body_fixed(self.position(), &origin.ellipsoid())?;
-        Ok(GroundLocation::new(coords, origin))
+    pub fn to_ellipsoid_location(&self) -> Result<EllipsoidLocation<R>, FromBodyFixedError> {
+        let ellipsoid = self.frame.reference_ellipsoid();
+        let coords = LonLatAlt::from_body_fixed(self.position(), &ellipsoid)?;
+        Ok(EllipsoidLocation::new(coords, self.frame))
     }
 }
 
 /// Errors that can occur when converting a dynamic Cartesian orbit to a ground location.
 #[derive(Debug, Error)]
 pub enum StateToGroundError {
-    /// The origin body does not define equatorial radius and flattening.
-    #[error("equatorial radius and flattening factor are not available for origin `{}`", .0.name())]
-    UndefinedSpheroid(Origin),
+    /// The frame is not body-fixed or does not have a reference ellipsoid defined.
+    #[error(transparent)]
+    UndefinedReferenceEllipsoid(#[from] UndefinedReferenceEllipsoidError),
     /// Failed to convert from body-fixed coordinates.
     #[error(transparent)]
     FromBodyFixed(#[from] FromBodyFixedError),
-    /// The frame is not a body-fixed frame.
-    #[error("not a body-fixed frame {0}")]
-    NonBodyFixedFrame(String),
 }
 
 fn rotation_lvlh(position: DVec3, velocity: DVec3) -> DMat3 {
@@ -204,20 +200,12 @@ impl CartesianOrbit {
     }
 
     /// Converts this dynamic Cartesian orbit to a ground location.
-    pub fn try_to_ground_location(&self) -> Result<GroundLocation, StateToGroundError> {
+    pub fn try_to_ellipsoid_location(&self) -> Result<EllipsoidLocation, StateToGroundError> {
         let frame = self.reference_frame();
-        let origin = self.origin();
-        if frame.try_body_fixed().is_err() {
-            return Err(StateToGroundError::NonBodyFixedFrame(
-                frame.name().to_string(),
-            ));
-        }
-        let ellipsoid = origin
-            .try_ellipsoid()
-            .map_err(|_| StateToGroundError::UndefinedSpheroid(origin))?;
-
+        let ellipsoid = frame.try_reference_ellipsoid()?;
         let coords = LonLatAlt::from_body_fixed(self.position(), &ellipsoid)?;
-        Ok(GroundLocation::try_new(coords, origin).unwrap())
+        EllipsoidLocation::try_with_ellipsoid(coords, ellipsoid, frame)
+            .map_err(|e| UndefinedReferenceEllipsoidError::NotBodyFixed(e).into())
     }
 
     /// Returns the LVLH rotation matrix, returning an error if the frame is not ICRF.
@@ -265,8 +253,10 @@ mod tests {
     use lox_bodies::{Earth, Jupiter, Venus};
     use lox_core::coords::Cartesian;
     use lox_core::glam::DVec3;
+    use lox_core::units::{Angle, Distance};
     use lox_ephem::Ephemeris;
     use lox_ephem::spk::parser::Spk;
+    use lox_frames::Iau;
     use lox_frames::providers::DefaultRotationProvider;
     use lox_test_utils::data_file;
     use lox_time::{time, time_scales::Tdb, utc::Utc};
@@ -332,10 +322,10 @@ mod tests {
     }
 
     #[test]
-    fn test_to_ground_location() {
-        let lat_exp = 51.484f64.to_radians();
-        let lon_exp = -35.516f64.to_radians();
-        let alt_exp = 237.434; // km
+    fn test_to_ellipsoid_location() {
+        let lat_exp = Angle::degrees(51.484);
+        let lon_exp = Angle::degrees(-35.516);
+        let alt_exp = Distance::kilometers(237.434);
 
         let position = DVec3::new(3359927.0, -2398072.0, 5153000.0);
         let velocity = DVec3::new(5065.7, 5485.0, -744.0);
@@ -346,7 +336,7 @@ mod tests {
             Earth,
             Iau::new(Earth),
         );
-        let ground = state.to_ground_location().unwrap();
+        let ground = state.to_ellipsoid_location().unwrap();
         assert_approx_eq!(ground.latitude(), lat_exp, rtol <= 1e-4);
         assert_approx_eq!(ground.longitude(), lon_exp, rtol <= 1e-4);
         assert_approx_eq!(ground.altitude(), alt_exp, rtol <= 1e-4);

--- a/crates/lox-space/benches/common/mod.rs
+++ b/crates/lox-space/benches/common/mod.rs
@@ -23,11 +23,12 @@ use lox_space::analysis::assets::{AssetId, GroundStation, Scenario, Spacecraft};
 use lox_space::analysis::visibility::ElevationMask;
 use lox_space::bodies::{Earth, Origin};
 use lox_space::core::coords::LonLatAlt;
+use lox_space::core::units::Angle;
 use lox_space::core::units::AngularRate;
 use lox_space::ephem::spk::parser::Spk;
 use lox_space::frames::providers::DefaultRotationProvider;
-use lox_space::frames::{Frame, Icrf};
-use lox_space::orbits::ground::GroundLocation;
+use lox_space::frames::{Frame, Iau, Icrf};
+use lox_space::orbits::ground::EllipsoidLocation;
 use lox_space::orbits::propagators::sgp4::{Elements, Sgp4};
 use lox_space::orbits::propagators::{OrbitSource, Propagator};
 use lox_space::orbits::{Ensemble, Trajectory};
@@ -59,16 +60,16 @@ fn spacecraft_trajectory_dynamic() -> Trajectory {
     .unwrap()
 }
 
-fn ground_location_dynamic() -> GroundLocation<Origin> {
+fn ground_location_dynamic() -> EllipsoidLocation {
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-    GroundLocation::try_new(coords, Origin::Earth).unwrap()
+    EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap()
 }
 
 /// Ground-space scenario over the lunar trajectory using dynamic dispatch.
 pub fn setup_dynamic() -> (Scenario, DynamicEnsemble) {
     let sc_traj = spacecraft_trajectory_dynamic();
     let gs_loc = ground_location_dynamic();
-    let mask = ElevationMask::with_fixed_elevation(0.0);
+    let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
     let gs = GroundStation::new("cebreros", gs_loc, mask);
     let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
     let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj));
@@ -88,9 +89,9 @@ fn spacecraft_trajectory_mono() -> Trajectory<Earth, Icrf> {
     .unwrap()
 }
 
-fn ground_location_mono() -> GroundLocation<Earth> {
+fn ground_location_mono() -> EllipsoidLocation<Iau<Earth>> {
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-    GroundLocation::try_new(coords, Earth).unwrap()
+    EllipsoidLocation::new(coords, Iau::new(Earth))
 }
 
 /// Ground-space scenario over the lunar trajectory using concrete types
@@ -98,7 +99,7 @@ fn ground_location_mono() -> GroundLocation<Earth> {
 pub fn setup_mono() -> (Scenario<Earth, Icrf>, MonoEnsemble) {
     let traj = spacecraft_trajectory_mono();
     let gs_loc = ground_location_mono();
-    let mask = ElevationMask::with_fixed_elevation(0.0);
+    let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
     let interval = TimeInterval::new(traj.start_time(), traj.end_time());
     let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(traj.into_dynamic()));
     let gs = GroundStation::new("cebreros", gs_loc.into_dynamic(), mask);
@@ -221,8 +222,8 @@ fn scaling_ground_stations() -> Vec<GroundStation> {
         .iter()
         .map(|&(id, lon, lat)| {
             let coords = LonLatAlt::from_degrees(lon, lat, 0.0).unwrap();
-            let loc = GroundLocation::try_new(coords, Origin::Earth).unwrap();
-            GroundStation::new(id, loc, ElevationMask::with_fixed_elevation(0.0))
+            let loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+            GroundStation::new(id, loc, ElevationMask::with_fixed_elevation(Angle::ZERO))
         })
         .collect()
 }

--- a/crates/lox-space/docs/ground.md
+++ b/crates/lox-space/docs/ground.md
@@ -14,11 +14,20 @@ Ground-based tracking and observation support.
 import lox_space as lox
 
 # Define a ground station
-gs = lox.GroundLocation(
-    origin=lox.Origin("Earth"),
+gs = lox.EllipsoidLocation(
+    frame="IAU_EARTH",          # any body-fixed frame, e.g. "ITRF"
     longitude=0.0 * lox.rad,    # Greenwich
     latitude=51.5 * lox.deg,    # ~51.5° N
     altitude=0.0 * lox.km,
+)
+
+# The frame's conventional ellipsoid is a default, not a constraint
+gs_wgs84 = lox.EllipsoidLocation(
+    frame="IAU_EARTH",
+    longitude=0.0 * lox.rad,
+    latitude=51.5 * lox.deg,
+    altitude=0.0 * lox.km,
+    ellipsoid=lox.Ellipsoid.WGS84,
 )
 
 # Calculate observables for a spacecraft state
@@ -39,7 +48,13 @@ mask = lox.ElevationMask.variable(azimuth, elevation)
 
 ---
 
-::: lox_space.GroundLocation
+::: lox_space.EllipsoidLocation
+    options:
+      show_source: false
+
+---
+
+::: lox_space.Ellipsoid
     options:
       show_source: false
 

--- a/crates/lox-space/docs/index.md
+++ b/crates/lox-space/docs/index.md
@@ -57,7 +57,7 @@ future_state = propagator.propagate(t + lox.TimeDelta.from_hours(1.5))
 | [Reference Frames](frames.md) | `Frame`, `SPK` |
 | [Orbital States](states.md) | `Cartesian`, `Keplerian`, `Trajectory` |
 | [Propagators](propagators.md) | `Vallado`, `SGP4`, `TLE`, `GroundPropagator` |
-| [Ground Stations](ground.md) | `GroundLocation`, `ElevationMask`, `Observables`, `Pass` |
+| [Ground Stations](ground.md) | `EllipsoidLocation`, `Ellipsoid`, `ElevationMask`, `Observables`, `Pass` |
 | [Events & Visibility](events.md) | `Event`, `Interval`, `intersect_intervals`, `union_intervals`, `complement_intervals`, `GroundStation`, `Spacecraft`, `Scenario`, `Ensemble`, `VisibilityAnalysis`, `VisibilityResults`, `PowerBudgetAnalysis`, `PowerBudgetResults` |
 | [Imaging](imaging.md) | `Aoi`, `OpticalPayload`, `OpticalAccessAnalysis`, `SarPayload`, `LookSide`, `SarAccessAnalysis`, `AccessResults` |
 | [Communications](comms.md) | `TxChain`, `RxChain`, `AmplifierTransmitter`, `NoiseTempReceiver`, `CascadeReceiver`, `Channel`, `ModCod`, `LinkBudget`, `PropagationLosses`, `fspl`, `freq_overlap` |

--- a/crates/lox-space/examples/sentinel_visibility.rs
+++ b/crates/lox-space/examples/sentinel_visibility.rs
@@ -17,9 +17,10 @@ use lox_space::analysis::assets::{GroundStation, Scenario, Spacecraft};
 use lox_space::analysis::visibility::{ElevationMask, VisibilityAnalysis, VisibilityResults};
 use lox_space::bodies::Origin;
 use lox_space::core::coords::LonLatAlt;
+use lox_space::core::units::Angle;
 use lox_space::frames::Frame;
 use lox_space::frames::providers::DefaultRotationProvider;
-use lox_space::orbits::ground::GroundLocation;
+use lox_space::orbits::ground::EllipsoidLocation;
 use lox_space::orbits::propagators::OrbitSource;
 use lox_space::orbits::propagators::sgp4::{Elements, Sgp4};
 use lox_space::time::deltas::TimeDelta;
@@ -95,21 +96,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     let interval = TimeInterval::new(t0, t1).into_dynamic();
 
     // 2. Build ground stations.
-    let mask = ElevationMask::with_fixed_elevation(ELEVATION_MASK_DEG.to_radians());
+    let mask = ElevationMask::with_fixed_elevation(Angle::degrees(ELEVATION_MASK_DEG));
     let stations = vec![
         GroundStation::new(
             "svalbard",
-            GroundLocation::try_new(
+            EllipsoidLocation::try_new(
                 LonLatAlt::from_degrees(15.4078, 78.2297, 450.0)?,
-                Origin::Earth,
+                Frame::Iau(Origin::Earth),
             )?,
             mask.clone(),
         ),
         GroundStation::new(
             "maspalomas",
-            GroundLocation::try_new(
+            EllipsoidLocation::try_new(
                 LonLatAlt::from_degrees(-15.6336, 27.7629, 205.0)?,
-                Origin::Earth,
+                Frame::Iau(Origin::Earth),
             )?,
             mask,
         ),

--- a/crates/lox-space/src/analysis/python.rs
+++ b/crates/lox-space/src/analysis/python.rs
@@ -28,8 +28,8 @@ use crate::ephem::spk::parser::Spk;
 use crate::frames::python::PyFrame;
 use crate::orbits::ground::Observables;
 use crate::orbits::python::{
-    PyGroundLocation, PyJ2Propagator, PyJ4Propagator, PyNumericalPropagator, PySgp4, PyTrajectory,
-    PyVallado,
+    PyEllipsoidLocation, PyJ2Propagator, PyJ4Propagator, PyNumericalPropagator, PySgp4,
+    PyTrajectory, PyVallado,
 };
 use crate::time::deltas::TimeDelta;
 use crate::time::python::deltas::PyTimeDelta;
@@ -43,7 +43,7 @@ use lox_orbits::orbits::Ensemble;
 use lox_orbits::propagators::OrbitSource;
 use lox_time::intervals::TimeInterval;
 use lox_time::series::TimeSeries;
-use lox_units::{Angle, Distance, Velocity};
+use lox_units::Distance;
 
 use numpy::{PyArray1, PyArrayMethods};
 use pyo3::exceptions::PyValueError;
@@ -132,20 +132,16 @@ pub struct PyGroundStation(pub GroundStation);
 #[pymethods]
 impl PyGroundStation {
     #[new]
-    #[pyo3(signature = (id, location, mask, body_fixed_frame=None, network_id=None, tx_terminals=None, rx_terminals=None))]
+    #[pyo3(signature = (id, location, mask, network_id=None, tx_terminals=None, rx_terminals=None))]
     fn new(
         id: String,
-        location: PyGroundLocation,
+        location: PyEllipsoidLocation,
         mask: PyElevationMask,
-        body_fixed_frame: Option<PyFrame>,
         network_id: Option<String>,
         tx_terminals: Option<HashMap<String, Bound<'_, PyAny>>>,
         rx_terminals: Option<HashMap<String, Bound<'_, PyAny>>>,
     ) -> PyResult<Self> {
         let mut gs = GroundStation::new(id, location.0, mask.0);
-        if let Some(frame) = body_fixed_frame {
-            gs = gs.with_body_fixed_frame(frame.0);
-        }
         if let Some(nid) = network_id {
             gs = gs.with_network_id(nid);
         }
@@ -164,8 +160,8 @@ impl PyGroundStation {
     }
 
     /// Return the ground location.
-    fn location(&self) -> PyGroundLocation {
-        PyGroundLocation(self.0.location().clone())
+    fn location(&self) -> PyEllipsoidLocation {
+        PyEllipsoidLocation(self.0.location().clone())
     }
 
     /// Return the elevation mask.
@@ -176,11 +172,6 @@ impl PyGroundStation {
     /// Return the network identifier, if assigned.
     fn network_id(&self) -> Option<String> {
         self.0.network_id().map(|id| id.as_str().to_string())
-    }
-
-    /// Return the body-fixed frame.
-    fn body_fixed_frame(&self) -> PyFrame {
-        PyFrame(self.0.body_fixed_frame())
     }
 
     /// Return the named transmit terminals as a dict.
@@ -859,7 +850,6 @@ impl PyVisibilityResults {
                         gs.mask(),
                         &dynamic_traj,
                         self.step,
-                        gs.body_fixed_frame(),
                     )
                     .map_err(|e| PyValueError::new_err(e.to_string()))?;
                 Ok(passes.into_iter().map(PyPass).collect())
@@ -904,7 +894,6 @@ impl PyVisibilityResults {
                             gs.location(),
                             gs.mask(),
                             &dynamic_traj,
-                            gs.body_fixed_frame(),
                         )
                     })
                     .map(PyPass)
@@ -993,7 +982,7 @@ impl PyElevationMask {
     ) -> PyResult<Self> {
         if let Some(min_elevation) = min_elevation {
             return Ok(PyElevationMask(ElevationMask::with_fixed_elevation(
-                min_elevation.0.to_radians(),
+                min_elevation.0,
             )));
         }
         if let (Some(azimuth), Some(elevation)) = (azimuth, elevation) {
@@ -1017,9 +1006,7 @@ impl PyElevationMask {
     ///     ElevationMask with fixed minimum elevation.
     #[classmethod]
     fn fixed(_cls: &Bound<'_, PyType>, min_elevation: PyAngle) -> Self {
-        PyElevationMask(ElevationMask::with_fixed_elevation(
-            min_elevation.0.to_radians(),
-        ))
+        PyElevationMask(ElevationMask::with_fixed_elevation(min_elevation.0))
     }
 
     /// Create a variable elevation mask from azimuth-dependent data.
@@ -1066,7 +1053,7 @@ impl PyElevationMask {
     /// Return the fixed elevation value (for fixed masks only).
     fn fixed_elevation(&self) -> Option<PyAngle> {
         match &self.0 {
-            ElevationMask::Fixed(min_elevation) => Some(PyAngle(Angle::radians(*min_elevation))),
+            ElevationMask::Fixed(min_elevation) => Some(PyAngle(*min_elevation)),
             ElevationMask::Variable(_) => None,
         }
     }
@@ -1079,7 +1066,7 @@ impl PyElevationMask {
     /// Returns:
     ///     Minimum elevation as Angle.
     fn min_elevation(&self, azimuth: PyAngle) -> PyAngle {
-        PyAngle(Angle::radians(self.0.min_elevation(azimuth.0.to_radians())))
+        PyAngle(self.0.min_elevation(azimuth.0))
     }
 
     fn __repr__(&self) -> String {
@@ -1087,7 +1074,7 @@ impl PyElevationMask {
             ElevationMask::Fixed(min_elevation) => {
                 format!(
                     "ElevationMask(min_elevation={})",
-                    PyAngle(Angle::radians(*min_elevation)).__repr__(),
+                    PyAngle(*min_elevation).__repr__(),
                 )
             }
             ElevationMask::Variable(series) => {
@@ -1122,31 +1109,31 @@ impl PyObservables {
         range_rate: PyVelocity,
     ) -> Self {
         PyObservables(Observables::new(
-            azimuth.0.to_radians(),
-            elevation.0.to_radians(),
-            range.0.to_meters(),
-            range_rate.0.to_meters_per_second(),
+            azimuth.0,
+            elevation.0,
+            range.0,
+            range_rate.0,
         ))
     }
 
     /// Return the azimuth angle.
     fn azimuth(&self) -> PyAngle {
-        PyAngle(Angle::radians(self.0.azimuth()))
+        PyAngle(self.0.azimuth())
     }
 
     /// Return the elevation angle.
     fn elevation(&self) -> PyAngle {
-        PyAngle(Angle::radians(self.0.elevation()))
+        PyAngle(self.0.elevation())
     }
 
     /// Return the range (distance).
     fn range(&self) -> PyDistance {
-        PyDistance(Distance::meters(self.0.range()))
+        PyDistance(self.0.range())
     }
 
     /// Return the range rate.
     fn range_rate(&self) -> PyVelocity {
-        PyVelocity(Velocity::meters_per_second(self.0.range_rate()))
+        PyVelocity(self.0.range_rate())
     }
 
     fn __repr__(&self) -> String {

--- a/crates/lox-space/src/orbits/python.rs
+++ b/crates/lox-space/src/orbits/python.rs
@@ -9,7 +9,7 @@ use crate::earth::python::ut1::{PyEopProvider, PyEopProviderError};
 use crate::ephem::python::{PyDafSpkError, PySpk};
 use crate::frames::Frame;
 use crate::frames::python::{PyFrame, PyRotationError};
-use crate::orbits::ground::{GroundLocation, GroundPropagator, GroundPropagatorError, Observables};
+use crate::orbits::ground::{EllipsoidLocation, GroundPropagator, GroundPropagatorError};
 use crate::orbits::propagators::Propagator;
 use crate::orbits::propagators::j2::J2Propagator;
 use crate::orbits::propagators::j4::J4Propagator;
@@ -23,7 +23,7 @@ use crate::time::python::deltas::PyTimeDelta;
 use crate::time::python::time::PyTime;
 use crate::time::time_scales::Tai;
 use crate::units::python::{PyAngle, PyDistance, PyVelocity};
-use lox_core::coords::{Cartesian, LonLatAlt};
+use lox_core::coords::{Cartesian, Ellipsoid, LonLatAlt};
 use lox_core::glam::DVec3;
 use lox_frames::providers::DefaultRotationProvider;
 use lox_frames::rotations::TryRotation;
@@ -343,19 +343,19 @@ impl PyCartesian {
         Ok(PyArray2::from_vec2(py, &rot)?)
     }
 
-    /// Convert this state to a ground location.
+    /// Convert this state to a location on a reference ellipsoid.
     ///
     /// This is useful for converting a state in a body-fixed frame to geodetic coordinates.
     ///
     /// Returns:
-    ///     GroundLocation with longitude, latitude, and altitude.
+    ///     EllipsoidLocation with longitude, latitude, and altitude.
     ///
     /// Raises:
     ///     ValueError: If conversion fails.
-    fn to_ground_location(&self) -> PyResult<PyGroundLocation> {
-        Ok(PyGroundLocation(
+    fn to_ellipsoid_location(&self) -> PyResult<PyEllipsoidLocation> {
+        Ok(PyEllipsoidLocation(
             self.0
-                .try_to_ground_location()
+                .try_to_ellipsoid_location()
                 .map_err(|err| PyValueError::new_err(err.to_string()))?,
         ))
     }
@@ -1560,40 +1560,136 @@ impl PyJ4Propagator {
     }
 }
 
-/// Represents a location on the surface of a celestial body.
-///
-/// Ground locations are specified using geodetic coordinates (longitude, latitude,
-/// altitude) relative to a central body's reference ellipsoid.
+/// A reference ellipsoid, defined by its equatorial radius and flattening.
 ///
 /// Args:
-///     origin: The central body (e.g., Earth, Moon).
+///     equatorial_radius: Semi-major axis as Distance.
+///     flattening: Flattening factor in [0, 1).
+///
+/// Examples:
+///     >>> lox.Ellipsoid.WGS84
+///     >>> lox.Ellipsoid(6378137.0 * lox.m, 1 / 298.257223563)
+#[pyclass(name = "Ellipsoid", module = "lox_space", frozen, from_py_object)]
+#[derive(Clone, Copy, Debug)]
+pub struct PyEllipsoid(pub Ellipsoid);
+
+#[pymethods]
+impl PyEllipsoid {
+    #[new]
+    fn new(equatorial_radius: PyDistance, flattening: f64) -> PyResult<Self> {
+        Ok(PyEllipsoid(
+            Ellipsoid::try_new(equatorial_radius.0, flattening)
+                .map_err(|e| PyValueError::new_err(e.to_string()))?,
+        ))
+    }
+
+    /// The WGS84 reference ellipsoid.
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn WGS84() -> Self {
+        PyEllipsoid(Ellipsoid::WGS84)
+    }
+
+    /// The GRS80 reference ellipsoid.
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn GRS80() -> Self {
+        PyEllipsoid(Ellipsoid::GRS80)
+    }
+
+    /// The WGS72 reference ellipsoid.
+    #[classattr]
+    #[allow(non_snake_case)]
+    fn WGS72() -> Self {
+        PyEllipsoid(Ellipsoid::WGS72)
+    }
+
+    /// Return the equatorial radius.
+    fn equatorial_radius(&self) -> PyDistance {
+        PyDistance(self.0.equatorial_radius())
+    }
+
+    /// Return the flattening factor.
+    fn flattening(&self) -> f64 {
+        self.0.flattening()
+    }
+
+    /// Return true if both ellipsoids have the same radius and flattening.
+    fn __eq__(&self, other: &PyEllipsoid) -> bool {
+        self.0 == other.0
+    }
+
+    /// Return the constructor arguments for pickling.
+    fn __getnewargs__(&self) -> (PyDistance, f64) {
+        (self.equatorial_radius(), self.flattening())
+    }
+
+    /// Return the developer-facing string representation of this ellipsoid.
+    fn __repr__(&self) -> String {
+        format!(
+            "Ellipsoid({}, {})",
+            self.equatorial_radius().__repr__(),
+            repr_f64(self.flattening()),
+        )
+    }
+}
+
+/// Represents a location on the surface of a celestial body.
+///
+/// Locations are specified using geodetic coordinates (longitude, latitude,
+/// altitude) relative to a reference ellipsoid, in a body-fixed frame.
+///
+/// Args:
+///     frame: Body-fixed frame as Frame or str (e.g. "IAU_EARTH", "ITRF").
 ///     longitude: Geodetic longitude as Angle.
 ///     latitude: Geodetic latitude as Angle.
 ///     altitude: Altitude above the reference ellipsoid as Distance.
-#[pyclass(name = "GroundLocation", module = "lox_space", frozen, from_py_object)]
+///     ellipsoid: Reference ellipsoid, overriding the one conventionally
+///         paired with the frame.
+///
+/// Examples:
+///     >>> darmstadt = lox.EllipsoidLocation(
+///     ...     "IAU_EARTH",
+///     ...     longitude=8.6512 * lox.deg,
+///     ...     latitude=49.8728 * lox.deg,
+///     ...     altitude=0.108 * lox.km,
+///     ... )
+#[pyclass(
+    name = "EllipsoidLocation",
+    module = "lox_space",
+    frozen,
+    from_py_object
+)]
 #[derive(Clone, Debug)]
-pub struct PyGroundLocation(pub GroundLocation);
+pub struct PyEllipsoidLocation(pub EllipsoidLocation);
 
 #[pymethods]
-impl PyGroundLocation {
+impl PyEllipsoidLocation {
     #[new]
+    #[pyo3(signature = (frame, longitude, latitude, altitude, ellipsoid=None))]
     fn new(
-        origin: &Bound<'_, PyAny>,
+        frame: &Bound<'_, PyAny>,
         longitude: PyAngle,
         latitude: PyAngle,
         altitude: PyDistance,
+        ellipsoid: Option<PyEllipsoid>,
     ) -> PyResult<Self> {
-        let origin: PyOrigin = origin.try_into()?;
+        let frame: PyFrame = frame.try_into()?;
         let coordinates = LonLatAlt::builder()
             .longitude(longitude.0)
             .latitude(latitude.0)
             .altitude(altitude.0)
             .build()
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
-        Ok(PyGroundLocation(
-            GroundLocation::try_new(coordinates, origin.0)
-                .map_err(PyUndefinedOriginPropertyError)?,
-        ))
+        let location = match ellipsoid {
+            Some(ellipsoid) => {
+                EllipsoidLocation::try_with_ellipsoid(coordinates, ellipsoid.0, frame.0)
+                    .map_err(|e| PyValueError::new_err(e.to_string()))?
+            }
+            None => EllipsoidLocation::try_new(coordinates, frame.0)
+                .map_err(|e| PyValueError::new_err(e.to_string()))?,
+        };
+        Ok(PyEllipsoidLocation(location))
     }
 
     /// Compute observables (azimuth, elevation, range, range rate) to a target.
@@ -1617,16 +1713,7 @@ impl PyGroundLocation {
             .transpose()?
             .unwrap_or(PyFrame(Frame::Iau(state.0.origin())));
         let state = state.to_frame_inner(frame, provider)?;
-        let rot = self.0.rotation_to_topocentric();
-        let position = rot * (state.0.position() - self.0.body_fixed_position());
-        let velocity = rot * state.0.velocity();
-        let range = position.length();
-        let range_rate = position.dot(velocity) / range;
-        let elevation = (position.z / range).asin();
-        let azimuth = position.y.atan2(-position.x);
-        Ok(PyObservables(Observables::new(
-            azimuth, elevation, range, range_rate,
-        )))
+        Ok(PyObservables(self.0.observables(state.0)))
     }
 
     /// Return the rotation matrix from body-fixed to topocentric frame.
@@ -1641,17 +1728,17 @@ impl PyGroundLocation {
 
     /// Return the geodetic longitude.
     fn longitude(&self) -> PyAngle {
-        PyAngle(Angle::radians(self.0.longitude()))
+        PyAngle(self.0.longitude())
     }
 
     /// Return the geodetic latitude.
     fn latitude(&self) -> PyAngle {
-        PyAngle(Angle::radians(self.0.latitude()))
+        PyAngle(self.0.latitude())
     }
 
     /// Return the altitude above the reference ellipsoid.
     fn altitude(&self) -> PyDistance {
-        PyDistance(Distance::kilometers(self.0.altitude()))
+        PyDistance(self.0.altitude())
     }
 
     /// Return the central body (origin).
@@ -1659,14 +1746,36 @@ impl PyGroundLocation {
         PyOrigin(self.0.origin())
     }
 
-    /// Return the developer-facing string representation of this ground location.
+    /// Return the body-fixed frame the coordinates are referenced to.
+    fn frame(&self) -> PyFrame {
+        PyFrame(self.0.frame())
+    }
+
+    /// Return the reference ellipsoid the coordinates are referenced to.
+    fn ellipsoid(&self) -> PyEllipsoid {
+        PyEllipsoid(self.0.ellipsoid())
+    }
+
+    /// Return the geodetic coordinates as a (longitude, latitude, altitude) tuple.
+    fn coordinates(&self) -> (PyAngle, PyAngle, PyDistance) {
+        (self.longitude(), self.latitude(), self.altitude())
+    }
+
+    /// Return the body-fixed Cartesian position as a numpy array in m.
+    fn body_fixed_position<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        let pos = self.0.body_fixed_position();
+        PyArray1::from_slice(py, &[pos.x, pos.y, pos.z])
+    }
+
+    /// Return the developer-facing string representation of this location.
     pub fn __repr__(&self) -> String {
         format!(
-            "GroundLocation({}, {}, {}, {})",
-            PyOrigin(self.0.origin()).__repr__(),
+            "EllipsoidLocation({}, {}, {}, {}, {})",
+            self.frame().__repr__(),
             self.longitude().__repr__(),
             self.latitude().__repr__(),
             self.altitude().__repr__(),
+            self.ellipsoid().__repr__(),
         )
     }
 }
@@ -1693,8 +1802,8 @@ impl From<PyGroundPropagatorError> for PyErr {
 #[pymethods]
 impl PyGroundPropagator {
     #[new]
-    fn new(location: PyGroundLocation) -> Self {
-        PyGroundPropagator(GroundPropagator::new_dynamic(location.0))
+    fn new(location: PyEllipsoidLocation) -> Self {
+        PyGroundPropagator(GroundPropagator::new(location.0))
     }
 
     /// Propagate the ground station.
@@ -1738,7 +1847,7 @@ impl PyGroundPropagator {
     }
 
     fn __repr__(&self) -> String {
-        let loc = PyGroundLocation(self.0.location().clone());
+        let loc = PyEllipsoidLocation(self.0.location().clone());
         format!("GroundPropagator({})", loc.__repr__())
     }
 }

--- a/crates/lox-space/src/prelude.rs
+++ b/crates/lox-space/src/prelude.rs
@@ -38,7 +38,7 @@ pub use crate::frames::{Frame, Icrf, Itrf};
 pub use crate::earth::eop::{EopParser, EopProvider};
 
 // Ground
-pub use crate::orbits::ground::GroundLocation;
+pub use crate::orbits::ground::EllipsoidLocation;
 
 // Analysis
 pub use crate::analysis::assets::{GroundStation, Scenario, Spacecraft};

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -27,8 +27,9 @@ use crate::itur::python::PyItuProvider;
 use crate::itur::python::register_itur_functions;
 use crate::math::python::PySeries;
 use crate::orbits::python::{
-    PyCartesian, PyGroundLocation, PyGroundPropagator, PyJ2Propagator, PyJ4Propagator, PyKeplerian,
-    PyModifiedEquinoctial, PyNumericalPropagator, PySgp4, PyTle, PyTrajectory, PyVallado,
+    PyCartesian, PyEllipsoid, PyEllipsoidLocation, PyGroundPropagator, PyJ2Propagator,
+    PyJ4Propagator, PyKeplerian, PyModifiedEquinoctial, PyNumericalPropagator, PySgp4, PyTle,
+    PyTrajectory, PyVallado,
 };
 use crate::time::python::{
     deltas::PyTimeDelta,
@@ -133,8 +134,9 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // orbits
     m.add_class::<PyCartesian>()?;
+    m.add_class::<PyEllipsoid>()?;
     m.add_class::<PyEvent>()?;
-    m.add_class::<PyGroundLocation>()?;
+    m.add_class::<PyEllipsoidLocation>()?;
     m.add_class::<PyGroundPropagator>()?;
     m.add_class::<PyInterval>()?;
     m.add_class::<PyJ2Propagator>()?;

--- a/crates/lox-space/tests/conftest.py
+++ b/crates/lox-space/tests/conftest.py
@@ -51,8 +51,8 @@ def estrack():
     return [
         lox.GroundStation(
             name,
-            lox.GroundLocation(
-                lox.Origin("Earth"), lon * lox.deg, lat * lox.deg, 0 * lox.km
+            lox.EllipsoidLocation(
+                "IAU_EARTH", lon * lox.deg, lat * lox.deg, 0 * lox.km
             ),
             lox.ElevationMask.fixed(0 * lox.rad),
         )

--- a/crates/lox-space/tests/serde.rs
+++ b/crates/lox-space/tests/serde.rs
@@ -13,7 +13,7 @@ use lox_space::frames::Teme;
 use lox_space::frames::rotations::Rotation;
 use lox_space::frames::*;
 use lox_space::orbits::CartesianOrbit;
-use lox_space::orbits::ground::GroundLocation;
+use lox_space::orbits::ground::EllipsoidLocation;
 use lox_space::time::Time;
 use lox_space::time::intervals::TimeInterval;
 use lox_space::time::time_scales::Tai;
@@ -373,9 +373,24 @@ fn test_state() {
 
 #[test]
 fn test_ground_location() {
-    let loc = GroundLocation::new(LonLatAlt::default(), Earth);
+    let loc = EllipsoidLocation::new(LonLatAlt::default(), Iau::new(Earth));
     let json = serde_json::to_string(&loc).expect("serialize");
-    let _: GroundLocation<Earth> = serde_json::from_str(&json).expect("deserialize");
+    let _: EllipsoidLocation<Iau<Earth>> = serde_json::from_str(&json).expect("deserialize");
+}
+
+#[test]
+fn test_ground_location_deserialize_rejects_non_body_fixed_frame() {
+    // `EllipsoidLocation::origin` relies on the frame being body-fixed, so
+    // deserialization must enforce the same invariant as the constructors.
+    let loc = EllipsoidLocation::try_new(LonLatAlt::default(), Frame::Iau(Origin::Earth))
+        .expect("construct");
+    let mut value = serde_json::to_value(&loc).expect("serialize");
+    value["frame"] = serde_json::to_value(Frame::Icrf).expect("serialize frame");
+
+    let err = serde_json::from_value::<EllipsoidLocation>(value)
+        .expect_err("ICRF must not deserialize into a location")
+        .to_string();
+    assert!(err.contains("body-fixed"), "unexpected error: {err}");
 }
 
 #[test]
@@ -670,7 +685,39 @@ fn test_network_id() {
 #[test]
 fn test_elevation_mask_fixed() {
     use lox_space::analysis::visibility::ElevationMask;
-    round_trip(&ElevationMask::with_fixed_elevation(0.1));
+    round_trip(&ElevationMask::with_fixed_elevation(Angle::radians(0.1)));
+}
+
+#[test]
+fn test_unit_types_serialize_transparently() {
+    // `Angle`, `Distance` and `Velocity` are newtypes over f64, so making the
+    // accessors unitful must not change the wire format of anything that
+    // stores them. Guards previously-written scenario files.
+    use lox_orbits::ground::Observables;
+    use lox_space::analysis::visibility::ElevationMask;
+    use lox_units::{Distance, Velocity};
+
+    let mask = ElevationMask::with_fixed_elevation(Angle::radians(0.1));
+    assert_eq!(
+        serde_json::to_value(&mask).unwrap(),
+        serde_json::json!({ "Fixed": 0.1 })
+    );
+
+    let obs = Observables::new(
+        Angle::radians(1.0),
+        Angle::radians(0.5),
+        Distance::meters(2000.0),
+        Velocity::meters_per_second(-7.0),
+    );
+    assert_eq!(
+        serde_json::to_value(&obs).unwrap(),
+        serde_json::json!({
+            "azimuth": 1.0,
+            "elevation": 0.5,
+            "range": 2000.0,
+            "range_rate": -7.0,
+        })
+    );
 }
 
 #[test]
@@ -733,11 +780,11 @@ fn test_access_window() {
 fn test_ground_station() {
     use lox_space::analysis::assets::GroundStation;
     use lox_space::analysis::visibility::ElevationMask;
-    use lox_space::orbits::ground::GroundLocation;
+    use lox_space::orbits::ground::EllipsoidLocation;
 
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-    let loc = GroundLocation::try_new(coords, Origin::Earth).unwrap();
-    let mask = ElevationMask::with_fixed_elevation(5.0);
+    let loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+    let mask = ElevationMask::with_fixed_elevation(Angle::degrees(5.0));
     let gs = GroundStation::new("madrid", loc, mask).with_network_id("estrack");
     round_trip_no_eq(&gs);
 }
@@ -789,15 +836,19 @@ fn test_scenario() {
     use lox_space::analysis::assets::{GroundStation, Scenario, Spacecraft};
     use lox_space::analysis::visibility::ElevationMask;
     use lox_space::orbits::Trajectory;
-    use lox_space::orbits::ground::GroundLocation;
+    use lox_space::orbits::ground::EllipsoidLocation;
     use lox_space::orbits::propagators::OrbitSource;
 
     let t0 = Time::new(TimeScale::Tai, 0, Default::default());
     let t1 = Time::new(TimeScale::Tai, 86400, Default::default());
 
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
-    let loc = GroundLocation::try_new(coords, Origin::Earth).unwrap();
-    let gs = GroundStation::new("madrid", loc, ElevationMask::with_fixed_elevation(5.0));
+    let loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
+    let gs = GroundStation::new(
+        "madrid",
+        loc,
+        ElevationMask::with_fixed_elevation(Angle::degrees(5.0)),
+    );
 
     let traj = Trajectory::from_csv_dynamic(
         &lox_test_utils::read_data_file("trajectory_lunar.csv"),

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -1528,8 +1528,8 @@ def test_gt_model_accessors():
 
 def test_ground_station_terminals():
     rx = lox.GtModel(KA_BAND, 30.0 * lox.dB)
-    location = lox.GroundLocation(
-        lox.Origin("Earth"), 13.4 * lox.deg, 52.5 * lox.deg, 0.1 * lox.km
+    location = lox.EllipsoidLocation(
+        "IAU_EARTH", 13.4 * lox.deg, 52.5 * lox.deg, 0.1 * lox.km
     )
     mask = lox.ElevationMask.fixed(5.0 * lox.deg)
     gs = lox.GroundStation("berlin", location, mask, rx_terminals={"ka": rx})
@@ -1542,8 +1542,8 @@ def test_ground_station_terminals():
 
 def test_asset_terminals_round_trip_both_tiers():
     # Component chains and lumped models survive the asset dict round trip.
-    location = lox.GroundLocation(
-        lox.Origin("Earth"), 13.4 * lox.deg, 52.5 * lox.deg, 0.1 * lox.km
+    location = lox.EllipsoidLocation(
+        "IAU_EARTH", 13.4 * lox.deg, 52.5 * lox.deg, 0.1 * lox.km
     )
     mask = lox.ElevationMask.fixed(5.0 * lox.deg)
     tx_terminals = {"hga": make_tx(), "beacon": lox.EirpModel(KA_BAND, 40.0 * lox.dB)}

--- a/crates/lox-space/tests/test_ground.py
+++ b/crates/lox-space/tests/test_ground.py
@@ -8,8 +8,8 @@ import pytest
 
 
 def test_observables():
-    location = lox.GroundLocation(
-        lox.Origin("Earth"), -4 * lox.deg, 41 * lox.deg, 0 * lox.km
+    location = lox.EllipsoidLocation(
+        "IAU_EARTH", -4 * lox.deg, 41 * lox.deg, 0 * lox.km
     )
     time = lox.Time("TDB", 2012, 7, 1)
     state = lox.Cartesian(
@@ -34,26 +34,105 @@ def test_observables():
 
 
 def test_ground_location_repr():
-    location = lox.GroundLocation(
-        lox.Origin("Earth"), -4 * lox.deg, 41 * lox.deg, 0 * lox.km
+    location = lox.EllipsoidLocation(
+        "IAU_EARTH", -4 * lox.deg, 41 * lox.deg, 0 * lox.km
     )
     r = repr(location)
-    assert r.startswith("GroundLocation(")
-    assert "Origin(" in r
+    assert r.startswith("EllipsoidLocation(")
+    assert "Frame(" in r
     assert "Angle(" in r
     assert "Distance(" in r
+    assert "Ellipsoid(" in r
 
 
 def test_ground_location_origin():
-    location = lox.GroundLocation(
-        lox.Origin("Earth"), 0 * lox.deg, 0 * lox.deg, 0 * lox.km
+    location = lox.EllipsoidLocation(
+        lox.Frame("IAU_EARTH"), 0 * lox.deg, 0 * lox.deg, 0 * lox.km
     )
     assert location.origin().name() == "Earth"
 
 
-def test_ground_location_string_origin():
-    location = lox.GroundLocation("Earth", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+def test_ground_location_string_frame():
+    location = lox.EllipsoidLocation("IAU_EARTH", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+    assert repr(location.frame()) == 'Frame("IAU_EARTH")'
     assert location.origin().name() == "Earth"
+
+
+def test_ground_location_terrestrial_frame():
+    """Any body-fixed frame works, not just IAU ones."""
+    location = lox.EllipsoidLocation("ITRF", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+    assert repr(location.frame()) == 'Frame("ITRF")'
+    assert location.origin().name() == "Earth"
+    assert location.ellipsoid() == lox.Ellipsoid.GRS80
+
+
+def test_ground_location_rejects_non_body_fixed_frame():
+    with pytest.raises(ValueError, match="body-fixed"):
+        lox.EllipsoidLocation("ICRF", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+
+
+def test_ground_location_default_ellipsoid():
+    """An IAU frame defaults to its body's own spheroid."""
+    location = lox.EllipsoidLocation("IAU_EARTH", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+    assert location.ellipsoid() != lox.Ellipsoid.WGS84
+
+
+def test_ground_location_ellipsoid_override():
+    """The frame's conventional ellipsoid is a default, not a constraint."""
+    default = lox.EllipsoidLocation("IAU_EARTH", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+    overridden = lox.EllipsoidLocation(
+        "IAU_EARTH",
+        0 * lox.deg,
+        0 * lox.deg,
+        0 * lox.km,
+        ellipsoid=lox.Ellipsoid.WGS84,
+    )
+    assert overridden.ellipsoid() == lox.Ellipsoid.WGS84
+    assert overridden.ellipsoid() != default.ellipsoid()
+
+
+def test_ground_location_coordinates():
+    location = lox.EllipsoidLocation(
+        "IAU_EARTH", -4 * lox.deg, 41 * lox.deg, 0.1 * lox.km
+    )
+    lon, lat, alt = location.coordinates()
+    assert lon == location.longitude()
+    assert lat == location.latitude()
+    assert alt == location.altitude()
+
+
+def test_ground_location_body_fixed_position():
+    location = lox.EllipsoidLocation("IAU_EARTH", 0 * lox.deg, 0 * lox.deg, 0 * lox.km)
+    pos = location.body_fixed_position()
+    assert pos.shape == (3,)
+    # On the equator at the prime meridian, the position is along +x.
+    assert pos[0] == pytest.approx(
+        location.ellipsoid().equatorial_radius().to_meters()
+    )
+    assert pos[1] == pytest.approx(0.0)
+    assert pos[2] == pytest.approx(0.0)
+
+
+def test_ellipsoid_constants():
+    assert lox.Ellipsoid.WGS84.equatorial_radius().to_meters() == pytest.approx(
+        6378137.0
+    )
+    assert lox.Ellipsoid.WGS84.flattening() == pytest.approx(1 / 298.257223563)
+    assert lox.Ellipsoid.GRS80.equatorial_radius().to_meters() == pytest.approx(
+        6378137.0
+    )
+    assert lox.Ellipsoid.WGS84 != lox.Ellipsoid.GRS80
+
+
+def test_ellipsoid_construction():
+    ellipsoid = lox.Ellipsoid(6378137.0 * lox.m, 1 / 298.257223563)
+    assert ellipsoid == lox.Ellipsoid.WGS84
+    assert repr(ellipsoid).startswith("Ellipsoid(")
+
+
+def test_ellipsoid_rejects_invalid_flattening():
+    with pytest.raises(ValueError, match="flattening"):
+        lox.Ellipsoid(6378137.0 * lox.m, 1.5)
 
 
 def test_elevation_mask():

--- a/crates/lox-space/tests/test_oneweb_europe_benchmark.py
+++ b/crates/lox-space/tests/test_oneweb_europe_benchmark.py
@@ -44,7 +44,7 @@ def create_europe_ground_assets(resolution_deg=1.0, min_elevation_deg=10.0):
     lats = np.arange(lat_min, lat_max + resolution_deg, resolution_deg)
 
     elevation_mask = lox.ElevationMask.fixed(min_elevation_deg * lox.deg)
-    origin = lox.Origin("Earth")
+    frame = lox.Frame("IAU_EARTH")
 
     ground_assets = []
     point_count = 0
@@ -53,8 +53,8 @@ def create_europe_ground_assets(resolution_deg=1.0, min_elevation_deg=10.0):
             # Filter to approximate Europe shape (rough filtering)
             if is_point_in_europe(lon, lat):
                 gs_name = f"EU_GS_{point_count:04d}"
-                ground_location = lox.GroundLocation(
-                    origin=origin,
+                ground_location = lox.EllipsoidLocation(
+                    frame=frame,
                     longitude=lon * lox.deg,
                     latitude=lat * lox.deg,
                     altitude=0.0 * lox.km,  # Sea level

--- a/crates/lox-space/tests/test_propagators.py
+++ b/crates/lox-space/tests/test_propagators.py
@@ -233,8 +233,8 @@ def test_j2_repr():
 
 def test_ground(provider):
     tai = lox.UTC.from_iso("2022-01-31T23:00:00").to_scale("TAI")
-    loc = lox.GroundLocation(
-        lox.Origin("Earth"), -4.3676 * lox.deg, 40.4527 * lox.deg, 0.0 * lox.km
+    loc = lox.EllipsoidLocation(
+        "IAU_EARTH", -4.3676 * lox.deg, 40.4527 * lox.deg, 0.0 * lox.km
     )
     ground = lox.GroundPropagator(loc)
     # GroundPropagator now returns body-fixed (IAU) states; transform to ICRF

--- a/crates/lox-space/tests/test_states.py
+++ b/crates/lox-space/tests/test_states.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pytest
 
 
-def test_state_to_ground_location():
+def test_state_to_ellipsoid_location():
     time = lox.UTC.from_iso("2024-07-05T09:09:18.173").to_scale("TAI")
     state = lox.Cartesian(
         time,
@@ -24,7 +24,7 @@ def test_state_to_ground_location():
         state.velocity() * 1e-3,
         [-3.53237875783652, -3.152377656863808, 5.642296713889555],
     )
-    ground = state.to_ground_location()
+    ground = state.to_ellipsoid_location()
     assert float(ground.longitude()) == pytest.approx(2.643578045424445)
     assert float(ground.latitude()) == pytest.approx(-0.27944957125091063)
     assert ground.altitude().to_kilometers() == pytest.approx(417.8524151150059)

--- a/crates/lox-space/tests/test_visibility.py
+++ b/crates/lox-space/tests/test_visibility.py
@@ -593,32 +593,19 @@ class TestAssets:
     def test_ground_station_location(self, ground_assets):
         for ga in ground_assets:
             loc = ga.location()
-            assert isinstance(loc, lox.GroundLocation)
+            assert isinstance(loc, lox.EllipsoidLocation)
 
     def test_ground_station_mask(self, ground_assets):
         for ga in ground_assets:
             mask = ga.mask()
             assert isinstance(mask, lox.ElevationMask)
 
-    def test_ground_station_body_fixed_frame_default(self, ground_assets):
-        """Default body-fixed frame should be IAU_EARTH."""
+    def test_ground_station_body_fixed_frame(self, ground_assets):
+        """A station's body-fixed frame comes from its location, not the station."""
         ga = ground_assets[0]
-        frame = ga.body_fixed_frame()
+        frame = ga.location().frame()
         assert isinstance(frame, lox.Frame)
         assert repr(frame) == 'Frame("IAU_EARTH")'
-
-    def test_ground_station_body_fixed_frame_custom(self):
-        """Custom body-fixed frame should be preserved."""
-        loc = lox.GroundLocation(
-            origin=lox.Origin("Earth"),
-            longitude=0 * lox.deg,
-            latitude=0 * lox.deg,
-            altitude=0 * lox.km,
-        )
-        mask = lox.ElevationMask.fixed(0 * lox.deg)
-        itrf = lox.Frame("ITRF")
-        gs = lox.GroundStation("test", loc, mask, body_fixed_frame=itrf)
-        assert repr(gs.body_fixed_frame()) == 'Frame("ITRF")'
 
     def test_ground_station_repr(self, ground_assets):
         r = repr(ground_assets[0])
@@ -645,8 +632,8 @@ class TestAssets:
         assert ground_assets[0].network_id() is None
 
     def test_ground_station_network_id_set(self):
-        loc = lox.GroundLocation(
-            origin=lox.Origin("Earth"),
+        loc = lox.EllipsoidLocation(
+            frame="IAU_EARTH",
             longitude=0 * lox.deg,
             latitude=0 * lox.deg,
             altitude=0 * lox.km,

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -327,9 +327,8 @@ class GroundStation:
     def __new__(
         cls,
         id: str,
-        location: GroundLocation,
+        location: EllipsoidLocation,
         mask: ElevationMask,
-        body_fixed_frame: Frame | None = None,
         network_id: str | None = None,
         tx_terminals: dict[str, TxTerminal] | None = None,
         rx_terminals: dict[str, RxTerminal] | None = None,
@@ -337,7 +336,7 @@ class GroundStation:
     def id(self) -> str:
         """Return the asset identifier."""
         ...
-    def location(self) -> GroundLocation:
+    def location(self) -> EllipsoidLocation:
         """Return the ground location."""
         ...
     def mask(self) -> ElevationMask:
@@ -345,9 +344,6 @@ class GroundStation:
         ...
     def network_id(self) -> str | None:
         """Return the network identifier, if assigned."""
-        ...
-    def body_fixed_frame(self) -> Frame:
-        """Return the body-fixed frame."""
         ...
     def tx_terminals(self) -> dict[str, TxTerminal]:
         """Return the named transmit terminals as a dict."""
@@ -1106,7 +1102,7 @@ class Cartesian:
     def rotation_lvlh(self) -> np.ndarray:
         """Compute the rotation matrix from inertial to LVLH frame."""
         ...
-    def to_ground_location(self) -> GroundLocation:
+    def to_ellipsoid_location(self) -> EllipsoidLocation:
         """Convert this state to a ground location."""
         ...
 
@@ -1621,18 +1617,44 @@ class J4:
         """Propagate the orbit to one or more times."""
         ...
 
-class GroundLocation:
+class Ellipsoid:
+    """A reference ellipsoid, defined by its equatorial radius and flattening.
+
+    Args:
+        equatorial_radius: Semi-major axis as Distance.
+        flattening: Flattening factor in [0, 1).
+
+    Examples:
+        >>> lox.Ellipsoid.WGS84
+        >>> lox.Ellipsoid(6378137.0 * lox.m, 1 / 298.257223563)
+    """
+
+    WGS84: Ellipsoid
+    GRS80: Ellipsoid
+    WGS72: Ellipsoid
+
+    def __new__(cls, equatorial_radius: Distance, flattening: float) -> Self: ...
+    def equatorial_radius(self) -> Distance:
+        """Return the equatorial radius."""
+        ...
+    def flattening(self) -> float:
+        """Return the flattening factor."""
+        ...
+
+class EllipsoidLocation:
     """Represents a location on the surface of a celestial body.
 
     Args:
-        origin: The central body (e.g., Earth, Moon).
+        frame: Body-fixed frame as Frame or str (e.g. "IAU_EARTH", "ITRF").
         longitude: Geodetic longitude as Angle.
         latitude: Geodetic latitude as Angle.
         altitude: Altitude above the reference ellipsoid as Distance.
+        ellipsoid: Reference ellipsoid, overriding the one conventionally
+            paired with the frame.
 
     Examples:
-        >>> darmstadt = lox.GroundLocation(
-        ...     lox.Origin("Earth"),
+        >>> darmstadt = lox.EllipsoidLocation(
+        ...     "IAU_EARTH",
         ...     longitude=8.6512 * lox.deg,
         ...     latitude=49.8728 * lox.deg,
         ...     altitude=0.108 * lox.km,
@@ -1640,10 +1662,11 @@ class GroundLocation:
     """
     def __new__(
         cls,
-        origin: str | int | Origin,
+        frame: str | Frame,
         longitude: Angle,
         latitude: Angle,
         altitude: Distance,
+        ellipsoid: Ellipsoid | None = None,
     ) -> Self: ...
     def longitude(self) -> Angle:
         """Return the geodetic longitude."""
@@ -1653,6 +1676,9 @@ class GroundLocation:
         ...
     def altitude(self) -> Distance:
         """Return the altitude above the reference ellipsoid."""
+        ...
+    def coordinates(self) -> tuple[Angle, Angle, Distance]:
+        """Return the geodetic coordinates as a (longitude, latitude, altitude) tuple."""
         ...
     def observables(
         self,
@@ -1665,6 +1691,15 @@ class GroundLocation:
     def origin(self) -> Origin:
         """Return the central body (origin)."""
         ...
+    def frame(self) -> Frame:
+        """Return the body-fixed frame the coordinates are referenced to."""
+        ...
+    def ellipsoid(self) -> Ellipsoid:
+        """Return the reference ellipsoid the coordinates are referenced to."""
+        ...
+    def body_fixed_position(self) -> np.ndarray:
+        """Return the body-fixed Cartesian position as a numpy array in m."""
+        ...
     def rotation_to_topocentric(self) -> np.ndarray:
         """Return the rotation matrix from body-fixed to topocentric frame."""
         ...
@@ -1676,11 +1711,11 @@ class GroundPropagator:
         location: The ground location to propagate.
 
     Examples:
-        >>> gs = lox.GroundLocation(lox.Origin("Earth"), lon, lat, alt)
+        >>> gs = lox.EllipsoidLocation("IAU_EARTH", lon, lat, alt)
         >>> prop = lox.GroundPropagator(gs)
         >>> trajectory = prop.propagate([t1, t2, t3])
     """
-    def __new__(cls, location: GroundLocation) -> Self: ...
+    def __new__(cls, location: EllipsoidLocation) -> Self: ...
     @overload
     def propagate(self, steps: Time) -> Cartesian: ...
     @overload


### PR DESCRIPTION
BREAKING CHANGE: `GroundLocation<B: TrySpheroid>` becomes
`EllipsoidLocation<R = Frame>`, parameterized on the body-fixed frame and
storing its reference ellipsoid explicitly, overridable via
`with_ellipsoid`/`try_with_ellipsoid`. `CartesianOrbit::to_ground_location`
becomes `to_ellipsoid_location`.

Scalar accessors on `EllipsoidLocation`, `Observables` and `ElevationMask`
return `Angle`/`Distance`/`Velocity` instead of raw `f64`; `altitude()`
previously returned kilometres while the rest of the crate used metres.
Bulk arrays feeding interpolation series stay `Vec<f64>` in radians. The
serde wire format is unchanged.

`Frame` now agrees with the zero-sized frame types on its capabilities:
CIRF, MOD, TOD and TEME are quasi-inertial; TIRF and PEF are body-fixed
about Earth and share ITRF's GRS80 datum.

Python: `lox.GroundLocation` becomes `lox.EllipsoidLocation` and takes a
`frame` instead of an `origin`, plus an optional `ellipsoid`. Adds
`lox.Ellipsoid` and the `frame`, `ellipsoid`, `coordinates` and
`body_fixed_position` accessors.
