### PR TITLE
Split ElevationMask into HorizonMask and a min-elevation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Key details:
 - `Distance` stores meters internally, even when created via `kilometers()`.
 - `GravitationalParameter` stores m³/s² internally, even when created via `km3_per_s2()`.
 - `Angle` stores **radians** internally.
-- `EllipsoidLocation` and `Observables` accessors return **unitful** types (`Angle`, `Distance`, `Velocity`), not raw `f64` — prefer this for new scalar accessors. Bulk numeric arrays feeding interpolation series (e.g. `ElevationMask::new`) stay `Vec<f64>` in radians.
+- `EllipsoidLocation` and `Observables` accessors return **unitful** types (`Angle`, `Distance`, `Velocity`), not raw `f64` — prefer this for new scalar accessors. Bulk numeric arrays feeding interpolation series (e.g. `HorizonMask::new`) stay `Vec<f64>` in radians.
 
 **Getting this wrong will produce silently incorrect results. Always verify units.**
 

--- a/crates/lox-analysis/CHANGELOG.md
+++ b/crates/lox-analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [**breaking**] split the conflated `ElevationMask` into two concepts: `HorizonMask`, the measured azimuth→elevation skyline profile (the former `Variable` variant; the `Fixed` variant is gone, `min_elevation(azimuth)` is now `elevation_at(azimuth)`, and `ElevationMaskError` is now `HorizonMaskError`), and an operational `min_elevation` floor on `GroundStation`. `GroundStation::new` no longer takes a mask — use the `with_min_elevation`/`with_horizon_mask` builders (`None` means unconstrained and flat 0° horizon respectively, reproducing the old `Fixed(0°)` default). Visibility detection and pass computation test elevation against `GroundStation::threshold_at(azimuth)`, the maximum of horizon and floor; `Pass::from_interval` and `VisibilityResults::to_passes` take the `GroundStation` instead of a location/mask pair. The serde format changes: `GroundStation` serializes optional `min_elevation`/`horizon_mask` fields instead of `mask`, and `HorizonMask` serializes as a bare interpolation series without the `Fixed`/`Variable` tag.
+
 ## [0.1.0-alpha.15](https://github.com/lox-space/lox/compare/lox-analysis-v0.1.0-alpha.14...lox-analysis-v0.1.0-alpha.15) - 2026-08-25
 
 ### Added

--- a/crates/lox-analysis/benches/visibility.rs
+++ b/crates/lox-analysis/benches/visibility.rs
@@ -8,10 +8,9 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use lox_analysis::assets::{AssetId, GroundStation, Scenario, Spacecraft};
-use lox_analysis::visibility::{ElevationMask, VisibilityAnalysis};
+use lox_analysis::visibility::VisibilityAnalysis;
 use lox_bodies::Origin;
 use lox_core::coords::LonLatAlt;
-use lox_core::units::Angle;
 use lox_frames::Frame;
 use lox_orbits::ground::EllipsoidLocation;
 use lox_orbits::orbits::{Ensemble, Trajectory};
@@ -32,8 +31,7 @@ static FIXTURE: LazyLock<Fixture> = LazyLock::new(|| {
     .unwrap();
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
     let gs_loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
-    let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-    let gs = GroundStation::new("cebreros", gs_loc, mask);
+    let gs = GroundStation::new("cebreros", gs_loc);
     let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
 
     let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());

--- a/crates/lox-analysis/src/assets.rs
+++ b/crates/lox-analysis/src/assets.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use lox_bodies::{CoordinateOrigin, Origin};
-use lox_core::units::AngularRate;
+use lox_core::units::{Angle, AngularRate};
 
 #[cfg(feature = "imaging")]
 use crate::imaging::OpticalPayload;
@@ -25,7 +25,7 @@ use lox_time::time_scales::TimeScale;
 use lox_comms::terminal::{RxTerminal, TxTerminal};
 
 use crate::parallel;
-use crate::visibility::ElevationMask;
+use crate::visibility::HorizonMask;
 use lox_orbits::constellations::{Constellation, ConstellationPropagator};
 use lox_orbits::ground::EllipsoidLocation;
 use lox_orbits::orbits::{Ensemble, KeplerianOrbit};
@@ -104,13 +104,24 @@ impl fmt::Display for NetworkId {
     }
 }
 
-/// A ground station with location, elevation mask, and optional network membership.
+/// A ground station with location, optional visibility constraints, and
+/// optional network membership.
+///
+/// Visibility is constrained by two independent, optional settings:
+/// - `horizon_mask`: the measured physical skyline around the station
+///   (`None` means a flat 0° horizon), and
+/// - `min_elevation`: the operational minimum-elevation floor
+///   (`None` means unconstrained).
+///
+/// Detection tests elevation against the maximum of both, resolved via
+/// [`threshold_at`](Self::threshold_at).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroundStation {
     id: AssetId,
     location: EllipsoidLocation,
-    mask: ElevationMask,
+    min_elevation: Option<Angle>,
+    horizon_mask: Option<HorizonMask>,
     network: Option<NetworkId>,
     #[cfg(feature = "comms")]
     tx_terminals: BTreeMap<String, TxTerminal>,
