### PR TITLE
chore: make lox-test-utils a path-only dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ lox-itur = { path = "crates/lox-itur", version = "0.1.0-alpha.6" }
 lox-math = { path = "crates/lox-math", version = "0.1.0-alpha.24" }
 lox-odm = { path = "crates/lox-odm", version = "0.1.0-alpha.4" }
 lox-orbits = { path = "crates/lox-orbits", version = "0.1.0-alpha.40" }
-lox-test-utils = { path = "crates/lox-test-utils", version = "0.1.0-alpha.10" }
+lox-test-utils = { path = "crates/lox-test-utils" }
 lox-time = { path = "crates/lox-time", version = "0.1.0-alpha.27" }
 lox-units = { path = "crates/lox-units", version = "0.1.0-alpha.16" }
 


### PR DESCRIPTION
The release of `0.1.0-alpha.50` failed publishing `lox-io`:

```
failed to select a version for the requirement `lox-test-utils = "^0.1.0-alpha.10"`
candidate versions found which didn't match: 0.1.0-alpha.9, 0.1.0-alpha.8, ...
```

`lox-test-utils` is a dev-dependency only (`lox-analysis`, `lox-earth`, `lox-io`,
`lox-orbits`, `lox-space`). Dev-dependencies do not constrain topological publish
order, so release-plz can schedule it after its own consumers — but the version
requirement in `[workspace.dependencies]` makes cargo demand it from the registry
when packaging those consumers.

Dropping the version makes it a path-only dev-dependency, which cargo strips when
packaging, so the ordering hazard is gone for good:

```
$ tar -xOzf target/package/lox-io-0.1.0-alpha.25.crate lox-io-0.1.0-alpha.25/Cargo.toml | grep -A2 dev-dependencies
[dev-dependencies.rstest]
version = "0.26.1"
```

Merging this unblocks the interrupted release: the 8 remaining crates
(`lox-io`, `lox-earth`, `lox-orbits`, `lox-analysis`, `lox-space`, `lox-itur`,
`lox-math`, `lox-odm`) publish in dependency order, and the `lox-space` tag then
triggers the PyPI upload.