@@ -119,18 +130,32 @@ pub struct GroundStation {
 }
 
 impl GroundStation {
-    /// Creates a new ground station with the given location and elevation mask.
-    pub fn new(id: impl Into<String>, location: EllipsoidLocation, mask: ElevationMask) -> Self {
+    /// Creates a new ground station at the given location, with a flat 0°
+    /// horizon and no minimum-elevation floor.
+    pub fn new(id: impl Into<String>, location: EllipsoidLocation) -> Self {
         Self {
             id: AssetId::new(id),
             location,
-            mask,
+            min_elevation: None,
+            horizon_mask: None,
             network: None,
             #[cfg(feature = "comms")]
             tx_terminals: BTreeMap::new(),
             #[cfg(feature = "comms")]
             rx_terminals: BTreeMap::new(),
         }
+    }
+
+    /// Sets the operational minimum-elevation floor.
+    pub fn with_min_elevation(mut self, min_elevation: Angle) -> Self {
+        self.min_elevation = Some(min_elevation);
+        self
+    }
+
+    /// Sets the measured horizon profile of the station.
+    pub fn with_horizon_mask(mut self, horizon_mask: HorizonMask) -> Self {
+        self.horizon_mask = Some(horizon_mask);
+        self
     }
 
     /// Assigns this ground station to a network.
@@ -175,9 +200,31 @@ impl GroundStation {
         &self.location
     }
 
-    /// Returns the elevation mask.
-    pub fn mask(&self) -> &ElevationMask {
-        &self.mask
+    /// Returns the operational minimum-elevation floor, if set.
+    pub fn min_elevation(&self) -> Option<Angle> {
+        self.min_elevation
+    }
+
+    /// Returns the measured horizon profile, if set.
+    pub fn horizon_mask(&self) -> Option<&HorizonMask> {
+        self.horizon_mask.as_ref()
+    }
+
+    /// Resolves the effective elevation threshold at the given azimuth: the
+    /// maximum of the horizon profile (flat 0° when unset) and the
+    /// minimum-elevation floor (unconstrained when unset).
+    ///
+    /// All visibility detection and pass computation resolves the station's
+    /// constraints through this method.
+    pub fn threshold_at(&self, azimuth: Angle) -> Angle {
+        let horizon = self
+            .horizon_mask
+            .as_ref()
+            .map_or(Angle::ZERO, |mask| mask.elevation_at(azimuth));
+        match self.min_elevation {
+            Some(floor) if floor > horizon => floor,
+            _ => horizon,
+        }
     }
 
     /// Returns the network identifier, if assigned.
@@ -637,10 +684,6 @@ mod tests {
         EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap()
     }
 
-    fn dummy_mask() -> ElevationMask {
-        ElevationMask::with_fixed_elevation(Angle::ZERO)
-    }
-
     #[cfg(feature = "comms")]
     fn eirp_terminal(eirp_dbw: f64) -> TxTerminal {
         EirpModel::new(FrequencyBand::Ka, eirp_dbw.db())
@@ -658,7 +701,7 @@ mod tests {
     #[cfg(feature = "comms")]
     #[test]
     fn test_ground_station_terminals() {
-        let gs = GroundStation::new("gs1", dummy_location(), dummy_mask())
+        let gs = GroundStation::new("gs1", dummy_location())
             .with_tx_terminal("beacon", eirp_terminal(40.0))
             .with_rx_terminal("main", gt_terminal(30.0))
             .with_rx_terminal("backup", gt_terminal(25.0));
@@ -669,7 +712,7 @@ mod tests {
         assert!(gs.tx_terminal("nonexistent").is_none());
         assert!(gs.rx_terminal("nonexistent").is_none());
 
-        let bare = GroundStation::new("bare", dummy_location(), dummy_mask());
+        let bare = GroundStation::new("bare", dummy_location());
         assert!(bare.tx_terminals().is_empty());
         assert!(bare.rx_terminals().is_empty());
     }
@@ -678,7 +721,7 @@ mod tests {
     #[test]
     fn test_ground_station_terminal_names_are_unique() {
         // Re-adding under the same name replaces the terminal.
-        let gs = GroundStation::new("gs1", dummy_location(), dummy_mask())
+        let gs = GroundStation::new("gs1", dummy_location())
             .with_rx_terminal("main", gt_terminal(30.0))
             .with_rx_terminal("main", gt_terminal(25.0));
         assert_eq!(gs.rx_terminals().len(), 1);
@@ -743,21 +786,21 @@ mod tests {
     #[test]
     fn test_ground_station_new() {
         let loc = dummy_location();
-        let mask = dummy_mask();
-        let gs = GroundStation::new("gs1", loc, mask);
+        let gs = GroundStation::new("gs1", loc);
         assert_eq!(gs.id().as_str(), "gs1");
+        assert!(gs.min_elevation().is_none());
+        assert!(gs.horizon_mask().is_none());
     }
 
     #[test]
     fn test_ground_station_network_id_none_by_default() {
-        let gs = GroundStation::new("gs1", dummy_location(), dummy_mask());
+        let gs = GroundStation::new("gs1", dummy_location());
         assert!(gs.network_id().is_none());
     }
 
     #[test]
     fn test_ground_station_with_network_id() {
-        let gs =
-            GroundStation::new("gs1", dummy_location(), dummy_mask()).with_network_id("estrack");
+        let gs = GroundStation::new("gs1", dummy_location()).with_network_id("estrack");
         assert_eq!(gs.network_id(), Some(&NetworkId::new("estrack")));
         // Verify network via filter_by_networks round-trip.
         let start = Time::j2000(TimeScale::Tai);
@@ -771,15 +814,39 @@ mod tests {
     #[test]
     fn test_ground_station_location_getter() {
         let loc = dummy_location();
-        let gs = GroundStation::new("gs1", loc.clone(), dummy_mask());
+        let gs = GroundStation::new("gs1", loc.clone());
         let _ = gs.location(); // verify it compiles and returns
     }
 
     #[test]
-    fn test_ground_station_mask_getter() {
-        let mask = ElevationMask::with_fixed_elevation(Angle::radians(0.1));
-        let gs = GroundStation::new("gs1", dummy_location(), mask.clone());
-        assert_eq!(gs.mask().min_elevation(Angle::ZERO), Angle::radians(0.1));
+    fn test_ground_station_threshold_at() {
+        use std::f64::consts::PI;
+
+        // Unconstrained station: flat 0° threshold everywhere.
+        let gs = GroundStation::new("gs1", dummy_location());
+        assert_eq!(gs.threshold_at(Angle::ZERO), Angle::ZERO);
+
+        // The floor alone raises the threshold uniformly.
+        let gs =
+            GroundStation::new("gs1", dummy_location()).with_min_elevation(Angle::radians(0.1));
+        assert_eq!(gs.min_elevation(), Some(Angle::radians(0.1)));
+        assert_eq!(gs.threshold_at(Angle::ZERO), Angle::radians(0.1));
+        assert_eq!(gs.threshold_at(Angle::PI), Angle::radians(0.1));
+
+        // Horizon mask and floor combine via max: the horizon dominates where
+        // it rises above the floor, the floor everywhere else.
+        let mask = HorizonMask::new(vec![-PI, 0.0, PI], vec![0.3, 0.0, 0.3]).unwrap();
+        let gs = GroundStation::new("gs1", dummy_location())
+            .with_horizon_mask(mask.clone())
+            .with_min_elevation(Angle::radians(0.1));
+        assert_eq!(gs.horizon_mask(), Some(&mask));
+        assert_eq!(gs.threshold_at(Angle::PI), Angle::radians(0.3));
+        assert_eq!(gs.threshold_at(Angle::ZERO), Angle::radians(0.1));
+
+        // Horizon mask without a floor: the profile alone applies.
+        let gs = GroundStation::new("gs1", dummy_location()).with_horizon_mask(mask);
+        assert_eq!(gs.threshold_at(Angle::ZERO), Angle::ZERO);
+        assert_eq!(gs.threshold_at(Angle::PI), Angle::radians(0.3));
     }
 
     // --- Spacecraft ---
@@ -853,7 +920,7 @@ mod tests {
     fn test_scenario_with_assets() {
         let start = Time::j2000(TimeScale::Tai);
         let end = start + TimeDelta::from_seconds(86400);
-        let gs = GroundStation::new("gs1", dummy_location(), dummy_mask());
+        let gs = GroundStation::new("gs1", dummy_location());
         let traj = lox_orbits::orbits::Trajectory::from_csv_dynamic(
             &lox_test_utils::read_data_file("trajectory_lunar.csv"),
             Origin::Earth,
@@ -892,9 +959,8 @@ mod tests {
     fn test_scenario_filter_by_networks() {
         let start = Time::j2000(TimeScale::Tai);
         let end = start + TimeDelta::from_seconds(86400);
-        let gs1 =
-            GroundStation::new("gs1", dummy_location(), dummy_mask()).with_network_id("estrack");
-        let gs2 = GroundStation::new("gs2", dummy_location(), dummy_mask());
+        let gs1 = GroundStation::new("gs1", dummy_location()).with_network_id("estrack");
+        let gs2 = GroundStation::new("gs2", dummy_location());
         let scenario =
             Scenario::new(start, end, Origin::Earth, Frame::Icrf).with_ground_stations(&[gs1, gs2]);
         let filtered = scenario.filter_by_networks(&[NetworkId::new("estrack")]);

--- a/crates/lox-analysis/src/lib.rs
+++ b/crates/lox-analysis/src/lib.rs
@@ -17,5 +17,5 @@ pub mod imaging;
 mod parallel;
 /// Power budget analysis: eclipse detection, beta angle, solar flux.
 pub mod power;
-/// Visibility analysis: line-of-sight, elevation masks, passes, and interval computation.
+/// Visibility analysis: line-of-sight, horizon masks, passes, and interval computation.
 pub mod visibility;

--- a/crates/lox-analysis/src/visibility.rs
+++ b/crates/lox-analysis/src/visibility.rs
@@ -94,12 +94,12 @@ pub trait LineOfSight: TrySpheroid + TryMeanRadius {
 impl<T: TrySpheroid + TryMeanRadius> LineOfSight for T {}
 
 // ---------------------------------------------------------------------------
-// Elevation mask
+// Horizon mask
 // ---------------------------------------------------------------------------
 
-/// Errors from constructing an [`ElevationMask`].
+/// Errors from constructing a [`HorizonMask`].
 #[derive(Debug, Clone, Error, PartialEq)]
-pub enum ElevationMaskError {
+pub enum HorizonMaskError {
     /// The azimuth range does not span \[-π, π\].
     #[error("invalid azimuth range: {}..{}", .0.to_degrees(), .1.to_degrees())]
     InvalidAzimuthRange(f64, f64),
@@ -108,53 +108,51 @@ pub enum ElevationMaskError {
     SeriesError(#[from] SeriesError),
 }
 
-/// Minimum elevation angle as a function of azimuth.
+/// The measured skyline profile of a ground station: horizon elevation as a
+/// piecewise-linear function of azimuth.
 ///
-/// Can be either a constant angle ([`Fixed`](Self::Fixed)) or an
-/// azimuth-dependent piecewise-linear profile ([`Variable`](Self::Variable)).
+/// This captures the physical horizon (terrain, buildings) around a station.
+/// The operational minimum-elevation policy is a separate, constant floor on
+/// [`GroundStation`]; visibility detection tests elevation against the
+/// maximum of both via [`GroundStation::threshold_at`].
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum ElevationMask {
-    /// Constant minimum elevation angle.
-    Fixed(Angle),
-    /// Azimuth-dependent minimum elevation angle (interpolated series).
-    Variable(Series),
-}
+pub struct HorizonMask(Series);
 
-impl ElevationMask {
-    /// Creates a variable elevation mask from paired azimuth/elevation vectors
-    /// in radians.
+impl HorizonMask {
+    /// Creates a horizon mask from paired azimuth/elevation vectors in
+    /// radians.
     ///
     /// The vectors feed a numeric interpolation series and so are taken as raw
     /// radians; scalar angles elsewhere on this type are [`Angle`]s.
-    pub fn new(azimuth: Vec<f64>, elevation: Vec<f64>) -> Result<Self, ElevationMaskError> {
+    pub fn new(azimuth: Vec<f64>, elevation: Vec<f64>) -> Result<Self, HorizonMaskError> {
         if !azimuth.is_empty() {
             let az_min = *azimuth.iter().min_by(|a, b| a.total_cmp(b)).unwrap();
             let az_max = *azimuth.iter().max_by(|a, b| a.total_cmp(b)).unwrap();
             if az_min != -PI || az_max != PI {
-                return Err(ElevationMaskError::InvalidAzimuthRange(az_min, az_max));
+                return Err(HorizonMaskError::InvalidAzimuthRange(az_min, az_max));
             }
         }
-        Ok(Self::Variable(Series::try_new(
+        Ok(Self(Series::try_new(
             azimuth,
             elevation,
             InterpolationType::Linear,
         )?))
     }
 
-    /// Creates a fixed elevation mask with a constant minimum elevation.
-    pub fn with_fixed_elevation(elevation: Angle) -> Self {
-        Self::Fixed(elevation)
+    /// Returns the horizon elevation at the given azimuth.
+    pub fn elevation_at(&self, azimuth: Angle) -> Angle {
+        Angle::radians(self.0.interpolate(azimuth.to_radians()))
     }
 
-    /// Returns the minimum elevation angle at the given azimuth.
-    pub fn min_elevation(&self, azimuth: Angle) -> Angle {
-        match self {
-            ElevationMask::Fixed(min_elevation) => *min_elevation,
-            ElevationMask::Variable(series) => {
-                Angle::radians(series.interpolate(azimuth.to_radians()))
-            }
-        }
+    /// Returns the azimuth grid of the profile in radians.
+    pub fn azimuth(&self) -> &[f64] {
+        self.0.x()
+    }
+
+    /// Returns the horizon elevations of the profile in radians.
+    pub fn elevation(&self) -> &[f64] {
+        self.0.y()
     }
 }
 
@@ -205,14 +203,13 @@ pub struct Pass {
 
 impl Pass {
     /// Create a Pass from an interval, calculating observables for times when
-    /// the satellite is above the elevation mask.
+    /// the satellite is above the station's elevation threshold.
     ///
-    /// Returns `None` if the satellite is never above the mask within the interval.
+    /// Returns `None` if the satellite is never above the threshold within the interval.
     pub fn from_interval(
         interval: TimeInterval<TimeScale>,
         time_resolution: TimeDelta,
-        gs: &EllipsoidLocation,
-        mask: &ElevationMask,
+        gs: &GroundStation,
         sc: &lox_orbits::orbits::Trajectory,
     ) -> Option<Pass> {
         let mut pass_times = Vec::new();
@@ -221,12 +218,11 @@ impl Pass {
         for current_time in interval.step_by(time_resolution) {
             let state = sc.at(current_time);
             let state_bf = state
-                .try_to_frame(gs.frame(), &DefaultRotationProvider)
+                .try_to_frame(gs.location().frame(), &DefaultRotationProvider)
                 .unwrap();
-            let obs = gs.observables(state_bf);
+            let obs = gs.location().observables(state_bf);
 
-            let min_elev = mask.min_elevation(obs.azimuth());
-            if obs.elevation() >= min_elev {
+            if obs.elevation() >= gs.threshold_at(obs.azimuth()) {
                 pass_times.push(current_time);
                 pass_observables.push(obs);
             }
@@ -377,16 +373,16 @@ impl From<RotationError> for EvalError {
 // DetectFn implementations
 // ---------------------------------------------------------------------------
 
-/// Elevation above mask for a ground station / spacecraft pair.
+/// Elevation above the station's threshold for a ground station / spacecraft
+/// pair.
 ///
 /// Generic over origin `O` and frame `R`. The detect function:
 /// 1. Interpolates the spacecraft trajectory at the given time
 /// 2. Rotates the state into the body-fixed frame via `TryRotation<R, Frame, TimeScale>`
 /// 3. Computes observables (azimuth, elevation, range, range rate)
-/// 4. Returns elevation minus minimum elevation from the mask
+/// 4. Returns elevation minus the station's elevation threshold
 struct ElevationDetectFn<'a, O: CoordinateOrigin, R: ReferenceFrame> {
-    gs: &'a EllipsoidLocation,
-    mask: &'a ElevationMask,
+    gs: &'a GroundStation,
     sc: &'a Trajectory<O, R>,
 }
 
@@ -403,10 +399,10 @@ where
     fn eval(&self, time: Time) -> Result<f64, Self::Error> {
         let sc = self.sc.at(time.into_dynamic());
         let sc = sc
-            .try_to_frame(self.gs.frame(), &DefaultRotationProvider)
+            .try_to_frame(self.gs.location().frame(), &DefaultRotationProvider)
             .map_err(|e| EvalError::Rotation(Box::new(e)))?;
-        let obs = self.gs.observables(sc);
-        Ok((obs.elevation() - self.mask.min_elevation(obs.azimuth())).to_radians())
+        let obs = self.gs.location().observables(sc);
+        Ok((obs.elevation() - self.gs.threshold_at(obs.azimuth())).to_radians())
     }
 }
 
@@ -421,28 +417,37 @@ where
     fn eval_bounded(&self, time: Time) -> Result<(f64, f64), Self::Error> {
         let sc = self.sc.at(time);
         let sc = sc
-            .try_to_frame(self.gs.frame(), &DefaultRotationProvider)
+            .try_to_frame(self.gs.location().frame(), &DefaultRotationProvider)
             .map_err(|e| EvalError::Rotation(Box::new(e)))?;
-        let obs = self.gs.observables(sc);
-        let value = (obs.elevation() - self.mask.min_elevation(obs.azimuth())).to_radians();
+        let obs = self.gs.location().observables(sc);
+        let value = (obs.elevation() - self.gs.threshold_at(obs.azimuth())).to_radians();
 
         // The topocentric elevation-angle rate is bounded by the transverse
         // angular rate of the line-of-sight vector, |v_bf| / range (the
         // body-fixed velocity is the analytic derivative of the interpolated
-        // position). A fixed mask contributes no azimuth-dependent term, so
-        // this bounds the whole crossing function. Azimuth-varying masks would
-        // additionally need the mask slope; until that is modelled they report
-        // an unbounded rate, which degrades adaptive stepping to the fixed step.
-        let bound = match self.mask {
-            ElevationMask::Fixed(_) => {
-                let range = obs.range().to_meters();
-                if range > 0.0 {
-                    sc.velocity().length() / range
-                } else {
-                    f64::INFINITY
-                }
+        // position). A constant threshold contributes no azimuth-dependent
+        // term, so this bounds the whole crossing function whenever the
+        // `min_elevation` floor dominates the horizon profile at the current
+        // azimuth — always, when no horizon mask is set. A dominating sloped
+        // horizon would additionally need the mask slope; until that is
+        // modelled it reports an unbounded rate, which degrades adaptive
+        // stepping to the fixed step.
+        let floor_dominates = match self.gs.horizon_mask() {
+            None => true,
+            Some(mask) => self
+                .gs
+                .min_elevation()
+                .is_some_and(|floor| floor >= mask.elevation_at(obs.azimuth())),
+        };
+        let bound = if floor_dominates {
+            let range = obs.range().to_meters();
+            if range > 0.0 {
+                sc.velocity().length() / range
+            } else {
+                f64::INFINITY
             }
-            ElevationMask::Variable(_) => f64::INFINITY,
+        } else {
+            f64::INFINITY
         };
         Ok((value, bound))
     }
@@ -723,11 +728,7 @@ where
     ) -> Result<Vec<TimeInterval>, VisibilityError> {
         let step = self.scan_step();
 
-        let elev = ElevationDetectFn {
-            gs: gs.location(),
-            mask: gs.mask(),
-            sc: sc_traj,
-        };
+        let elev = ElevationDetectFn { gs, sc: sc_traj };
 
         // Elevation is the cheap constraint and always runs over the whole
         // window; `adaptive` lets it stride by its own rate bound.
@@ -942,13 +943,11 @@ impl VisibilityResults {
     /// Returns an error if the pair is an inter-satellite pair, since passes
     /// with ground-station observables are not meaningful for such pairs.
     /// Returns an empty vec if the pair is not found.
-    #[allow(clippy::too_many_arguments)]
     pub fn to_passes(
         &self,
         ground_id: &AssetId,
         space_id: &AssetId,
-        gs: &EllipsoidLocation,
-        mask: &ElevationMask,
+        gs: &GroundStation,
         sc: &lox_orbits::orbits::Trajectory,
         time_resolution: TimeDelta,
     ) -> Result<Vec<Pass>, PassError> {
@@ -970,7 +969,7 @@ impl VisibilityResults {
                             interval.start().into_dynamic(),
                             interval.end().into_dynamic(),
                         );
-                        Pass::from_interval(dynamic_interval, time_resolution, gs, mask, sc)
+                        Pass::from_interval(dynamic_interval, time_resolution, gs, sc)
                     })
                     .collect()
             })
@@ -1126,13 +1125,7 @@ where
                         // The trajectory may carry typed origin/frame; erase them
                         // for pass computation.
                         let dynamic_traj = sc_traj.clone().into_dynamic();
-                        Pass::from_interval(
-                            *interval,
-                            self.step,
-                            gs.location(),
-                            gs.mask(),
-                            &dynamic_traj,
-                        )
+                        Pass::from_interval(*interval, self.step, gs, &dynamic_traj)
                     })
                     .collect();
                 Some(((gs_id.clone(), sc_id.clone()), passes))
@@ -1273,11 +1266,7 @@ where
                 Some(d) if 0.5 * d > step => 0.5 * d,
                 _ => step,
             };
-            let elev = ElevationDetectFn {
-                gs: gs.location(),
-                mask: gs.mask(),
-                sc: sc_traj,
-            };
+            let elev = ElevationDetectFn { gs, sc: sc_traj };
             let windows = if adaptive {
                 elev.intervals(
                     AdaptiveSampler::new(step, interval.duration().max(step)),
@@ -1676,8 +1665,7 @@ mod tests {
     fn test_elevation() {
         let sc = spacecraft_trajectory_dynamic();
         let gs_traj = ground_station_trajectory();
-        let gs = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
+        let gs = GroundStation::new("cebreros", location_dynamic());
         let expected: Vec<f64> = read_data_file("elevation.csv")
             .lines()
             .map(|line| line.parse::<f64>().unwrap().to_radians())
@@ -1687,7 +1675,6 @@ mod tests {
         let typed_sc = Trajectory::from_parts(epoch.with_scale(TimeScale::Tai), o, f, data);
         let elev_fn = ElevationDetectFn {
             gs: &gs,
-            mask: &mask,
             sc: &typed_sc,
         };
         // Use the ground station trajectory times
@@ -1703,30 +1690,29 @@ mod tests {
     }
 
     #[test]
-    fn test_elevation_mask() {
+    fn test_horizon_mask() {
         let azimuth = vec![-PI, 0.0, PI];
         let elevation = vec![-2.0, 0.0, 2.0];
-        let mask = ElevationMask::new(azimuth, elevation).unwrap();
-        assert_eq!(mask.min_elevation(Angle::ZERO), Angle::ZERO);
+        let mask = HorizonMask::new(azimuth, elevation).unwrap();
+        assert_eq!(mask.elevation_at(Angle::ZERO), Angle::ZERO);
     }
 
     #[test]
-    fn test_elevation_mask_invalid_mask() {
+    fn test_horizon_mask_invalid_azimuth_range() {
         let azimuth = vec![-PI, 0.0, PI / 2.0];
         let elevation = vec![-2.0, 0.0, 2.0];
-        let mask = ElevationMask::new(azimuth, elevation);
+        let mask = HorizonMask::new(azimuth, elevation);
         assert_eq!(
             mask,
-            Err(ElevationMaskError::InvalidAzimuthRange(-PI, PI / 2.0))
+            Err(HorizonMaskError::InvalidAzimuthRange(-PI, PI / 2.0))
         )
     }
 
     #[test]
     fn test_visibility() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
         let spk = ephemeris();
         let ground_assets = [gs.clone()];
@@ -1748,9 +1734,8 @@ mod tests {
     #[test]
     fn test_visibility_no_ephemeris() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
         let ground_assets = [gs.clone()];
         let space_assets = [sc.clone()];
@@ -1773,9 +1758,8 @@ mod tests {
     #[test]
     fn test_visibility_combined() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
         let spk = ephemeris();
         let ground_assets = [gs.clone()];
@@ -1800,9 +1784,8 @@ mod tests {
     #[test]
     fn test_pass_observables_above_mask() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::degrees(10.0));
         let sc_traj = spacecraft_trajectory_dynamic();
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc).with_min_elevation(Angle::degrees(10.0));
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
         let ground_assets = [gs.clone()];
         let space_assets = [sc.clone()];
@@ -1814,16 +1797,15 @@ mod tests {
         let passes = analysis.to_passes(&results);
         let key = (gs.id().clone(), sc.id().clone());
         let pair_passes = &passes[&key];
-        let mask = gs.mask();
 
         for pass in pair_passes {
             for obs in pass.observables() {
-                let min_elevation = mask.min_elevation(obs.azimuth());
+                let threshold = gs.threshold_at(obs.azimuth());
                 assert!(
-                    obs.elevation() >= min_elevation,
-                    "Observable elevation {:.2}° is below mask minimum {:.2}° at azimuth {:.2}°",
+                    obs.elevation() >= threshold,
+                    "Observable elevation {:.2}° is below threshold {:.2}° at azimuth {:.2}°",
                     obs.elevation().to_degrees(),
-                    min_elevation.to_degrees(),
+                    threshold.to_degrees(),
                     obs.azimuth().to_degrees()
                 );
             }
@@ -1881,9 +1863,8 @@ mod tests {
     #[test]
     fn test_visibility_adaptive_matches_uniform() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
         let sc_traj = spacecraft_trajectory_dynamic();
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc);
         let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
         let ground_assets = [gs.clone()];
         let space_assets = [sc.clone()];
@@ -2207,9 +2188,8 @@ mod tests {
     #[test]
     fn test_ground_space_filter() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-        let gs1 = GroundStation::new("cebreros", gs_loc.clone(), mask.clone());
-        let gs2 = GroundStation::new("malargue", gs_loc, mask);
+        let gs1 = GroundStation::new("cebreros", gs_loc.clone());
+        let gs2 = GroundStation::new("malargue", gs_loc);
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
         let sc1 = Spacecraft::new("sc1", OrbitSource::Trajectory(sc_traj.clone()));
@@ -2258,9 +2238,8 @@ mod tests {
     #[test]
     fn test_both_filters_combined_with_ground_space() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-        let gs1 = GroundStation::new("cebreros", gs_loc.clone(), mask.clone());
-        let gs2 = GroundStation::new("malargue", gs_loc, mask);
+        let gs1 = GroundStation::new("cebreros", gs_loc.clone());
+        let gs2 = GroundStation::new("malargue", gs_loc);
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
         let sc1 = Spacecraft::new("sc1", OrbitSource::Trajectory(sc_traj.clone()));
@@ -2292,8 +2271,7 @@ mod tests {
     #[test]
     fn test_min_pass_duration_filters_short_passes() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc);
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
         let sc = Spacecraft::new("sc1", OrbitSource::Trajectory(sc_traj));
@@ -2345,8 +2323,7 @@ mod tests {
             .compute()
             .unwrap();
 
-        let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
+        let gs = GroundStation::new("dummy", location_dynamic());
         let dummy_traj = Trajectory::from_csv_dynamic(
             &read_data_file("trajectory_lunar.csv"),
             Origin::Earth,
@@ -2358,8 +2335,7 @@ mod tests {
             .to_passes(
                 sc1.id(),
                 sc2.id(),
-                &gs_loc,
-                &mask,
+                &gs,
                 &dummy_traj,
                 TimeDelta::from_seconds(60),
             )
@@ -2369,13 +2345,12 @@ mod tests {
 
     #[test]
     fn test_to_passes_unknown_pair_returns_empty() {
-        let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-        let gs = GroundStation::new("cebreros", gs_loc.clone(), mask.clone());
+        let gs = GroundStation::new("cebreros", location_dynamic());
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
         let sc = Spacecraft::new("sc1", OrbitSource::Trajectory(sc_traj));
-        let (scenario, ensemble) = make_scenario_and_ensemble(&[gs], &[sc], interval);
+        let (scenario, ensemble) =
+            make_scenario_and_ensemble(std::slice::from_ref(&gs), &[sc], interval);
 
         let results = VisibilityAnalysis::new(&scenario, &ensemble)
             .compute()
@@ -2393,8 +2368,7 @@ mod tests {
             .to_passes(
                 &unknown_id,
                 &unknown_id,
-                &gs_loc,
-                &mask,
+                &gs,
                 &dummy_traj,
                 TimeDelta::from_seconds(60),
             )
@@ -2405,8 +2379,7 @@ mod tests {
     #[test]
     fn test_combined_ground_and_inter_satellite() {
         let gs_loc = location_dynamic();
-        let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-        let gs = GroundStation::new("cebreros", gs_loc, mask);
+        let gs = GroundStation::new("cebreros", gs_loc);
         let sc_traj = spacecraft_trajectory_dynamic();
         let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
         let sc1 = Spacecraft::new("sc1", OrbitSource::Trajectory(sc_traj.clone()));
@@ -2515,5 +2488,125 @@ mod tests {
     fn ephemeris() -> &'static Spk {
         static EPHEMERIS: OnceLock<Spk> = OnceLock::new();
         EPHEMERIS.get_or_init(|| Spk::from_file(data_file("spice/de440s.bsp")).unwrap())
+    }
+
+    /// Computes ground-space visibility intervals for a single station over
+    /// the lunar trajectory.
+    fn intervals_for_station(gs: GroundStation) -> Vec<TimeInterval> {
+        let sc_traj = spacecraft_trajectory_dynamic();
+        let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj.clone()));
+        let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
+        let (scenario, ensemble) = make_scenario_and_ensemble(
+            std::slice::from_ref(&gs),
+            std::slice::from_ref(&sc),
+            interval,
+        );
+        let results = VisibilityAnalysis::new(&scenario, &ensemble)
+            .compute()
+            .expect("visibility");
+        results
+            .intervals_for(gs.id(), sc.id())
+            .expect("pair not found")
+            .to_vec()
+    }
+
+    #[test]
+    fn test_unconstrained_station_reproduces_fixed_zero_mask() {
+        // A station with neither a horizon mask nor a minimum-elevation floor
+        // must reproduce the old `ElevationMask::Fixed(0°)` behaviour: the
+        // reference contacts in contacts.csv were generated with that mask.
+        let unconstrained =
+            intervals_for_station(GroundStation::new("cebreros", location_dynamic()));
+        let expected = contacts_tai();
+        assert_eq!(unconstrained.len(), expected.len());
+        assert_approx_eq!(expected, unconstrained.clone(), rtol <= 1e-4);
+
+        // An explicit 0° floor is equivalent to no floor at all.
+        let zero_floor = intervals_for_station(
+            GroundStation::new("cebreros", location_dynamic()).with_min_elevation(Angle::ZERO),
+        );
+        assert_eq!(unconstrained, zero_floor);
+    }
+
+    #[test]
+    fn test_visibility_combines_horizon_mask_and_min_elevation() {
+        // Horizon mask: 20° across the western azimuth sector, 0° in the
+        // eastern sector. Combined with a 10° floor, the horizon dominates in
+        // the west and the floor dominates in the east.
+        let deg20 = Angle::degrees(20.0).to_radians();
+        let horizon =
+            || HorizonMask::new(vec![-PI, -0.05, 0.0, PI], vec![deg20, deg20, 0.0, 0.0]).unwrap();
+        let floor = Angle::degrees(10.0);
+
+        let mask_only = intervals_for_station(
+            GroundStation::new("cebreros", location_dynamic()).with_horizon_mask(horizon()),
+        );
+        let floor_only = intervals_for_station(
+            GroundStation::new("cebreros", location_dynamic()).with_min_elevation(floor),
+        );
+        let combined = intervals_for_station(
+            GroundStation::new("cebreros", location_dynamic())
+                .with_horizon_mask(horizon())
+                .with_min_elevation(floor),
+        );
+
+        let total = |intervals: &[TimeInterval]| -> f64 {
+            intervals
+                .iter()
+                .map(|iv| iv.duration().to_seconds().to_f64())
+                .sum()
+        };
+
+        // The combined threshold is max(horizon, floor), so each constraint
+        // must trim windows the other alone would admit.
+        assert!(!combined.is_empty());
+        assert!(
+            total(&combined) < total(&mask_only),
+            "the 10° floor must trim the horizon-only windows ({:.0}s vs {:.0}s)",
+            total(&combined),
+            total(&mask_only)
+        );
+        assert!(
+            total(&combined) < total(&floor_only),
+            "the 20° horizon sector must trim the floor-only windows ({:.0}s vs {:.0}s)",
+            total(&combined),
+            total(&floor_only)
+        );
+    }
+
+    #[test]
+    fn test_rate_bound_finite_for_constant_threshold() {
+        let sc_traj = spacecraft_trajectory_dynamic();
+        let (epoch, origin, frame, data) = sc_traj.into_parts();
+        let typed = Trajectory::from_parts(epoch.with_scale(TimeScale::Tai), origin, frame, data);
+        let time = typed.start_time();
+
+        let bound_for = |gs: &GroundStation| {
+            let (_, bound) = ElevationDetectFn { gs, sc: &typed }
+                .eval_bounded(time)
+                .unwrap();
+            bound
+        };
+
+        // Without a horizon mask the threshold is constant, so the adaptive
+        // scan keeps its finite |v|/range rate bound — with or without a floor.
+        let flat = GroundStation::new("flat", location_dynamic());
+        assert!(bound_for(&flat).is_finite());
+        let floored = GroundStation::new("floored", location_dynamic())
+            .with_min_elevation(Angle::degrees(5.0));
+        assert!(bound_for(&floored).is_finite());
+
+        // A sloped horizon above the floor has no modelled rate bound.
+        let deg20 = Angle::degrees(20.0).to_radians();
+        let masked = GroundStation::new("masked", location_dynamic())
+            .with_horizon_mask(HorizonMask::new(vec![-PI, PI], vec![deg20, deg20]).unwrap());
+        assert!(bound_for(&masked).is_infinite());
+
+        // When the floor dominates the horizon at the current azimuth the
+        // constant part governs and the bound stays finite.
+        let dominated = GroundStation::new("dominated", location_dynamic())
+            .with_horizon_mask(HorizonMask::new(vec![-PI, PI], vec![deg20, deg20]).unwrap())
+            .with_min_elevation(Angle::degrees(30.0));
+        assert!(bound_for(&dominated).is_finite());
     }
 }

--- a/crates/lox-space/CHANGELOG.md
+++ b/crates/lox-space/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [**breaking**] `ElevationMask` is now `HorizonMask` in the Python API and only models the measured azimuth→elevation skyline profile: the `fixed`/`variable` constructors and `fixed_elevation` are gone, and `min_elevation(azimuth)` is now `elevation_at(azimuth)`. `GroundStation` takes optional `min_elevation` and `horizon_mask` keyword arguments instead of a mask, exposes them via `min_elevation()`/`horizon_mask()`, and resolves the effective constraint via `threshold_at(azimuth)` (the maximum of horizon and floor; omitting both reproduces the old fixed 0° mask).
+
 ## [0.1.0-alpha.50](https://github.com/lox-space/lox/compare/lox-space-v0.1.0-alpha.49...lox-space-v0.1.0-alpha.50) - 2026-08-25
 
 ### Added

--- a/crates/lox-space/benches/common/mod.rs
+++ b/crates/lox-space/benches/common/mod.rs
@@ -20,10 +20,8 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use lox_space::analysis::assets::{AssetId, GroundStation, Scenario, Spacecraft};
-use lox_space::analysis::visibility::ElevationMask;
 use lox_space::bodies::{Earth, Origin};
 use lox_space::core::coords::LonLatAlt;
-use lox_space::core::units::Angle;
 use lox_space::core::units::AngularRate;
 use lox_space::ephem::spk::parser::Spk;
 use lox_space::frames::providers::DefaultRotationProvider;
@@ -69,8 +67,7 @@ fn ground_location_dynamic() -> EllipsoidLocation {
 pub fn setup_dynamic() -> (Scenario, DynamicEnsemble) {
     let sc_traj = spacecraft_trajectory_dynamic();
     let gs_loc = ground_location_dynamic();
-    let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
-    let gs = GroundStation::new("cebreros", gs_loc, mask);
+    let gs = GroundStation::new("cebreros", gs_loc);
     let interval = TimeInterval::new(sc_traj.start_time(), sc_traj.end_time());
     let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(sc_traj));
     let scenario = Scenario::new(interval.start(), interval.end(), Origin::Earth, Frame::Icrf)
@@ -99,10 +96,9 @@ fn ground_location_mono() -> EllipsoidLocation<Iau<Earth>> {
 pub fn setup_mono() -> (Scenario<Earth, Icrf>, MonoEnsemble) {
     let traj = spacecraft_trajectory_mono();
     let gs_loc = ground_location_mono();
-    let mask = ElevationMask::with_fixed_elevation(Angle::ZERO);
     let interval = TimeInterval::new(traj.start_time(), traj.end_time());
     let sc = Spacecraft::new("lunar", OrbitSource::Trajectory(traj.into_dynamic()));
-    let gs = GroundStation::new("cebreros", gs_loc.into_dynamic(), mask);
+    let gs = GroundStation::new("cebreros", gs_loc.into_dynamic());
     let scenario = Scenario::new(interval.start(), interval.end(), Earth, Icrf)
         .with_spacecraft(&[sc])
         .with_ground_stations(&[gs]);
@@ -223,7 +219,7 @@ fn scaling_ground_stations() -> Vec<GroundStation> {
         .map(|&(id, lon, lat)| {
             let coords = LonLatAlt::from_degrees(lon, lat, 0.0).unwrap();
             let loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
-            GroundStation::new(id, loc, ElevationMask::with_fixed_elevation(Angle::ZERO))
+            GroundStation::new(id, loc)
         })
         .collect()
 }

--- a/crates/lox-space/docs/ground.md
+++ b/crates/lox-space/docs/ground.md
@@ -36,14 +36,16 @@ print(f"Azimuth: {obs.azimuth().to_degrees():.2f} deg")
 print(f"Elevation: {obs.elevation().to_degrees():.2f} deg")
 print(f"Range: {obs.range().to_kilometers():.1f} km")
 
-# Define elevation mask
-mask = lox.ElevationMask.fixed(5 * lox.deg)
+# Set an operational minimum elevation on a ground station
+station = lox.GroundStation("ESOC", gs, min_elevation=5 * lox.deg)
 
-# Or variable mask based on azimuth
+# Or add a measured horizon profile; visibility uses the maximum of the
+# horizon and the minimum elevation at each azimuth
 import numpy as np
-azimuth = np.linspace(0, 2*np.pi, 36)
+azimuth = np.linspace(-np.pi, np.pi, 36)
 elevation = np.full(36, 0.1)  # radians
-mask = lox.ElevationMask.variable(azimuth, elevation)
+mask = lox.HorizonMask(azimuth, elevation)
+station = lox.GroundStation("ESOC", gs, min_elevation=5 * lox.deg, horizon_mask=mask)
 ```
 
 ---
@@ -60,7 +62,7 @@ mask = lox.ElevationMask.variable(azimuth, elevation)
 
 ---
 
-::: lox_space.ElevationMask
+::: lox_space.HorizonMask
     options:
       show_source: false
 

--- a/crates/lox-space/docs/index.md
+++ b/crates/lox-space/docs/index.md
@@ -57,7 +57,7 @@ future_state = propagator.propagate(t + lox.TimeDelta.from_hours(1.5))
 | [Reference Frames](frames.md) | `Frame`, `SPK` |
 | [Orbital States](states.md) | `Cartesian`, `Keplerian`, `Trajectory` |
 | [Propagators](propagators.md) | `Vallado`, `SGP4`, `TLE`, `GroundPropagator` |
-| [Ground Stations](ground.md) | `EllipsoidLocation`, `Ellipsoid`, `ElevationMask`, `Observables`, `Pass` |
+| [Ground Stations](ground.md) | `EllipsoidLocation`, `Ellipsoid`, `HorizonMask`, `Observables`, `Pass` |
 | [Events & Visibility](events.md) | `Event`, `Interval`, `intersect_intervals`, `union_intervals`, `complement_intervals`, `GroundStation`, `Spacecraft`, `Scenario`, `Ensemble`, `VisibilityAnalysis`, `VisibilityResults`, `PowerBudgetAnalysis`, `PowerBudgetResults` |
 | [Imaging](imaging.md) | `Aoi`, `OpticalPayload`, `OpticalAccessAnalysis`, `SarPayload`, `LookSide`, `SarAccessAnalysis`, `AccessResults` |
 | [Communications](comms.md) | `TxChain`, `RxChain`, `AmplifierTransmitter`, `NoiseTempReceiver`, `CascadeReceiver`, `Channel`, `ModCod`, `LinkBudget`, `PropagationLosses`, `fspl`, `freq_overlap` |

--- a/crates/lox-space/examples/sentinel_visibility.rs
+++ b/crates/lox-space/examples/sentinel_visibility.rs
@@ -14,7 +14,7 @@
 use std::error::Error;
 
 use lox_space::analysis::assets::{GroundStation, Scenario, Spacecraft};
-use lox_space::analysis::visibility::{ElevationMask, VisibilityAnalysis, VisibilityResults};
+use lox_space::analysis::visibility::{VisibilityAnalysis, VisibilityResults};
 use lox_space::bodies::Origin;
 use lox_space::core::coords::LonLatAlt;
 use lox_space::core::units::Angle;
@@ -43,7 +43,7 @@ const WINDOW_HOURS: i64 = 24;
 const PROPAGATION_STEP_SECS: i64 = 10;
 
 // Minimum elevation for a contact, in degrees.
-const ELEVATION_MASK_DEG: f64 = 5.0;
+const MIN_ELEVATION_DEG: f64 = 5.0;
 
 fn tle_to_sgp4(name: &str, line_1: &[u8], line_2: &[u8]) -> Result<Sgp4, Box<dyn Error>> {
     let elements = Elements::from_tle(Some(name.to_string()), line_1, line_2)?;
@@ -96,7 +96,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let interval = TimeInterval::new(t0, t1).into_dynamic();
 
     // 2. Build ground stations.
-    let mask = ElevationMask::with_fixed_elevation(Angle::degrees(ELEVATION_MASK_DEG));
+    let min_elevation = Angle::degrees(MIN_ELEVATION_DEG);
     let stations = vec![
         GroundStation::new(
             "svalbard",
@@ -104,16 +104,16 @@ fn main() -> Result<(), Box<dyn Error>> {
                 LonLatAlt::from_degrees(15.4078, 78.2297, 450.0)?,
                 Frame::Iau(Origin::Earth),
             )?,
-            mask.clone(),
-        ),
+        )
+        .with_min_elevation(min_elevation),
         GroundStation::new(
             "maspalomas",
             EllipsoidLocation::try_new(
                 LonLatAlt::from_degrees(-15.6336, 27.7629, 205.0)?,
                 Frame::Iau(Origin::Earth),
             )?,
-            mask,
-        ),
+        )
+        .with_min_elevation(min_elevation),
     ];
 
     // 3. Build the spacecraft assets with SGP4 orbit sources.

--- a/crates/lox-space/src/analysis/python.rs
+++ b/crates/lox-space/src/analysis/python.rs
@@ -15,7 +15,7 @@ use crate::analysis::power::{
 };
 use crate::analysis::sun::AnalyticalSunEphemeris;
 use crate::analysis::visibility::{
-    ElevationMask, ElevationMaskError, PairType, Pass, VisibilityAnalysis, VisibilityError,
+    HorizonMask, HorizonMaskError, PairType, Pass, VisibilityAnalysis, VisibilityError,
     VisibilityResults,
 };
 use crate::bodies::Origin;
@@ -45,7 +45,6 @@ use lox_time::intervals::TimeInterval;
 use lox_time::series::TimeSeries;
 use lox_units::Distance;
 
-use numpy::{PyArray1, PyArrayMethods};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
@@ -58,11 +57,11 @@ impl From<PyVisibilityError> for PyErr {
     }
 }
 
-/// Error wrapper converting `ElevationMaskError` into a Python `ValueError`.
-pub struct PyElevationMaskError(pub ElevationMaskError);
+/// Error wrapper converting `HorizonMaskError` into a Python `ValueError`.
+pub struct PyHorizonMaskError(pub HorizonMaskError);
 
-impl From<PyElevationMaskError> for PyErr {
-    fn from(err: PyElevationMaskError) -> Self {
+impl From<PyHorizonMaskError> for PyErr {
+    fn from(err: PyHorizonMaskError) -> Self {
         PyValueError::new_err(err.0.to_string())
     }
 }
@@ -117,12 +116,15 @@ impl PyEvent {
 
 /// A named ground station for visibility analysis.
 ///
-/// Wraps a ground location and elevation mask with an identifier.
+/// Wraps a ground location with an identifier, an optional operational
+/// minimum-elevation floor, and an optional measured horizon mask.
+/// Visibility tests elevation against the maximum of both.
 ///
 /// Args:
 ///     id: Unique identifier for this ground station.
 ///     location: Ground station location.
-///     mask: Elevation mask defining minimum elevation constraints.
+///     min_elevation: Optional minimum-elevation floor (unconstrained when omitted).
+///     horizon_mask: Optional measured horizon profile (flat 0° horizon when omitted).
 ///     tx_terminals: Optional dict of named transmit terminals (TxChain or EirpModel).
 ///     rx_terminals: Optional dict of named receive terminals (RxChain or GtModel).
 #[pyclass(name = "GroundStation", module = "lox_space", frozen, from_py_object)]
@@ -132,16 +134,23 @@ pub struct PyGroundStation(pub GroundStation);
 #[pymethods]
 impl PyGroundStation {
     #[new]
-    #[pyo3(signature = (id, location, mask, network_id=None, tx_terminals=None, rx_terminals=None))]
+    #[pyo3(signature = (id, location, min_elevation=None, horizon_mask=None, network_id=None, tx_terminals=None, rx_terminals=None))]
     fn new(
         id: String,
         location: PyEllipsoidLocation,
-        mask: PyElevationMask,
+        min_elevation: Option<PyAngle>,
+        horizon_mask: Option<PyHorizonMask>,
         network_id: Option<String>,
         tx_terminals: Option<HashMap<String, Bound<'_, PyAny>>>,
         rx_terminals: Option<HashMap<String, Bound<'_, PyAny>>>,
     ) -> PyResult<Self> {
-        let mut gs = GroundStation::new(id, location.0, mask.0);
+        let mut gs = GroundStation::new(id, location.0);
+        if let Some(min_elevation) = min_elevation {
+            gs = gs.with_min_elevation(min_elevation.0);
+        }
+        if let Some(horizon_mask) = horizon_mask {
+            gs = gs.with_horizon_mask(horizon_mask.0);
+        }
         if let Some(nid) = network_id {
             gs = gs.with_network_id(nid);
         }
@@ -164,9 +173,28 @@ impl PyGroundStation {
         PyEllipsoidLocation(self.0.location().clone())
     }
 
-    /// Return the elevation mask.
-    fn mask(&self) -> PyElevationMask {
-        PyElevationMask(self.0.mask().clone())
+    /// Return the minimum-elevation floor, if set.
+    fn min_elevation(&self) -> Option<PyAngle> {
+        self.0.min_elevation().map(PyAngle)
+    }
+
+    /// Return the horizon mask, if set.
+    fn horizon_mask(&self) -> Option<PyHorizonMask> {
+        self.0.horizon_mask().cloned().map(PyHorizonMask)
+    }
+
+    /// Return the effective elevation threshold at the given azimuth.
+    ///
+    /// The threshold is the maximum of the horizon profile (0° when no
+    /// horizon mask is set) and the minimum-elevation floor.
+    ///
+    /// Args:
+    ///     azimuth: Azimuth angle as Angle.
+    ///
+    /// Returns:
+    ///     Elevation threshold as Angle.
+    fn threshold_at(&self, azimuth: PyAngle) -> PyAngle {
+        PyAngle(self.0.threshold_at(azimuth.0))
     }
 
     /// Return the network identifier, if assigned.
@@ -194,10 +222,9 @@ impl PyGroundStation {
 
     fn __repr__(&self) -> String {
         format!(
-            "GroundStation(\"{}\", {}, {})",
+            "GroundStation(\"{}\", {})",
             self.id(),
             self.location().__repr__(),
-            self.mask().__repr__(),
         )
     }
 }
@@ -843,14 +870,7 @@ impl PyVisibilityResults {
                 let dynamic_traj = sc_traj.clone().into_dynamic();
                 let passes = self
                     .results
-                    .to_passes(
-                        &gs_id,
-                        &sc_id,
-                        gs.location(),
-                        gs.mask(),
-                        &dynamic_traj,
-                        self.step,
-                    )
+                    .to_passes(&gs_id, &sc_id, gs, &dynamic_traj, self.step)
                     .map_err(|e| PyValueError::new_err(e.to_string()))?;
                 Ok(passes.into_iter().map(PyPass).collect())
             }
@@ -888,13 +908,7 @@ impl PyVisibilityResults {
                             interval.start().into_dynamic(),
                             interval.end().into_dynamic(),
                         );
-                        Pass::from_interval(
-                            dynamic_interval,
-                            self.step,
-                            gs.location(),
-                            gs.mask(),
-                            &dynamic_traj,
-                        )
+                        Pass::from_interval(dynamic_interval, self.step, gs, &dynamic_traj)
                     })
                     .map(PyPass)
                     .collect();
@@ -951,137 +965,57 @@ impl PyVisibilityResults {
     }
 }
 
-/// Defines elevation constraints for visibility analysis.
+/// A measured horizon profile for visibility analysis.
 ///
-/// An elevation mask specifies the minimum elevation angle required for
-/// visibility at different azimuth angles. Can be either fixed (constant
-/// minimum elevation) or variable (azimuth-dependent).
+/// A horizon mask captures the physical skyline around a ground station as
+/// elevation over azimuth. Visibility additionally honours the station's
+/// operational `min_elevation` floor; detection tests elevation against the
+/// maximum of both.
 ///
 /// Args:
-///     azimuth: Array of azimuth angles in radians (for variable mask).
-///     elevation: Array of minimum elevations in radians (for variable mask).
-///     min_elevation: Fixed minimum elevation in radians.
-#[pyclass(
-    name = "ElevationMask",
-    module = "lox_space",
-    frozen,
-    eq,
-    from_py_object
-)]
+///     azimuth: Array of azimuth angles in radians spanning [-π, π].
+///     elevation: Array of horizon elevations in radians.
+#[pyclass(name = "HorizonMask", module = "lox_space", frozen, eq, from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
-pub struct PyElevationMask(pub ElevationMask);
+pub struct PyHorizonMask(pub HorizonMask);
 
 #[pymethods]
-impl PyElevationMask {
+impl PyHorizonMask {
     #[new]
-    #[pyo3(signature = (azimuth=None, elevation=None, min_elevation=None))]
-    fn new(
-        azimuth: Option<&Bound<'_, PyArray1<f64>>>,
-        elevation: Option<&Bound<'_, PyArray1<f64>>>,
-        min_elevation: Option<PyAngle>,
-    ) -> PyResult<Self> {
-        if let Some(min_elevation) = min_elevation {
-            return Ok(PyElevationMask(ElevationMask::with_fixed_elevation(
-                min_elevation.0,
-            )));
-        }
-        if let (Some(azimuth), Some(elevation)) = (azimuth, elevation) {
-            let azimuth = azimuth.to_vec()?;
-            let elevation = elevation.to_vec()?;
-            return Ok(PyElevationMask(
-                ElevationMask::new(azimuth, elevation).map_err(PyElevationMaskError)?,
-            ));
-        }
-        Err(PyValueError::new_err(
-            "invalid argument combination, either `min_elevation` or `azimuth` and `elevation` arrays need to be present",
+    fn new(azimuth: Vec<f64>, elevation: Vec<f64>) -> PyResult<Self> {
+        Ok(PyHorizonMask(
+            HorizonMask::new(azimuth, elevation).map_err(PyHorizonMaskError)?,
         ))
     }
 
-    /// Create a fixed elevation mask with constant minimum elevation.
-    ///
-    /// Args:
-    ///     min_elevation: Minimum elevation angle as Angle.
-    ///
-    /// Returns:
-    ///     ElevationMask with fixed minimum elevation.
-    #[classmethod]
-    fn fixed(_cls: &Bound<'_, PyType>, min_elevation: PyAngle) -> Self {
-        PyElevationMask(ElevationMask::with_fixed_elevation(min_elevation.0))
+    fn __getnewargs__(&self) -> (Vec<f64>, Vec<f64>) {
+        (self.azimuth(), self.elevation())
     }
 
-    /// Create a variable elevation mask from azimuth-dependent data.
-    ///
-    /// Args:
-    ///     azimuth: Array of azimuth angles in radians.
-    ///     elevation: Array of minimum elevations in radians.
-    ///
-    /// Returns:
-    ///     ElevationMask with variable minimum elevation.
-    #[classmethod]
-    fn variable(
-        _cls: &Bound<'_, PyType>,
-        azimuth: &Bound<'_, PyArray1<f64>>,
-        elevation: &Bound<'_, PyArray1<f64>>,
-    ) -> PyResult<Self> {
-        let azimuth = azimuth.to_vec()?;
-        let elevation = elevation.to_vec()?;
-        Ok(PyElevationMask(
-            ElevationMask::new(azimuth, elevation).map_err(PyElevationMaskError)?,
-        ))
+    /// Return the azimuth grid in radians.
+    fn azimuth(&self) -> Vec<f64> {
+        self.0.azimuth().to_vec()
     }
 
-    fn __getnewargs__(&self) -> (Option<Vec<f64>>, Option<Vec<f64>>, Option<PyAngle>) {
-        (self.azimuth(), self.elevation(), self.fixed_elevation())
+    /// Return the horizon elevations in radians.
+    fn elevation(&self) -> Vec<f64> {
+        self.0.elevation().to_vec()
     }
 
-    /// Return the azimuth array (for variable masks only).
-    fn azimuth(&self) -> Option<Vec<f64>> {
-        match &self.0 {
-            ElevationMask::Fixed(_) => None,
-            ElevationMask::Variable(series) => Some(series.x().to_vec()),
-        }
-    }
-
-    /// Return the elevation array (for variable masks only).
-    fn elevation(&self) -> Option<Vec<f64>> {
-        match &self.0 {
-            ElevationMask::Fixed(_) => None,
-            ElevationMask::Variable(series) => Some(series.y().to_vec()),
-        }
-    }
-
-    /// Return the fixed elevation value (for fixed masks only).
-    fn fixed_elevation(&self) -> Option<PyAngle> {
-        match &self.0 {
-            ElevationMask::Fixed(min_elevation) => Some(PyAngle(*min_elevation)),
-            ElevationMask::Variable(_) => None,
-        }
-    }
-
-    /// Return the minimum elevation at the given azimuth.
+    /// Return the horizon elevation at the given azimuth.
     ///
     /// Args:
     ///     azimuth: Azimuth angle as Angle.
     ///
     /// Returns:
-    ///     Minimum elevation as Angle.
-    fn min_elevation(&self, azimuth: PyAngle) -> PyAngle {
-        PyAngle(self.0.min_elevation(azimuth.0))
+    ///     Horizon elevation as Angle.
+    fn elevation_at(&self, azimuth: PyAngle) -> PyAngle {
+        PyAngle(self.0.elevation_at(azimuth.0))
     }
 
     fn __repr__(&self) -> String {
-        match &self.0 {
-            ElevationMask::Fixed(min_elevation) => {
-                format!(
-                    "ElevationMask(min_elevation={})",
-                    PyAngle(*min_elevation).__repr__(),
-                )
-            }
-            ElevationMask::Variable(series) => {
-                let n = series.x().len();
-                format!("ElevationMask({n} azimuth/elevation pairs)")
-            }
-        }
+        let n = self.0.azimuth().len();
+        format!("HorizonMask({n} azimuth/elevation pairs)")
     }
 }
 

--- a/crates/lox-space/src/python.rs
+++ b/crates/lox-space/src/python.rs
@@ -5,7 +5,7 @@
 use std::f64::consts::PI;
 
 use crate::analysis::python::{
-    PyAccessResults, PyAccessWindow, PyAoi, PyElevationMask, PyEnsemble, PyEvent, PyGroundStation,
+    PyAccessResults, PyAccessWindow, PyAoi, PyEnsemble, PyEvent, PyGroundStation, PyHorizonMask,
     PyLookSide, PyObservables, PyOpticalAccessAnalysis, PyOpticalPayload, PyPass, PyPassDirection,
     PyPowerBudgetAnalysis, PyPowerBudgetResults, PySarAccessAnalysis, PySarPayload, PyScenario,
     PySpacecraft, PyVisibilityAnalysis, PyVisibilityResults,
@@ -107,8 +107,8 @@ pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySeries>()?;
 
     // analysis
-    m.add_class::<PyElevationMask>()?;
     m.add_class::<PyGroundStation>()?;
+    m.add_class::<PyHorizonMask>()?;
     m.add_class::<PyObservables>()?;
     m.add_class::<PyPass>()?;
     m.add_class::<PyScenario>()?;

--- a/crates/lox-space/tests/conftest.py
+++ b/crates/lox-space/tests/conftest.py
@@ -54,7 +54,6 @@ def estrack():
             lox.EllipsoidLocation(
                 "IAU_EARTH", lon * lox.deg, lat * lox.deg, 0 * lox.km
             ),
-            lox.ElevationMask.fixed(0 * lox.rad),
         )
         for name, lat, lon in stations
     ]

--- a/crates/lox-space/tests/serde.rs
+++ b/crates/lox-space/tests/serde.rs
@@ -683,25 +683,12 @@ fn test_network_id() {
 }
 
 #[test]
-fn test_elevation_mask_fixed() {
-    use lox_space::analysis::visibility::ElevationMask;
-    round_trip(&ElevationMask::with_fixed_elevation(Angle::radians(0.1)));
-}
-
-#[test]
 fn test_unit_types_serialize_transparently() {
     // `Angle`, `Distance` and `Velocity` are newtypes over f64, so making the
     // accessors unitful must not change the wire format of anything that
     // stores them. Guards previously-written scenario files.
     use lox_orbits::ground::Observables;
-    use lox_space::analysis::visibility::ElevationMask;
     use lox_units::{Distance, Velocity};
-
-    let mask = ElevationMask::with_fixed_elevation(Angle::radians(0.1));
-    assert_eq!(
-        serde_json::to_value(&mask).unwrap(),
-        serde_json::json!({ "Fixed": 0.1 })
-    );
 
     let obs = Observables::new(
         Angle::radians(1.0),
@@ -721,10 +708,10 @@ fn test_unit_types_serialize_transparently() {
 }
 
 #[test]
-fn test_elevation_mask_variable() {
-    use lox_space::analysis::visibility::ElevationMask;
+fn test_horizon_mask() {
+    use lox_space::analysis::visibility::HorizonMask;
     use std::f64::consts::PI;
-    let mask = ElevationMask::new(
+    let mask = HorizonMask::new(
         vec![-PI, -PI / 2.0, 0.0, PI / 2.0, PI],
         vec![5.0, 10.0, 5.0, 10.0, 5.0],
     )
@@ -779,13 +766,17 @@ fn test_access_window() {
 #[test]
 fn test_ground_station() {
     use lox_space::analysis::assets::GroundStation;
-    use lox_space::analysis::visibility::ElevationMask;
+    use lox_space::analysis::visibility::HorizonMask;
     use lox_space::orbits::ground::EllipsoidLocation;
+    use std::f64::consts::PI;
 
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
     let loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
-    let mask = ElevationMask::with_fixed_elevation(Angle::degrees(5.0));
-    let gs = GroundStation::new("madrid", loc, mask).with_network_id("estrack");
+    let mask = HorizonMask::new(vec![-PI, 0.0, PI], vec![0.1, 0.0, 0.1]).unwrap();
+    let gs = GroundStation::new("madrid", loc)
+        .with_min_elevation(Angle::degrees(5.0))
+        .with_horizon_mask(mask)
+        .with_network_id("estrack");
     round_trip_no_eq(&gs);
 }
 
@@ -834,7 +825,6 @@ fn test_spacecraft_with_payloads() {
 #[test]
 fn test_scenario() {
     use lox_space::analysis::assets::{GroundStation, Scenario, Spacecraft};
-    use lox_space::analysis::visibility::ElevationMask;
     use lox_space::orbits::Trajectory;
     use lox_space::orbits::ground::EllipsoidLocation;
     use lox_space::orbits::propagators::OrbitSource;
@@ -844,11 +834,7 @@ fn test_scenario() {
 
     let coords = LonLatAlt::from_degrees(-4.3676, 40.4527, 0.0).unwrap();
     let loc = EllipsoidLocation::try_new(coords, Frame::Iau(Origin::Earth)).unwrap();
-    let gs = GroundStation::new(
-        "madrid",
-        loc,
-        ElevationMask::with_fixed_elevation(Angle::degrees(5.0)),
-    );
+    let gs = GroundStation::new("madrid", loc).with_min_elevation(Angle::degrees(5.0));
 
     let traj = Trajectory::from_csv_dynamic(
         &lox_test_utils::read_data_file("trajectory_lunar.csv"),

--- a/crates/lox-space/tests/test_comms.py
+++ b/crates/lox-space/tests/test_comms.py
@@ -1531,12 +1531,13 @@ def test_ground_station_terminals():
     location = lox.EllipsoidLocation(
         "IAU_EARTH", 13.4 * lox.deg, 52.5 * lox.deg, 0.1 * lox.km
     )
-    mask = lox.ElevationMask.fixed(5.0 * lox.deg)
-    gs = lox.GroundStation("berlin", location, mask, rx_terminals={"ka": rx})
+    gs = lox.GroundStation(
+        "berlin", location, min_elevation=5.0 * lox.deg, rx_terminals={"ka": rx}
+    )
     assert gs.rx_terminals()["ka"] == rx
     assert gs.tx_terminals() == {}
 
-    bare = lox.GroundStation("bare", location, mask)
+    bare = lox.GroundStation("bare", location, min_elevation=5.0 * lox.deg)
     assert bare.rx_terminals() == {}
 
 
@@ -1545,11 +1546,14 @@ def test_asset_terminals_round_trip_both_tiers():
     location = lox.EllipsoidLocation(
         "IAU_EARTH", 13.4 * lox.deg, 52.5 * lox.deg, 0.1 * lox.km
     )
-    mask = lox.ElevationMask.fixed(5.0 * lox.deg)
     tx_terminals = {"hga": make_tx(), "beacon": lox.EirpModel(KA_BAND, 40.0 * lox.dB)}
     rx_terminals = {"main": make_rx(), "lumped": lox.GtModel(KA_BAND, 30.0 * lox.dB)}
     gs = lox.GroundStation(
-        "berlin", location, mask, tx_terminals=tx_terminals, rx_terminals=rx_terminals
+        "berlin",
+        location,
+        min_elevation=5.0 * lox.deg,
+        tx_terminals=tx_terminals,
+        rx_terminals=rx_terminals,
     )
     assert gs.tx_terminals() == tx_terminals
     assert gs.rx_terminals() == rx_terminals

--- a/crates/lox-space/tests/test_ground.py
+++ b/crates/lox-space/tests/test_ground.py
@@ -135,8 +135,8 @@ def test_ellipsoid_rejects_invalid_flattening():
         lox.Ellipsoid(6378137.0 * lox.m, 1.5)
 
 
-def test_elevation_mask():
-    mask = lox.ElevationMask.variable(
+def test_horizon_mask():
+    mask = lox.HorizonMask(
         np.array([-np.pi, 0.0, np.pi]), np.array([0.0, 5.0, 0.0])
     )
-    assert float(mask.min_elevation(lox.Angle(np.pi / 2))) == pytest.approx(2.5)
+    assert float(mask.elevation_at(lox.Angle(np.pi / 2))) == pytest.approx(2.5)

--- a/crates/lox-space/tests/test_oneweb_europe_benchmark.py
+++ b/crates/lox-space/tests/test_oneweb_europe_benchmark.py
@@ -43,7 +43,7 @@ def create_europe_ground_assets(resolution_deg=1.0, min_elevation_deg=10.0):
     lons = np.arange(lon_min, lon_max + resolution_deg, resolution_deg)
     lats = np.arange(lat_min, lat_max + resolution_deg, resolution_deg)
 
-    elevation_mask = lox.ElevationMask.fixed(min_elevation_deg * lox.deg)
+    min_elevation = min_elevation_deg * lox.deg
     frame = lox.Frame("IAU_EARTH")
 
     ground_assets = []
@@ -60,7 +60,9 @@ def create_europe_ground_assets(resolution_deg=1.0, min_elevation_deg=10.0):
                     altitude=0.0 * lox.km,  # Sea level
                 )
                 ground_assets.append(
-                    lox.GroundStation(gs_name, ground_location, elevation_mask)
+                    lox.GroundStation(
+                        gs_name, ground_location, min_elevation=min_elevation
+                    )
                 )
                 point_count += 1
 

--- a/crates/lox-space/tests/test_pickle.py
+++ b/crates/lox-space/tests/test_pickle.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import math
 import pickle
 
 import lox_space as lox
@@ -13,7 +14,7 @@ import pytest
     [
         lox.Origin("Earth"),
         lox.Frame("ICRF"),
-        lox.ElevationMask.fixed(0.0 * lox.rad),
+        lox.HorizonMask([-math.pi, 0.0, math.pi], [0.0, 0.1, 0.0]),
         lox.TimeScale("TAI"),
         lox.Time("TAI", 2000, 1, 1),
     ],

--- a/crates/lox-space/tests/test_visibility.py
+++ b/crates/lox-space/tests/test_visibility.py
@@ -550,13 +550,12 @@ class TestPass:
             assert float(obs.range()) > 0
             assert -math.pi <= float(obs.azimuth()) <= math.pi
 
-    def test_observables_above_mask(self, results, ground_assets, space_assets):
-        """All observables in a pass should be above the elevation mask."""
+    def test_observables_above_threshold(self, results, ground_assets, space_assets):
+        """All observables in a pass should be above the station's threshold."""
         p, gs = self._first_pass_with_gs(results, ground_assets, space_assets)
-        mask = gs.mask()
         for obs in p.observables():
-            min_elev = mask.min_elevation(obs.azimuth())
-            assert float(obs.elevation()) >= float(min_elev)
+            threshold = gs.threshold_at(obs.azimuth())
+            assert float(obs.elevation()) >= float(threshold)
 
     def test_interpolate_within_pass(self, results, ground_assets, space_assets):
         p = self._first_pass(results, ground_assets, space_assets)
@@ -595,10 +594,36 @@ class TestAssets:
             loc = ga.location()
             assert isinstance(loc, lox.EllipsoidLocation)
 
-    def test_ground_station_mask(self, ground_assets):
+    def test_ground_station_constraints_unset_by_default(self, ground_assets):
         for ga in ground_assets:
-            mask = ga.mask()
-            assert isinstance(mask, lox.ElevationMask)
+            assert ga.min_elevation() is None
+            assert ga.horizon_mask() is None
+            assert float(ga.threshold_at(0 * lox.rad)) == 0.0
+
+    def test_ground_station_threshold_combines_floor_and_horizon(self):
+        loc = lox.EllipsoidLocation(
+            frame="IAU_EARTH",
+            longitude=0 * lox.deg,
+            latitude=0 * lox.deg,
+            altitude=0 * lox.km,
+        )
+        az = np.array([-np.pi, -0.1, 0.0, np.pi])
+        el = np.array([np.radians(20), np.radians(20), 0.0, 0.0])
+        gs = lox.GroundStation(
+            "test",
+            loc,
+            min_elevation=10 * lox.deg,
+            horizon_mask=lox.HorizonMask(az, el),
+        )
+        assert float(gs.min_elevation()) == pytest.approx(np.radians(10))
+        assert gs.horizon_mask() is not None
+        # The horizon dominates in the western sector, the floor in the east.
+        assert float(gs.threshold_at(-np.pi / 2 * lox.rad)) == pytest.approx(
+            np.radians(20)
+        )
+        assert float(gs.threshold_at(np.pi / 2 * lox.rad)) == pytest.approx(
+            np.radians(10)
+        )
 
     def test_ground_station_body_fixed_frame(self, ground_assets):
         """A station's body-fixed frame comes from its location, not the station."""
@@ -638,8 +663,7 @@ class TestAssets:
             latitude=0 * lox.deg,
             altitude=0 * lox.km,
         )
-        mask = lox.ElevationMask.fixed(0 * lox.deg)
-        gs = lox.GroundStation("test", loc, mask, network_id="estrack")
+        gs = lox.GroundStation("test", loc, network_id="estrack")
         assert gs.network_id() == "estrack"
 
     def test_spacecraft_constellation_id_none(self, space_assets):
@@ -688,49 +712,31 @@ class TestScenario:
 
 
 # ---------------------------------------------------------------------------
-# ElevationMask
+# HorizonMask
 # ---------------------------------------------------------------------------
 
 
-class TestElevationMask:
-    def test_fixed(self):
-        mask = lox.ElevationMask.fixed(np.radians(10) * lox.rad)
-        assert float(mask.min_elevation(0 * lox.rad)) == pytest.approx(np.radians(10))
-        assert float(mask.min_elevation(np.pi * lox.rad)) == pytest.approx(
-            np.radians(10)
-        )
-        assert float(mask.fixed_elevation()) == pytest.approx(np.radians(10))
-        assert mask.azimuth() is None
-        assert mask.elevation() is None
-
-    def test_variable(self):
+class TestHorizonMask:
+    def test_constructor(self):
         az = np.array([-np.pi, 0.0, np.pi])
         el = np.array([0.0, np.radians(10), 0.0])
-        mask = lox.ElevationMask.variable(az, el)
-        assert float(mask.min_elevation(0 * lox.rad)) == pytest.approx(np.radians(10))
-        assert float(mask.min_elevation(-np.pi * lox.rad)) == pytest.approx(0.0)
-        assert mask.fixed_elevation() is None
-        assert mask.azimuth() is not None
-        assert mask.elevation() is not None
+        mask = lox.HorizonMask(az, el)
+        assert float(mask.elevation_at(0 * lox.rad)) == pytest.approx(np.radians(10))
+        assert float(mask.elevation_at(-np.pi * lox.rad)) == pytest.approx(0.0)
+        assert mask.azimuth() == pytest.approx(az.tolist())
+        assert mask.elevation() == pytest.approx(el.tolist())
 
-    def test_constructor_with_min_elevation(self):
-        mask = lox.ElevationMask(min_elevation=np.radians(5) * lox.rad)
-        assert float(mask.min_elevation(0 * lox.rad)) == pytest.approx(np.radians(5))
-
-    def test_constructor_with_arrays(self):
-        az = np.array([-np.pi, 0.0, np.pi])
-        el = np.array([0.0, np.radians(10), 0.0])
-        mask = lox.ElevationMask(azimuth=az, elevation=el)
-        assert float(mask.min_elevation(0 * lox.rad)) == pytest.approx(np.radians(10))
-
-    def test_constructor_invalid(self):
-        with pytest.raises(ValueError):
-            lox.ElevationMask()
+    def test_invalid_azimuth_range(self):
+        az = np.array([-np.pi / 2, 0.0, np.pi])
+        el = np.array([0.0, 0.1, 0.0])
+        with pytest.raises(ValueError, match="azimuth range"):
+            lox.HorizonMask(az, el)
 
     def test_equality(self):
-        a = lox.ElevationMask.fixed(0.1 * lox.rad)
-        b = lox.ElevationMask.fixed(0.1 * lox.rad)
-        c = lox.ElevationMask.fixed(0.2 * lox.rad)
+        az = np.array([-np.pi, 0.0, np.pi])
+        a = lox.HorizonMask(az, np.array([0.0, 0.1, 0.0]))
+        b = lox.HorizonMask(az, np.array([0.0, 0.1, 0.0]))
+        c = lox.HorizonMask(az, np.array([0.0, 0.2, 0.0]))
         assert a == b
         assert a != c
 

--- a/lox_space.pyi
+++ b/lox_space.pyi
@@ -312,23 +312,27 @@ days: TimeDelta
 class GroundStation:
     """A named ground station for visibility analysis.
 
-    Wraps a ground location and elevation mask with an identifier.
+    Wraps a ground location with an identifier, an optional operational
+    minimum-elevation floor, and an optional measured horizon mask.
+    Visibility tests elevation against the maximum of both.
 
     Args:
         id: Unique identifier for this ground station.
         location: Ground station location.
-        mask: Elevation mask defining minimum elevation constraints.
+        min_elevation: Optional minimum-elevation floor (unconstrained when omitted).
+        horizon_mask: Optional measured horizon profile (flat 0° horizon when omitted).
         tx_terminals: Optional dict of named transmit terminals (TxChain or EirpModel).
         rx_terminals: Optional dict of named receive terminals (RxChain or GtModel).
 
     Examples:
-        >>> gs = lox.GroundStation("ESOC", ground_location, elevation_mask)
+        >>> gs = lox.GroundStation("ESOC", ground_location, min_elevation=5 * lox.deg)
     """
     def __new__(
         cls,
         id: str,
         location: EllipsoidLocation,
-        mask: ElevationMask,
+        min_elevation: Angle | None = None,
+        horizon_mask: HorizonMask | None = None,
         network_id: str | None = None,
         tx_terminals: dict[str, TxTerminal] | None = None,
         rx_terminals: dict[str, RxTerminal] | None = None,
@@ -339,8 +343,18 @@ class GroundStation:
     def location(self) -> EllipsoidLocation:
         """Return the ground location."""
         ...
-    def mask(self) -> ElevationMask:
-        """Return the elevation mask."""
+    def min_elevation(self) -> Angle | None:
+        """Return the minimum-elevation floor, if set."""
+        ...
+    def horizon_mask(self) -> HorizonMask | None:
+        """Return the horizon mask, if set."""
+        ...
+    def threshold_at(self, azimuth: Angle) -> Angle:
+        """Return the effective elevation threshold at the given azimuth.
+
+        The threshold is the maximum of the horizon profile (0° when no
+        horizon mask is set) and the minimum-elevation floor.
+        """
         ...
     def network_id(self) -> str | None:
         """Return the network identifier, if assigned."""
@@ -806,50 +820,34 @@ class VisibilityResults:
         """Return the total number of visibility intervals across all pairs."""
         ...
 
-class ElevationMask:
-    """Defines elevation constraints for visibility analysis.
+class HorizonMask:
+    """A measured horizon profile for visibility analysis.
 
-    An elevation mask specifies the minimum elevation angle required for
-    visibility at different azimuth angles. Can be either fixed (constant)
-    or variable (azimuth-dependent).
+    A horizon mask captures the physical skyline around a ground station as
+    elevation over azimuth. Visibility additionally honours the station's
+    operational ``min_elevation`` floor; detection tests elevation against
+    the maximum of both.
 
     Args:
-        azimuth: Array of azimuth angles in radians (for variable mask).
-        elevation: Array of minimum elevations in radians (for variable mask).
-        min_elevation: Fixed minimum elevation as Angle.
+        azimuth: Array of azimuth angles in radians spanning [-π, π].
+        elevation: Array of horizon elevations in radians.
 
     Examples:
-        >>> # Fixed elevation mask (5 degrees)
-        >>> mask = lox.ElevationMask.fixed(5.0 * lox.deg)
-
-        >>> # Variable mask based on terrain
-        >>> mask = lox.ElevationMask.variable(azimuth, elevation)
+        >>> mask = lox.HorizonMask(azimuth, elevation)
     """
     def __new__(
         cls,
-        azimuth: np.ndarray | None = None,
-        elevation: np.ndarray | None = None,
-        min_elevation: Angle | None = None,
+        azimuth: np.ndarray,
+        elevation: np.ndarray,
     ) -> Self: ...
-    @classmethod
-    def variable(cls, azimuth: np.ndarray, elevation: np.ndarray) -> Self:
-        """Create a variable elevation mask from azimuth-dependent data."""
+    def azimuth(self) -> list[float]:
+        """Return the azimuth grid in radians."""
         ...
-    @classmethod
-    def fixed(cls, min_elevation: Angle) -> Self:
-        """Create a fixed elevation mask with constant minimum elevation."""
+    def elevation(self) -> list[float]:
+        """Return the horizon elevations in radians."""
         ...
-    def azimuth(self) -> list[float] | None:
-        """Return the azimuth array (for variable masks only)."""
-        ...
-    def elevation(self) -> list[float] | None:
-        """Return the elevation array (for variable masks only)."""
-        ...
-    def fixed_elevation(self) -> Angle | None:
-        """Return the fixed elevation value (for fixed masks only)."""
-        ...
-    def min_elevation(self, azimuth: Angle) -> Angle:
-        """Return the minimum elevation at the given azimuth."""
+    def elevation_at(self, azimuth: Angle) -> Angle:
+        """Return the horizon elevation at the given azimuth."""
         ...
 
 def intersect_intervals(a: list[Interval], b: list[Interval]) -> list[Interval]:


### PR DESCRIPTION
BREAKING CHANGE: `ElevationMask` conflated two concepts — the measured skyline around a station and the operational minimum-elevation policy. It is replaced by `HorizonMask`, which only models the azimuth→elevation profile (the former `Variable` variant; the `Fixed` variant is gone, `min_elevation(azimuth)` becomes `elevation_at(azimuth)`, and `ElevationMaskError` becomes `HorizonMaskError`), and a constant `min_elevation` floor on `GroundStation`.

`GroundStation::new` no longer takes a mask; both constraints are optional builders, `with_min_elevation` (unset means unconstrained) and `with_horizon_mask` (unset means a flat 0° horizon), so leaving both unset reproduces the old `Fixed(0°)` behaviour. No default floor is baked in — that is the caller's policy. Visibility detection and pass computation resolve the effective constraint through the new
`GroundStation::threshold_at(azimuth)`, the maximum of horizon and floor, which is the future seam for per-terminal overrides. `Pass::from_interval` and `VisibilityResults::to_passes` take the `GroundStation` instead of a location/mask pair.

The adaptive scan keeps its finite |v|/range rate bound whenever the constant floor dominates the horizon at the current azimuth — always, when no horizon mask is set — so flat-config stations retain the fast path; a dominating sloped horizon still reports an unbounded rate.

The serde wire format changes: `GroundStation` serializes optional `min_elevation`/`horizon_mask` fields instead of `mask`, and `HorizonMask` serializes as a bare interpolation series without the `Fixed`/`Variable` tag.

Python: `lox.ElevationMask` becomes `lox.HorizonMask(azimuth, elevation)`; the `fixed`/`variable` constructors and `fixed_elevation` are gone. `lox.GroundStation` takes optional `min_elevation` and `horizon_mask` keyword arguments instead of a mask and gains the `min_elevation()`, `horizon_mask()` and `threshold_at()` accessors.